### PR TITLE
Source ip

### DIFF
--- a/lib/classes/Swift/Transport/AbstractSmtpTransport.php
+++ b/lib/classes/Swift/Transport/AbstractSmtpTransport.php
@@ -32,6 +32,9 @@ abstract class Swift_Transport_AbstractSmtpTransport
   /** The event dispatching layer */
   protected $_eventDispatcher;
   
+  /** Source Ip */
+  protected $_sourceIp;
+  
   /** Return an array of params for the Buffer */
   abstract protected function _getBufferParams();
   
@@ -73,6 +76,25 @@ abstract class Swift_Transport_AbstractSmtpTransport
     return $this->_domain;
   }
   
+
+  /**
+   * Sets the sourceIp
+   * @param string $source
+   */
+  public function setSourceIp($source) 
+  {
+    $this->_sourceIp=$source;
+  }
+
+  /**
+   * Returns the ip used to connect to the destination
+   * @return string
+   */
+  public function getSourceIp()
+  {
+    return $this->_sourceIp;
+  }
+
   /**
    * Start the SMTP connection.
    */

--- a/lib/classes/Swift/Transport/EsmtpTransport.php
+++ b/lib/classes/Swift/Transport/EsmtpTransport.php
@@ -138,6 +138,25 @@ class Swift_Transport_EsmtpTransport
   }
   
   /**
+   * Sets the sourceIp
+   * @param string $source
+   */
+  public function setSourceIp($source)
+  {
+    $this->_params['sourceIp']=$source;
+    return $this;
+  }
+
+  /**
+   * Returns the ip used to connect to the destination
+   * @return string
+   */
+  public function getSourceIp()
+  {
+    return $this->_params['sourceIp'];
+  }
+  
+  /**
    * Set ESMTP extension handlers.
    * @param Swift_Transport_EsmtpHandler[] $handlers
    */

--- a/lib/classes/Swift/Transport/StreamBuffer.php
+++ b/lib/classes/Swift/Transport/StreamBuffer.php
@@ -226,7 +226,12 @@ class Swift_Transport_StreamBuffer
     {
       $timeout = $this->_params['timeout'];
     }
-    if (!$this->_stream = fsockopen($host, $this->_params['port'], $errno, $errstr, $timeout))
+    $options = array();
+    if (!empty($this->_params['sourceIp']))
+    {
+    	$options['socket']['bindto']=$this->_params['sourceIp'].':0';
+    }
+    if (!$this->_stream = stream_socket_client($host.':'.$this->_params['port'], $errno, $errstr, $timeout, STREAM_CLIENT_ASYNC_CONNECT|STREAM_CLIENT_CONNECT, stream_context_create($options)))
     {
       throw new Swift_TransportException(
         'Connection could not be established with host ' . $this->_params['host'] .


### PR DESCRIPTION
This allows the Source IP of the sender to be manipulated from outside the library.

This is useful if you need to send emails directly to the destination servers, bypassing local MTA for this job.
