### PR TITLE
Fixing a minor bug in message filename random generation

### DIFF
--- a/lib/classes/Swift/FileSpool.php
+++ b/lib/classes/Swift/FileSpool.php
@@ -201,7 +201,7 @@ class Swift_FileSpool extends Swift_ConfigurableSpool
     $strlen=strlen($base);
     for ($i=0; $i<$count; ++$i) 
     {
-      $ret.=$base[((int)rand(0,$base-1))];
+      $ret.=$base[((int)rand(0,$strlen-1))];
     }
     return $ret;
   }


### PR DESCRIPTION
There is a little bug in the new implementation of FileSpool.

Message filename are generated only with 'A' character.
