### PR TITLE
Amazon ses

### DIFF
--- a/docs/book/en/10-VendorTransport.markdown
+++ b/docs/book/en/10-VendorTransport.markdown
@@ -1,0 +1,48 @@
+Vendor Transports
+=================
+
+Vendor Specific transports are provided as a mean to more easily send emails
+to your recipients. Those vendors are by no-way better than any others we just
+for now don't have a transport implementation for other vendor. However, feel
+free to submit any vendor we missed.
+
+> The vendors are listed in alphabetical order, not by any kind of quality of 
+> service or any subjective data
+
+Amazon Simple Email Service
+---------------------------
+
+Amazon SES is provided by Amazon and allows you to send emails over the cloud
+and using their own infrastructure. For more information about the service, 
+please take a look http://aws.amazon.com/ses/ . To be able to use the 
+Amazon SES Transport, you'll need to install and load the Amazon SDK, this
+allows you to stay up-to-date and use other service without conflicts.
+To download the SDK : http://aws.amazon.com/sdkforphp/
+
+    [php]
+    require_once AMAZON_PATH.'/sdk.class.php';
+    require_once 'lib/swift_required.php';
+
+	$localUrl='XXXX';
+	
+    $transport = 
+    // Create the Transport to send simple mails over default server
+    Swift_Swift_Transport_Vendors_AmazonSES::newInstance();
+    
+    // Alternatively Connect to a local Amazon Server
+    // Swift_Swift_Transport_Vendors_AmazonSES::newInstance($localUrl);
+    
+    // Alternatively Connect to a local Amazon Server and send RAW mails
+    // Swift_Swift_Transport_Vendors_AmazonSES::newInstance($localUrl, true);
+    
+    // Alternatively send RAW mails on default server
+    // Swift_Swift_Transport_Vendors_AmazonSES::newInstance(null, true);
+    
+    $message = Swift_Message::newInstance();
+    
+    // Create your message content as usual 
+    
+    $mailer = Swift_Mailer::newInstance( $transport );
+    $mailer->send($message);
+
+

--- a/lib/classes/Swift/Transport/Vendors/AmazonSES.php
+++ b/lib/classes/Swift/Transport/Vendors/AmazonSES.php
@@ -6,8 +6,15 @@
  * file that was distributed with this source code.
  */
 
+/*
+ * This is A vendor Specific Transport
+ * If you want to send email through this vendor API, you'll need
+ * to download the Amazon SDK [http://aws.amazon.com/sdkforphp/]
+ * And subscribe there : http://aws.amazon.com/ses/
+ */
+
 /**
- * This Transport Implements SES Interface
+ * This Transport Implements Amazon SES Interface
  * @package Swift
  * @subpackage Transport
  * @author Xavier De Cock <xdecock@gmail.com>

--- a/lib/classes/Swift/Transport/Vendors/AmazonSES.php
+++ b/lib/classes/Swift/Transport/Vendors/AmazonSES.php
@@ -40,6 +40,10 @@ class Swift_Transport_Vendors_AmazonSES implements Swift_Transport
     $this->_sendRaw = $sendRaw;
   }
   
+  public static function newInstance($region=null, $raw=false) {
+    return new self($region, $raw);
+  }
+  
   public function send(Swift_Mime_Message $message, &$failedRecipients = null)
   {
     try {

--- a/lib/classes/Swift/Transport/Vendors/AmazonSES.php
+++ b/lib/classes/Swift/Transport/Vendors/AmazonSES.php
@@ -1,0 +1,182 @@
+<?php
+/*
+ * This file is part of SwiftMailer.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * This Transport Implements SES Interface
+ * @package Swift
+ * @subpackage Transport
+ * @author Xavier De Cock <xdecock@gmail.com>
+ * @author Rubn on Lighthouse Bug #176
+ */
+class Swift_Transport_Vendors_AmazonSES implements Swift_Transport 
+{
+  protected $_region;
+  
+  protected $_sendRaw = false;
+  
+  public function __construct($region = null, $sendRaw = false)
+  {
+    if (!class_exists('AmazonSES', false))
+    {
+      throw new Swift_TransportException('AmazonSDK is not loaded, please load it before Starting Swift\'s '.get_class($this));
+    }
+    if ($region === null)
+    {
+      $region = AmazonSES::DEFAULT_URL;
+    }
+    $this->_region = $region;
+    $this->_sendRaw = $sendRaw;
+  }
+  
+  public function send(Swift_Mime_Message $message, &$failedRecipients = null)
+  {
+    try {
+      $ses = new AmazonSES();
+      $ses->setRegion($this->region);
+      if ($this->_sendRaw)
+      {
+        $messageContent=$message->toString();
+        $ses->send_raw_email($messageContent);
+      }
+      else
+      {
+        /* Find Sender */
+        $returnPath = $message->getReturnPath();
+        if (empty($returnPath))
+        {
+          $returnPath = false;
+        }
+        $sender = $message->getSender();
+        if (empty($sender))
+        {
+          $sender = $message->getFrom();
+          if (count($sender) > 0)
+          {
+            throw new Swift_TransportException('Multiple From in the mail, but no sender defined, please correct this');
+          }
+        }
+        $sender = reset($this->_normalizeAddresses($sender));
+        $destinations = array();
+        /* Add Recipients */
+        $to = $message->getTo();
+        if (count($to))
+        {
+          $destinations['ToAddresses'] = $this->_normalizeAddresses($to);
+        }
+        unset($to);
+        /* Add Cc */
+        $cc = $message->getCc();
+        if (count($cc))
+        {
+          $destinations['CcAddresses'] = $this->_normalizeAddresses($cc);
+        }
+        unset($cc);
+        /* Add Bcc */
+        $bcc = $message->getBcc();
+        if (count($bcc))
+        {
+          $destinations['BccAddresses'] = $this->_normalizeAddresses($bcc);
+        }
+        unset($bcc);
+        /* Content */
+        $SESmessage = array();
+        /* Subject */
+        $SESmessage['Subject.Data'] = $message->getSubject();
+        $SESmessage['Subject.Charset'] = $message->getCharset();
+        switch ($message->getContentType())
+        {
+          /* If Message is single part */
+          case 'text/plain':
+            /* Text Only */
+            $SESmessage['Body.Text.Data'] = $message->getBody();
+            $SESmessage['Body.Text.Charset'] = $message->getCharset();
+            break;
+            
+          case 'text/html':
+            /* HTML Only */
+            $SESmessage['Body.Html.Data'] = $message->getBody();
+            $SESmessage['Body.Html.Charset'] = $message->getCharset();
+            break;
+            
+          default:
+            /* Multipart/Alternative */
+            $parts = $message->getChildren();
+            $textFound = $htmlFound = false;
+            foreach ($parts as $part)
+            {
+              if ($part->getContentType() == 'text/plain') {
+                if ($textFound)
+                {
+                  throw new Swift_TransportException('Multiple Text Part, Unable to send the mail through AmazonSES SendEmail API, please use SendRawEmail API ');
+                }
+                $SESmessage['Body.Text.Data'] = $part->getBody();
+                $SESmessage['Body.Text.Charset'] = $part->getCharset();
+                $textFound = true;
+              }
+              if ($part->getContentType() == 'text/html') {
+                if ($htmlFound)
+                {
+                  throw new Swift_TransportException('Multiple HTML Part, Unable to send the mail through AmazonSES SendEmail API, please use SendRawEmail API ');
+                }
+                $SESmessage['Body.Html.Data'] = $part->getBody();
+                $SESmessage['Body.Html.Charset'] = $part->getCharset();
+                $htmlFound = true;
+              }
+            }
+            break;
+        }
+        /* Options */
+        $options = array();
+        $replyTo = $message->getReplyTo();
+        if (count($replyTo))
+        {
+          $options['ReplyToAddresses'] = array_keys($replyTo);
+        }
+        if ($returnPath)
+        {
+          $options['ReturnPath'] = $returnPath;
+        }
+        /* Send The mail */
+        $ses->send_email($sender, $destinations, $SESmessage, $options);
+      }
+    }
+    catch (Exception $e)
+    {
+      throw new Swift_TransportException('Unknown Exception In '.__CLASS__.' : '.$e->getMessage());
+    }
+  }
+  
+  public function isStarted()
+  {
+    return true;
+  }
+  
+  public function registerPlugin()
+  {
+    return $this;
+  }
+  
+  public function start()
+  {
+    return $this;
+  }
+  
+  public function stop()
+  {
+    return $this;
+  }
+  
+  protected function _normalizeAddresses($addresses) {
+    $normalizedAddresses = array();
+    foreach ($addresses as $address => $name)
+    {
+      $normalizedAddresses[] = ($name === null ? $name . '<' .$address. '>' : $address);
+    }
+    return $normalizedAddresses;
+  }
+}


### PR DESCRIPTION
Reimplementation of the basic class provided in bug #176

Exposes the whole API.

We require Amazon SDK to be loaded by the end User before starting the transport.

Exposes SendEmail and SendRawEmail.

I'll strongly recommend to store all Cloud API Email Providers into _Transports_Vendors_*

This will avoid Bloating the Transport_ Namespace :)

All suggestions are welcome.
