### PR TITLE
fix for "slashes are escaped" bug 111

### DIFF
--- a/lib/classes/Swift/Mime/Headers/UnstructuredHeader.php
+++ b/lib/classes/Swift/Mime/Headers/UnstructuredHeader.php
@@ -98,9 +98,7 @@ class Swift_Mime_Headers_UnstructuredHeader
     if (!$this->getCachedValue())
     {
       $this->setCachedValue(
-        str_replace('\\', '\\\\', $this->encodeWords(
-          $this, $this->_value
-          ))
+        $this->encodeWords($this, $this->_value)
         );
     }
     return $this->getCachedValue();

--- a/tests/bug/Swift/Bug111Test.php
+++ b/tests/bug/Swift/Bug111Test.php
@@ -1,0 +1,46 @@
+<?php
+
+require_once 'Swift/Tests/SwiftUnitTestCase.php';
+
+class Swift_Bug111Test extends Swift_Tests_SwiftUnitTestCase
+{
+  
+  public function testUnstructuredHeaderSlashesShouldNotBeEscaped()
+  {
+    $complicated_header = array(
+      'to'=> array(
+        'email1@example.com',
+        'email2@example.com',
+        'email3@example.com',
+        'email4@example.com',
+        'email5@example.com',
+      ),
+      'sub' => array(
+        '-name-' => array(
+          'email1',
+          '"email2"',
+          'email3\\',
+          'email4',
+          'email5',
+        ),
+        '-url-' => array(
+          'http://google.com',
+          'http://yahoo.com',
+          'http://hotmail.com',
+          'http://aol.com',
+          'http://facebook.com',
+        ),
+      )
+    );
+    $json = json_encode($complicated_header);
+    
+    $message = new Swift_Message();
+    $headers = $message->getHeaders();
+    $headers->addTextHeader('X-SMTPAPI', $json);
+    $header = $headers->get('X-SMTPAPI');
+    
+    $this->assertEqual('Swift_Mime_Headers_UnstructuredHeader', get_class($header));
+    $this->assertEqual($json, $header->getFieldBody());
+  }
+  
+}


### PR DESCRIPTION
I have run into the bug discussed here in 2009:

http://swiftmailer.lighthouseapp.com/projects/21527/tickets/111-slashes-are-escaped

xdecock's fix solves the immediate problem. I cannot know if this fix might cause some other problem, but the tests that don't require an smtp server still pass.

I've added a bug 111 test to check the specific case I'm trying to solve, sending a custom X-SMTPAPI header containing HTML to SendGrid. The header is JSON encoded, which uses backslashes liberally for it's own syntax. Re-escaping backslashes is destroying the JSON.
