### PR TITLE
Remove async connect flag

### DIFF
--- a/lib/classes/Swift/Transport/StreamBuffer.php
+++ b/lib/classes/Swift/Transport/StreamBuffer.php
@@ -268,7 +268,7 @@ class Swift_Transport_StreamBuffer
     {
     	$options['socket']['bindto']=$this->_params['sourceIp'].':0';
     }
-    if (!$this->_stream = stream_socket_client($host.':'.$this->_params['port'], $errno, $errstr, $timeout, STREAM_CLIENT_ASYNC_CONNECT|STREAM_CLIENT_CONNECT, stream_context_create($options)))
+    if (!$this->_stream = stream_socket_client($host.':'.$this->_params['port'], $errno, $errstr, $timeout, STREAM_CLIENT_CONNECT, stream_context_create($options)))
     {
       throw new Swift_TransportException(
         'Connection could not be established with host ' . $this->_params['host'] .


### PR DESCRIPTION
The case isn't handled by the rest of the code. If the connect doesn't happen
right away then subsequent (and too quick) fgets() gets FALSE and everything fails.
