### PR TITLE
Fixed bug #166

### DIFF
--- a/lib/classes/Swift/Transport/AbstractSmtpTransport.php
+++ b/lib/classes/Swift/Transport/AbstractSmtpTransport.php
@@ -156,13 +156,6 @@ abstract class Swift_Transport_AbstractSmtpTransport
     $sent = 0;
     $failedRecipients = (array) $failedRecipients;
     
-    if (!$reversePath = $this->_getReversePath($message))
-    {
-      throw new Swift_TransportException(
-        'Cannot send message without a sender address'
-        );
-    }
-    
     if ($evt = $this->_eventDispatcher->createSendEvent($this, $message))
     {
       $this->_eventDispatcher->dispatchEvent($evt, 'beforeSendPerformed');
@@ -170,6 +163,13 @@ abstract class Swift_Transport_AbstractSmtpTransport
       {
         return 0;
       }
+    }
+    
+    if (!$reversePath = $this->_getReversePath($message))
+    {
+      throw new Swift_TransportException(
+        'Cannot send message without a sender address'
+        );
     }
     
     $to = (array) $message->getTo();


### PR DESCRIPTION
The AbstractSmtpTransport now figures out the reverseAddress _after_ the
beforeSend event is processed, instead of before. This makes it possible to
modify the Sender/Return-Path/From headers during event processing.
