### PR TITLE
Change charset attribute to encoding in XML prolog

### DIFF
--- a/notes/message.xml
+++ b/notes/message.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" charset="utf-8" ?>
+<?xml version="1.0" encoding="utf-8" ?>
 <message>
   <subject>Some test message</subject>
   <to name="Chris Corbyn">chris@w3style.co.uk</to>


### PR DESCRIPTION
Changed charset attribute to encoding in prolog as per XML spec: http://www.w3.org/TR/2000/REC-xml-20001006#NT-EncodingDecl
