### PR TITLE
avoid warning when cache directory do not exists

### DIFF
--- a/lib/classes/Swift/KeyCache/DiskKeyCache.php
+++ b/lib/classes/Swift/KeyCache/DiskKeyCache.php
@@ -250,7 +250,10 @@ class Swift_KeyCache_DiskKeyCache implements Swift_KeyCache
       {
         $this->clearKey($nsKey, $itemKey);
       }
-      rmdir($this->_path . '/' . $nsKey);
+      if (is_dir($this->_path . '/' . $nsKey))
+      {
+        rmdir($this->_path . '/' . $nsKey);
+      }
       unset($this->_keys[$nsKey]);
     }
   }


### PR DESCRIPTION
I get some warnings when the ->clearAll() method is called and the cache directory does not exist, which is annoying in a dev env where errors are displayed and the response is supposed to be json or xml.

This pull request just checks if the directory exists before deleting it.
