### PR TITLE
Making Swift_Mime_Grammar a shared instance

### DIFF
--- a/lib/dependency_maps/mime_deps.php
+++ b/lib/dependency_maps/mime_deps.php
@@ -8,7 +8,7 @@ Swift_DependencyContainer::getInstance()
   -> asValue('utf-8')
   
   -> register('mime.grammar')
-  -> asNewInstanceOf('Swift_Mime_Grammar')
+  -> asSharedInstanceOf('Swift_Mime_Grammar')
   
   -> register('mime.message')
   -> asNewInstanceOf('Swift_Mime_SimpleMessage')


### PR DESCRIPTION
When creating new Swift_Message objects (especially in a loop, where you might want to create 100+ messages in memory), it uses way more memory than it should.

It seems like Swift_Mime_Grammar should at least be shared -- right? That class doesn't seem to have any custom state.

Are there any other ways we can cut down on memory usage when you have a bunch of Swift_Message objects?

(Related, though not 100% directly related - it would be great if there was a way to make the `serialize()`d version of Swift_Message take up less space, as they are often used with something like DJJob and inserted into a database)
