### PR TITLE
Fix wrong detection of magic_quotes_runtime

### DIFF
--- a/lib/classes/Swift/ByteStream/FileByteStream.php
+++ b/lib/classes/Swift/ByteStream/FileByteStream.php
@@ -50,7 +50,11 @@ class Swift_ByteStream_FileByteStream
   {
     $this->_path = $path;
     $this->_mode = $writable ? 'w+b' : 'rb';
-    $this->_quotes = ini_get('magic_quotes_runtime');
+    
+    if (function_exists('get_magic_quotes_runtime') && @get_magic_quotes_runtime() == 1)
+    {
+      $this->_quotes = true;
+    }
   }
   
   /**

--- a/lib/classes/Swift/KeyCache/DiskKeyCache.php
+++ b/lib/classes/Swift/KeyCache/DiskKeyCache.php
@@ -65,7 +65,11 @@ class Swift_KeyCache_DiskKeyCache implements Swift_KeyCache
   {
     $this->_stream = $stream;
     $this->_path = $path;
-    $this->_quotes = ini_get('magic_quotes_runtime');
+
+    if (function_exists('get_magic_quotes_runtime') && @get_magic_quotes_runtime() == 1)
+    {
+      $this->_quotes = true;
+    }
   }
 
   /**


### PR DESCRIPTION
There is a bug in.

lib\classes\Swift\ByteStream\FileByteStream.php
lib\classes\Swift\KeyCache\DiskKeyCache.php

That wrongfully detects the usage of magic_quotes_runtime.
If ini_set('magic_quotes_runtime', 'Off'); was used, magic quotes were enabled, even though they where disabled in the first place.
