### PR TITLE
Remove warning

### DIFF
--- a/lib/preferences.php
+++ b/lib/preferences.php
@@ -12,7 +12,7 @@ Swift_Preferences::getInstance()->setCharset('utf-8');
 // Without these lines the default caching mechanism is "array" but this uses
 // a lot of memory.
 // If possible, use a disk cache to enable attaching large attachments etc
-if (function_exists('sys_get_temp_dir') && is_writable(sys_get_temp_dir()))
+if (function_exists('sys_get_temp_dir') && @is_writable(sys_get_temp_dir()))
 {
   Swift_Preferences::getInstance()
     -> setTempDir(sys_get_temp_dir())


### PR DESCRIPTION
When "open_basedir" is enabled, the is_writable may issue a warning
causing a crash if using with frameworks like symfony.

It's just a quick fix, but at least out of the box the component should not make the app crash for just a simple reason.

See this old ticket that speaks about this problem, without a true solution being approved: http://swiftmailer.lighthouseapp.com/projects/21527/tickets/40
