### PR TITLE
Remove 5.3 backslash in class definition

### DIFF
--- a/lib/classes/Swift/Plugins/ImpersonatePlugin.php
+++ b/lib/classes/Swift/Plugins/ImpersonatePlugin.php
@@ -14,7 +14,7 @@
  * @subpackage Plugins
  * @author Arjen Brouwer
  */
-class Swift_Plugins_ImpersonatePlugin implements \Swift_Events_SendListener {
+class Swift_Plugins_ImpersonatePlugin implements Swift_Events_SendListener {
 
     /**
      * The sender to impersonate.


### PR DESCRIPTION
It looks like a simple PHP 5.3 typo was added to this class. We noticed the issue when trying to encode the file with ionCube encoder for PHP 5.2
