### PR TITLE
[doc][installing-the-files] Fixed a minor typo

### DIFF
--- a/doc/including-the-files.rst
+++ b/doc/including-the-files.rst
@@ -1,7 +1,7 @@
 Including Swift Mailer (Autoloading)
 ====================================
 
-Swift Mailer uses an auto-loader so the only file you need to include is the
+Swift Mailer uses an autoloader so the only file you need to include is the
 ``lib/swift_required.php`` file.
 
 To use Swift Mailer's autoloader:


### PR DESCRIPTION
`auto-loader` should be spelled as `autoloader`
