### PR TITLE
Prefixed mail() call with error control operator.

### DIFF
--- a/lib/classes/Swift/Transport/SimpleMailInvoker.php
+++ b/lib/classes/Swift/Transport/SimpleMailInvoker.php
@@ -46,11 +46,11 @@ class Swift_Transport_SimpleMailInvoker implements Swift_Transport_MailInvoker
   {
     if (!ini_get('safe_mode'))
     {
-      return mail($to, $subject, $body, $headers, $extraParams);
+      return @mail($to, $subject, $body, $headers, $extraParams);
     }
     else
     {
-      return mail($to, $subject, $body, $headers);      
+      return @mail($to, $subject, $body, $headers);      
     }
   }
   


### PR DESCRIPTION
In some setups, calling mail() with the fifth parameter with safe_mode Off will generate a warning; but the mail is successfully sent.

Warning: mail(): Policy restriction in effect. The fifth parameter is disabled on this system in [...]Swift-4.0.6/lib/classes/Swift/Transport/SimpleMailInvoker.php on line 50.
