### PR TITLE
Transport/Stream Buffer

### DIFF
--- a/lib/classes/Swift/Transport/StreamBuffer.php
+++ b/lib/classes/Swift/Transport/StreamBuffer.php
@@ -260,7 +260,8 @@ class Swift_Transport_StreamBuffer
     {
     	$options['socket']['bindto']=$this->_params['sourceIp'].':0';
     }
-    if (!$this->_stream = stream_socket_client($host.':'.$this->_params['port'], $errno, $errstr, $timeout, STREAM_CLIENT_CONNECT, stream_context_create($options)))
+    $this->_stream = @stream_socket_client($host.':'.$this->_params['port'], $errno, $errstr, $timeout, STREAM_CLIENT_CONNECT, stream_context_create($options));
+    if (false === $this->_stream)
     {
       throw new Swift_TransportException(
         'Connection could not be established with host ' . $this->_params['host'] .


### PR DESCRIPTION
Prevent stream_socket_client() from generating an error and throw a Swift_TransportException instead

There are a lot of formatting changes... The only real change is https://github.com/vicb/swiftmailer/pull/new#L0R263
