### PR TITLE
Fix email subject with special characters (e.g. UTF-8) in Outlook

### DIFF
--- a/lib/classes/Swift/Mime/Headers/AbstractHeader.php
+++ b/lib/classes/Swift/Mime/Headers/AbstractHeader.php
@@ -381,14 +381,9 @@ abstract class Swift_Mime_Headers_AbstractHeader implements Swift_Mime_Header
         )
       );
     
-    foreach ($encodedTextLines as $lineNum => $line)
-    {
-      $encodedTextLines[$lineNum] = '=?' . $charsetDecl .
+    return '=?' . $charsetDecl .
         '?' . $this->_encoder->getName() .
-        '?' . $line . '?=';
-    }
-    
-    return implode("\r\n ", $encodedTextLines);
+        '?' . implode('', $encodedTextLines) . '?=';
   }
   
   /**


### PR DESCRIPTION
Following up & fixing #70, #79 and #185. Outlook 2003 and later does not correctly handle "folding" in the subject, resulting in a totally broken emails (see http://cloud.iserv.ch/G9GF).

I removed the code folding entirely. Interesting is that "folding" is actually only applied to strings that need encoding, that is why the issue never appeared with ASCII-only subjects and only happens if your subject happens to match a certain string length where the encoded part is folded.

This might also be threaded as a SwiftMailer bug, but because it was not taken care of as of now, I think the best solution (to support Outlook) is not to apply it on encoding either.
