### PR TITLE
[ByteSteam] Properties in AbstractFilterableInputStream are marked private but are used by inheriting classes.

### DIFF
--- a/lib/classes/Swift/ByteStream/AbstractFilterableInputStream.php
+++ b/lib/classes/Swift/ByteStream/AbstractFilterableInputStream.php
@@ -20,7 +20,7 @@ abstract class Swift_ByteStream_AbstractFilterableInputStream
 {
   
   /** Write sequence */
-  private $_sequence = 0;
+  protected $_sequence = 0;
   
   /** StreamFilters */
   private $_filters = array();


### PR DESCRIPTION
In lib/classes/Swift/ByteStream/AbstractFilterableInputStream.php all the properties are marked as private but are later used inside inheriting classes (resulting in an Fatal error).

I found this bug using the Code Inspector of PHPStorm.
