### PR TITLE
Updated Swift_CharacterReader_Utf8Reader::getMapType docblock

### DIFF
--- a/lib/classes/Swift/CharacterReader/Utf8Reader.php
+++ b/lib/classes/Swift/CharacterReader/Utf8Reader.php
@@ -142,7 +142,7 @@ class Swift_CharacterReader_Utf8Reader
   
   /**
    * Returns mapType
-   * @int mapType
+   * @return int mapType
    */
   public function getMapType()
   {


### PR DESCRIPTION
Changed `@int` to `@return int` in docblock because it was causing problem to the Symfony2 annotations parser. See Symfony2 issue [GH-4518](https://github.com/symfony/symfony/issues/4518) for further details.
