### PR TITLE
[pear_package_create] PHP path fix

### DIFF
--- a/test-suite/lib/simpletest/packages/pear_package_create.php
+++ b/test-suite/lib/simpletest/packages/pear_package_create.php
@@ -1,4 +1,4 @@
-#!/usr/local/bin/php -q
+#!/usr/bin/env php -q
 <?php
 /**
 * Generates a package.xml file for simpletest


### PR DESCRIPTION
Changes the php path to use the environment instead as php isn't always in this location which can cause issues with certain build systems that scan files for additional dependencies in this way. (RPMs for example)
