### PR TITLE
RedirectingPlugin: Allow specifying a whitelist with regular expressions

### DIFF
--- a/lib/classes/Swift/Plugins/RedirectingPlugin.php
+++ b/lib/classes/Swift/Plugins/RedirectingPlugin.php
@@ -25,13 +25,21 @@ class Swift_Plugins_RedirectingPlugin implements Swift_Events_SendListener
     private $_recipient;
 
     /**
+     * List of regular expression for recipient whitelisting
+     *
+     * @var array
+     */
+    private $_whitelist = array();
+
+    /**
      * Create a new RedirectingPlugin.
      *
      * @param integer $recipient
      */
-    public function __construct($recipient)
+    public function __construct($recipient, array $whitelist = array())
     {
         $this->_recipient = $recipient;
+        $this->_whitelist = $whitelist;
     }
 
     /**
@@ -55,6 +63,26 @@ class Swift_Plugins_RedirectingPlugin implements Swift_Events_SendListener
     }
 
     /**
+     * Set a list of regular expressions to whitelist certain recipients
+     *
+     * @param array $whitelist
+     */
+    public function setWhitelist(array $whitelist)
+    {
+        $this->_whitelist = $whitelist;
+    }
+
+    /**
+     * Get the whitelist
+     *
+     * @return array
+     */
+    public function getWhitelist()
+    {
+        return $this->_whitelist;
+    }
+
+    /**
      * Invoked immediately before the Message is sent.
      *
      * @param Swift_Events_SendEvent $evt
@@ -69,10 +97,66 @@ class Swift_Plugins_RedirectingPlugin implements Swift_Events_SendListener
         $headers->addMailboxHeader('X-Swift-Cc', $message->getCc());
         $headers->addMailboxHeader('X-Swift-Bcc', $message->getBcc());
 
-        // replace them with the one to send to
-        $message->setTo($this->_recipient);
-        $headers->removeAll('Cc');
-        $headers->removeAll('Bcc');
+        // Add hard coded recipient
+        $message->addTo($this->_recipient);
+
+        // Filter remaining headers against whitelist
+        $this->_filterHeaderSet($headers, 'To');
+        $this->_filterHeaderSet($headers, 'Cc');
+        $this->_filterHeaderSet($headers, 'Bcc');
+    }
+
+    /**
+     * Filter header set against a whitelist of regular expressions
+     *
+     * @param Swift_Mime_HeaderSet $headerSet
+     * @param string $type
+     */
+    private function _filterHeaderSet(Swift_Mime_HeaderSet $headerSet, $type)
+    {
+        foreach ($headerSet->getAll($type) as $headers) {
+            $headers->setNameAddresses($this->_filterNameAddresses($headers->getNameAddresses()));
+        }
+    }
+
+    /**
+     * Filtered list of addresses => name pairs
+     *
+     * @param array $recipients
+     * @return array
+     */
+    private function _filterNameAddresses(array $recipients)
+    {
+        $filtered = array();
+
+        foreach ($recipients as $address => $name) {
+            if ($this->_isWhitelisted($address)) {
+                $filtered[$address] = $name;
+            }
+        }
+
+        return $filtered;
+    }
+
+    /**
+     * Matches address against whitelist of regular expressions
+     *
+     * @param $recipient
+     * @return bool
+     */
+    protected function _isWhitelisted($recipient)
+    {
+        if ($recipient === $this->_recipient) {
+            return true;
+        }
+
+        foreach ($this->_whitelist as $pattern) {
+            if (preg_match($pattern, $recipient)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**


### PR DESCRIPTION
This pull requests allows to specify a whitelist for the RedirectingPlugin so that one can specify a whitelist where not to rewrite emails to. A typical use case is using external service provides like Litmus to test emails. Those providers randomly generate email addresses for a single test run. Allow whitelisting e.g. *@litmusapp.com helps a lot here. Another use case might be seed lists, where certain recipients in an organisation retrieve mails nevertheless the app is still in pre-prod stage.
