### PR TITLE
typo fix: creating messages/setting the body content: choose instead of chose

### DIFF
--- a/doc/messages.rst
+++ b/doc/messages.rst
@@ -202,7 +202,7 @@ be included ``addPart()`` can be used.
 The body of a message is the main part that is read by the user. Often people
 want to send a message in HTML format (``text/html``), other
 times people want to send in plain text (``text/plain``), or
-sometimes people want to send both versions and allow the recipient to chose
+sometimes people want to send both versions and allow the recipient to choose
 how they view the message.
 
 As a rule of thumb, if you're going to send a HTML email, always include a


### PR DESCRIPTION
Just an accidental typo.

original:

> sometimes people want to send both versions and allow the recipient to chose how they view the message.

after fix:

> sometimes people want to send both versions and allow the recipient to choose how they view the message.
