### PR TITLE
fixed grammatical error

### DIFF
--- a/doc/headers.rst
+++ b/doc/headers.rst
@@ -459,7 +459,7 @@ address.  For example, ``<1234955437.499becad62ec2@example.org>``.
 The part to the left of the @ sign is usually unique, based on the current time 
 and some random factor. The part on the right is usually a domain name.
 
-Any ID passed the an ID header's ``setId()`` method absolutely MUST conform to 
+Any ID passed to the header's ``setId()`` method absolutely MUST conform to 
 this structure, otherwise you'll get an Exception thrown at you by Swift Mailer 
 (a ``Swift_RfcComplianceException``).  This is to ensure that the generated 
 email complies with relevant RFC documents and therefore is less likely to be 


### PR DESCRIPTION
This sentence is gramatically incorrect:

> Any ID passed the an ID header's `setId()` method absolutely MUST conform to this structure [...]
