### PR TITLE
Wrong PHPDoc @return

### DIFF
--- a/lib/classes/Swift/Message.php
+++ b/lib/classes/Swift/Message.php
@@ -55,7 +55,7 @@ class Swift_Message extends Swift_Mime_SimpleMessage
      * @param string $contentType
      * @param string $charset
      *
-     * @return Swift_Mime_Message
+     * @return Swift_Message
      */
     public static function newInstance($subject = null, $body = null, $contentType = null, $charset = null)
     {


### PR DESCRIPTION
The newInstance method is returning itself, but the PHPDoc is hinting, that it returns the Swift_Mime_Message interface. Seems wrong to me & my IDE (PHPStorm) will not chain methods when creating a new message with the newInstance Method.
