### PR TITLE
Avoid warning: "is_writable(): open_basedir restriction in effect."

### DIFF
--- a/lib/preferences.php
+++ b/lib/preferences.php
@@ -14,11 +14,11 @@ Swift_Preferences::getInstance()->setCharset('utf-8');
 // You can override the default temporary directory by setting the TMPDIR environment variable.
 
 $tmp = getenv('TMPDIR');
-if ($tmp && is_writable($tmp)) {
+if ($tmp && @is_writable($tmp)) {
     Swift_Preferences::getInstance()
         ->setTempDir($tmp)
         ->setCacheType('disk');
-} elseif (function_exists('sys_get_temp_dir') && is_writable(sys_get_temp_dir())) {
+} elseif (function_exists('sys_get_temp_dir') && @is_writable(sys_get_temp_dir())) {
     Swift_Preferences::getInstance()
         ->setTempDir(sys_get_temp_dir())
         ->setCacheType('disk');


### PR DESCRIPTION
When the parameter provided for is_writable function is a path restricted by setting open_basedir configuration (http://php.net/manual/en/ini.core.php#ini.open-basedir), it throws warning instead of simply returning false. @ operator suppress the warning. Warning unnecessarily breaks the flow of the program - returned value 'false' is sufficient.
