### PR TITLE
Fix performance when tokenizing massive headers

### DIFF
--- a/lib/classes/Swift/Mime/Headers/AbstractHeader.php
+++ b/lib/classes/Swift/Mime/Headers/AbstractHeader.php
@@ -458,9 +458,11 @@ abstract class Swift_Mime_Headers_AbstractHeader implements Swift_Mime_Header
 
         //Generate atoms; split at all invisible boundaries followed by WSP
         foreach (preg_split('~(?=[ \t])~', $string) as $token) {
-            $tokens = array_merge($tokens, $this->generateTokenLines($token));
+            $newTokens = $this->generateTokenLines($token);
+            foreach ($newTokens as $newToken) {
+                $tokens[] = $newToken;
+            }
         }
-
         return $tokens;
     }
 


### PR DESCRIPTION
I made this update to fix a performance issue when using very large headers. The use case is SendGrid's bulk messaging API in which there can be many thousands of lines of JSON in one  X-SMTPAPI header. array_merge() is known to be slow when dealing with arrays over about 100 items and being called repeatedly, because it's doing a key re-sort operation every time. 

This change, in my 1000 item example, made the processing that happens inside ->send() go from 2 minutes to 2 seconds.
