### PR TITLE
Conditionally save current recipients

### DIFF
--- a/lib/classes/Swift/Plugins/RedirectingPlugin.php
+++ b/lib/classes/Swift/Plugins/RedirectingPlugin.php
@@ -93,10 +93,19 @@ class Swift_Plugins_RedirectingPlugin implements Swift_Events_SendListener
         $message = $evt->getMessage();
         $headers = $message->getHeaders();
 
-        // save current recipients
-        $headers->addMailboxHeader('X-Swift-To', $message->getTo());
-        $headers->addMailboxHeader('X-Swift-Cc', $message->getCc());
-        $headers->addMailboxHeader('X-Swift-Bcc', $message->getBcc());
+        // conditionally save current recipients
+
+        if ($headers->has('to')) {
+            $headers->addMailboxHeader('X-Swift-To', $message->getTo());
+        }
+
+        if ($headers->has('cc')) {
+            $headers->addMailboxHeader('X-Swift-Cc', $message->getCc());
+        }
+
+        if ($headers->has('bcc')) {
+            $headers->addMailboxHeader('X-Swift-Bcc', $message->getBcc());
+        }
 
         // Add hard coded recipient
         $message->addTo($this->_recipient);


### PR DESCRIPTION
- Swift_Plugins_RedirectingPlugin::beforeSendPerformed() does not check for the existence of headers before setting their X-Swift equivalent
- Swift_Plugins_RedirectingPlugin::_restoreMessage_restoreMessage() does check if the X-Swift equivalent exists before restoring the actual header

This leads to the possibility that although the cc and bcc headers were not originally set they will be set once the message is restored. This in turn leads to unexpected behaviour when checking for a headers existence with Swift_Mime_HeaderSet::has().

This patch checks for the existence of headers before setting their X-Swift equivalent.
