### PR TITLE
AbstractSmtpTransport should include the status code in the exception

### DIFF
--- a/lib/classes/Swift/Transport/AbstractSmtpTransport.php
+++ b/lib/classes/Swift/Transport/AbstractSmtpTransport.php
@@ -385,8 +385,8 @@ abstract class Swift_Transport_AbstractSmtpTransport implements Swift_Transport
             $this->_throwException(
                 new Swift_TransportException(
                     'Expected response code ' . implode('/', $wanted) . ' but got code ' .
-                    '"' . $code . '", with message "' . $response . '"'
-                    )
+                    '"' . $code . '", with message "' . $response . '"',
+                    $code)
                 );
         }
     }


### PR DESCRIPTION
Swift_TransportException should include the status code from the smtp backend.
