### PR TITLE
[error] Varying boundary length

### DIFF
--- a/lib/classes/Swift/Mime/SimpleMimeEntity.php
+++ b/lib/classes/Swift/Mime/SimpleMimeEntity.php
@@ -415,7 +415,7 @@ class Swift_Mime_SimpleMimeEntity implements Swift_Mime_MimeEntity
     public function getBoundary()
     {
         if (!isset($this->_boundary)) {
-            $this->_boundary = '_=_swift_v4_' . time() . '_' . getmypid() . '_' . uniqid(mt_rand(), true) . '_=_';
+            $this->_boundary = '_=_swift_v4_' . time() . '_' . md5(getmypid().mt_rand().uniqid('', true)) . '_=_';
         }
 
         return $this->_boundary;


### PR DESCRIPTION
At Swift_Mime_Headers_ParameterizedHeader::_createParameter boundary can be encoded because the length is bigger then allowed by $_maxLineLength.

Too long boundary in header after the encoding:

 boundary="=?utf-8?Q?=5F=3D=5Fswift=5Fv4=5F1365410405=5F16224=5F48336961651628265cb?=
 =?utf-8?Q?7d58=2E54152349=5F=3D=5F?="

Original boundary:
--_=_swift_v4_1365410405_16224_48336961651628265cb7d58.54152349_=_

where:

unix timestemp : 1365410405 
pid : 16224  // The maximum for 32 bit systems would be 32768, for 64 bit 4194304
uniqid(mt_rand(), true) : 48336961651628265cb7d58.54152349 // uniqid('', true)

Max values, lengths:

pid : The maximum for 32 bit systems would be 32768, for 64 bit 4194304 length: 1->7
uniqid('', true): length: 23
mt_rand(): max value 2147483647, length: 1->10

Both the getmypid() and mt_rand() function returns varying length result, anyway I don't know if pid in boundary is a good idea.

Maybe using md5 is better way to limit the max length and getting bigger entropy... 

Thx @smatyas for the help.
