### PR TITLE
Add MappedTransport to allow for various routing options

### DIFF
--- a/lib/classes/Swift/MappedTransport.php
+++ b/lib/classes/Swift/MappedTransport.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of SwiftMailer.
+ * (c) 2004-2009 Chris Corbyn
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * Uses several mapped Transport implementations when sending.
+ *
+ * @package    Swift
+ * @subpackage Transport
+ * @author     Patrick McAndrew <patrick@urg.name>
+ */
+class Swift_MappedTransport extends Swift_Transport_MappedTransport
+{
+    /**
+     * Creates a new MappedTransport with $transports.
+     *
+     * @param array $transports
+     */
+    public function __construct($transports = array())
+    {
+        call_user_func_array(
+            array($this, 'Swift_Transport_MappedTransport::__construct'),
+            Swift_DependencyContainer::getInstance()
+                ->createDependenciesFor('transport.mapped')
+            );
+
+        $this->setTransports($transports);
+    }
+
+    /**
+     * Create a new MappedTransport instance.
+     *
+     * @param array $transports
+     *
+     * @return Swift_MappedTransport
+     */
+    public static function newInstance($transports = array())
+    {
+        return new self($transports);
+    }
+}

--- a/lib/classes/Swift/Transport/MappedTransport.php
+++ b/lib/classes/Swift/Transport/MappedTransport.php
@@ -1,0 +1,275 @@
+<?php
+
+/*
+ * This file is part of SwiftMailer.
+ * (c) 2004-2009 Chris Corbyn
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * Uses several Transports with mapping rules.
+ *
+ * @package    Swift
+ * @subpackage Transport
+ * @author     Patrick McAndrew <patrick@urg.name>
+ */
+class Swift_Transport_MappedTransport implements Swift_Transport
+{
+    /**
+     * The Transports which are used in mapping.
+     *
+     * @var array[] (TransportName -> Swift_Transport)
+     */
+    protected $_transports = array();
+
+    /**
+     * The default transport name
+     *
+     * @var string
+     */
+    protected $_defaultTransportName;
+
+    /**
+     * The Mapping which are used in mapping.
+     *
+     * @var string[] (key -> value)
+     */
+    protected $_mappings = array();
+    
+    /**
+     * Creates a new MappedTransport.
+     */
+    public function __construct()
+    {
+    }
+
+    /**
+     * Set $transports to delegate to.
+     *
+     * @param Swift_Transport[] $transports
+     */
+    public function setTransports(array $transports)
+    {
+        foreach($transports as $key => $value) {
+           if (is_string($key) == false) {
+               throw new Exception("Invalid transport array - must be key(string) => value");
+           } else {
+               $this->_mappings[$key] = array();
+           }
+        }
+        
+        $this->_transports = $transports;
+    }
+    
+    /**
+     * Get $transports to delegate to.
+     *
+     * @return Swift_Transport[]
+     */
+    public function getTransports()
+    {
+        return $this->_transports;
+    }
+
+    /**
+     * Get $transports to delegate to.
+     *
+     * @return Swift_Transport[]
+     */
+    public function getTransportByName($transportName)
+    {
+        if (array_key_exists($transportName, $this->_transports)) {
+          return $this->_transports[$transportName];
+        } else {
+          return null;
+        }
+    }
+
+    /**
+     * Set the default transport name
+     *
+     * @param string $transportName
+     */
+    public function setDefaultTransportName($transportName)
+    {
+        $this->_defaultTransportName = $transportName;
+    }
+
+    /**
+     * Get the default transport name
+     *
+     * @return string
+     */
+    public function getDefaultTransportName()
+    {
+        return $this->_defaultTransportName;
+    }
+
+    /**
+     * Get the default transport
+     *
+     * @return Swift_Transport 
+     */
+    public function getDefaultTransport()
+    {
+        return $this->getTransportByName($this->getDefaultTransportName());
+    }
+
+    /**
+     * Set $mappings to delegate to.
+     *
+     * @param string $transport
+     * @param string[] $mappings
+     */
+    public function setMappings($transportName, array $mappings)
+    {
+        $this->_mappings[$transportName] = $mappings;
+    }
+    
+    /**
+     * Get $transports to delegate to.
+     *
+     * @param string $transportName
+     * @return string[]
+     */
+    public function getMappings($transportName)
+    {
+        return $this->_mappings[$transportName];
+    }
+
+    /**
+     * Test if this Transport mechanism has started.
+     *
+     * @return boolean
+     */
+    public function isStarted()
+    {
+        foreach($this->_transports as $transport)
+        {
+           if ($transport->isStarted()) {
+               return true;
+           }
+        }
+        
+        return false;
+    }
+
+    /**
+     * Start this Transport mechanism.
+     */
+    public function start()
+    {
+      // nothing to do - individual transports will be started as required in the send
+    }
+
+    /**
+     * Stop this Transport mechanism.
+     */
+    public function stop()
+    {
+        foreach ($this->_transports as $transport) {
+            $transport->stop();
+        }
+    }
+
+    /**
+     * Send the given Message.
+     *
+     * Recipient/sender data will be retrieved from the Message API.
+     * The return value is the number of recipients who were accepted for delivery.
+     *
+     * @param Swift_Mime_Message $message
+     * @param string[]           $failedRecipients An array of failures by-reference
+     *
+     * @return int
+     */
+    public function send(Swift_Mime_Message $message, &$failedRecipients = null)
+    {
+        $transport = $this->_getMappingTransport($message);
+        if ($transport == null) {
+            throw new Swift_TransportException(
+                'Unable to find transport'
+                );
+        }
+              if (!$transport->isStarted()) {
+                  $transport->start();
+              }
+              $sent = $transport->send($message, $failedRecipients);
+
+        return $sent;
+    }
+
+    /**
+     * Register a plugin.
+     *
+     * @param Swift_Events_EventListener $plugin
+     */
+    public function registerPlugin(Swift_Events_EventListener $plugin)
+    {
+        foreach ($this->_transports as $transport) {
+            $transport->registerPlugin($plugin);
+        }
+    }
+
+    // -- Protected methods
+
+    /**
+     * Find the transport according to mappings
+     *
+     * @return Swift_Transport
+     */
+    protected function _getMappingTransport(Swift_Mime_Message $message)
+    {
+       foreach ($this->getTransports() as $transportName => $transport) {
+         $mapping = $this->getMappings($transportName);
+         if ($mapping != null) {
+           foreach ($mapping as $mappingItem)  {
+              foreach ($mappingItem as $key => $mappingValue)  {
+                  // call key function on the message (e.g. getFrom)
+                  $messageValue = call_user_func(array($message, $key));
+
+                  // we're currently expecting messagevalue to be:
+                  // Swift_Mime_SimpleHeaderSet if getHeaders() is called
+                  // array($email => name) if getFrom/getTo is called
+                  // string if getSubject is called
+                  if ($messageValue instanceof Swift_Mime_SimpleHeaderSet && is_array($mappingValue)) {
+                     $mappingValueKey = key($mappingValue);
+                     $headers = $messageValue->getAll($mappingValueKey);
+                     foreach ($headers as $header) {
+                       if (preg_match($this->ensureRegEx($mappingValue[$mappingValueKey]), $header->getValue())) {
+                          return $transport;
+                       }
+                     }
+                  } else if (is_array($messageValue)) {  //  email address (email=>name), in which case match the email
+                       foreach ($messageValue as $messageItemKey => $messageItemValue) {
+                         if (preg_match($this->ensureRegEx($mappingValue), $messageItemKey)) {
+                            return $transport;
+                         }
+                       }
+                  } else if (preg_match($this->ensureRegEx($mappingValue), $messageValue)) {
+                       return $transport;
+                  }   
+              }
+           }
+         }
+       }
+       
+       return $this->getDefaultTransport(); 
+    }
+    
+    /**
+     * Find the transport according to mappings
+     *
+     * @return Swift_Transport
+     */
+    protected function ensureRegEx($pattern)
+    {
+      if (!preg_match('/^\/.*\/$/', $pattern)) {
+          $pattern = '/^' . str_replace('.', '\.', $pattern) . '$/i';
+      }
+      
+      return $pattern;
+    }
+}

--- a/lib/dependency_maps/transport_deps.php
+++ b/lib/dependency_maps/transport_deps.php
@@ -26,6 +26,9 @@ Swift_DependencyContainer::getInstance()
     ->register('transport.failover')
     ->asNewInstanceOf('Swift_Transport_FailoverTransport')
 
+    -> register('transport.mapped')
+    -> asNewInstanceOf('Swift_Transport_MappedTransport')
+
     ->register('transport.spool')
     ->asNewInstanceOf('Swift_Transport_SpoolTransport')
     ->withDependencies(array('transport.eventdispatcher'))

--- a/tests/unit/Swift/Transport/MappedTransportTest.php
+++ b/tests/unit/Swift/Transport/MappedTransportTest.php
@@ -1,0 +1,396 @@
+<?php
+
+require_once 'Swift/Tests/SwiftUnitTestCase.php';
+require_once 'Swift/Transport/MappedTransport.php';
+require_once 'Swift/TransportException.php';
+require_once 'Swift/Transport.php';
+require_once 'Swift/Events/EventListener.php';
+
+class Swift_Transport_MappedTransportTest
+    extends Swift_Tests_SwiftUnitTestCase
+{
+    public function testDefaultTransport()
+    {
+        $context = new Mockery();
+        $message1 = $context->mock('Swift_Mime_Message');
+        $message2 = $context->mock('Swift_Mime_Message');
+        $t1 = $context->mock('Swift_Transport');
+        $t2 = $context->mock('Swift_Transport');
+        $con1 = $context->states('Connection 1')->startsAs('off');
+        $con2 = $context->states('Connection 2')->startsAs('off');
+        $context->checking(Expectations::create()
+            -> one($message1)->getFrom()->returns(array('foo@bar.com'=>'Name'))
+            -> one($message2)->getFrom()->returns(array('foo@bar.com'=>'Name'))
+            -> allowing($t1)->isStarted() -> returns(false) -> when($con1->is('off'))
+            -> allowing($t1)->isStarted() -> returns(true) -> when($con1->is('on'))
+            -> allowing($t1)->start() -> when($con1->is('off')) -> then($con1->is('on'))
+            -> one($t1)->send($message1, optional()) -> returns(1) -> when($con1->is('on'))
+            -> one($t1)->send($message2, optional()) -> returns(1) -> when($con1->is('on'))
+            -> ignoring($t1)
+            -> allowing($t2)->isStarted() -> returns(false) -> when($con2->is('off'))
+            -> allowing($t2)->isStarted() -> returns(true) -> when($con2->is('on'))
+            -> allowing($t2)->start() -> when($con2->is('off')) -> then($con2->is('on'))
+            -> never($t2)->send($message1, optional())
+            -> never($t2)->send($message2, optional())
+            -> ignoring($t2)
+            );
+
+        $transport = $this->_getTransport(array('t1' => $t1, 't2' => $t2), 't1');
+        $transport->setMappings('t2', array(array('getFrom' => 'foobar@bar.com')));
+        $transport->start();
+        $this->assertEqual(1, $transport->send($message1));
+        $this->assertEqual(1, $transport->send($message2));
+
+        $context->assertIsSatisfied();
+    }
+
+    public function testGetFromMapping()
+    {
+        $context = new Mockery();
+        $message1 = $context->mock('Swift_Mime_Message');
+        $message2 = $context->mock('Swift_Mime_Message');
+        $t1 = $context->mock('Swift_Transport');
+        $t2 = $context->mock('Swift_Transport');
+        $con1 = $context->states('Connection 1')->startsAs('off');
+        $con2 = $context->states('Connection 2')->startsAs('off');
+        $context->checking(Expectations::create()
+            -> one($message1)->getFrom()->returns(array('foo@bar.com'=>'Name'))
+            -> one($message2)->getFrom()->returns(array('foobar@bar.com'=>'Name'))
+            -> allowing($t1)->isStarted() -> returns(false) -> when($con1->is('off'))
+            -> allowing($t1)->isStarted() -> returns(true) -> when($con1->is('on'))
+            -> allowing($t1)->start() -> when($con1->is('off')) -> then($con1->is('on'))
+            -> one($t1)->send($message1, optional()) -> returns(1) -> when($con1->is('on'))
+            -> never($t1)->send($message2, optional())
+            -> ignoring($t1)
+            -> allowing($t2)->isStarted() -> returns(false) -> when($con2->is('off'))
+            -> allowing($t2)->isStarted() -> returns(true) -> when($con2->is('on'))
+            -> allowing($t2)->start() -> when($con2->is('off')) -> then($con2->is('on'))
+            -> one($t2)->send($message2, optional()) -> returns(1) -> when($con2->is('on'))
+            -> never($t2)->send($message1, optional())
+            -> ignoring($t2)
+            );
+
+        $transport = $this->_getTransport(array('t1' => $t1, 't2' => $t2), 't1');
+        $transport->setMappings('t2', array(array('getFrom' => 'foobar@bar.com')));
+        $transport->start();
+        $this->assertEqual(1, $transport->send($message1));
+        $this->assertEqual(1, $transport->send($message2));
+
+        $context->assertIsSatisfied();
+    }
+    
+    public function testGetFromCaseInsensitiveMapping()
+    {
+        $context = new Mockery();
+        $message1 = $context->mock('Swift_Mime_Message');
+        $message2 = $context->mock('Swift_Mime_Message');
+        $t1 = $context->mock('Swift_Transport');
+        $t2 = $context->mock('Swift_Transport');
+        $con1 = $context->states('Connection 1')->startsAs('off');
+        $con2 = $context->states('Connection 2')->startsAs('off');
+        $context->checking(Expectations::create()
+            -> one($message1)->getFrom()->returns(array('foo@bar.com'=>'Name'))
+            -> one($message2)->getFrom()->returns(array('FoObaR@bar.COM'=>'Name'))
+            -> allowing($t1)->isStarted() -> returns(false) -> when($con1->is('off'))
+            -> allowing($t1)->isStarted() -> returns(true) -> when($con1->is('on'))
+            -> allowing($t1)->start() -> when($con1->is('off')) -> then($con1->is('on'))
+            -> one($t1)->send($message1, optional()) -> returns(1) -> when($con1->is('on'))
+            -> never($t1)->send($message2, optional())
+            -> ignoring($t1)
+            -> allowing($t2)->isStarted() -> returns(false) -> when($con2->is('off'))
+            -> allowing($t2)->isStarted() -> returns(true) -> when($con2->is('on'))
+            -> allowing($t2)->start() -> when($con2->is('off')) -> then($con2->is('on'))
+            -> one($t2)->send($message2, optional()) -> returns(1) -> when($con2->is('on'))
+            -> never($t2)->send($message1, optional())
+            -> ignoring($t2)
+            );
+
+        $transport = $this->_getTransport(array('t1' => $t1, 't2' => $t2), 't1');
+        $transport->setMappings('t2', array(array('getFrom' => 'foobar@bar.com')));
+        $transport->start();
+        $this->assertEqual(1, $transport->send($message1));
+        $this->assertEqual(1, $transport->send($message2));
+
+        $context->assertIsSatisfied();
+    }
+
+    public function testGetFromRegExMapping()
+    {
+        $context = new Mockery();
+        $message1 = $context->mock('Swift_Mime_Message');
+        $message2 = $context->mock('Swift_Mime_Message');
+        $t1 = $context->mock('Swift_Transport');
+        $t2 = $context->mock('Swift_Transport');
+        $con1 = $context->states('Connection 1')->startsAs('off');
+        $con2 = $context->states('Connection 2')->startsAs('off');
+        $context->checking(Expectations::create()
+            -> one($message1)->getFrom()->returns(array('foo@bar.com'=>'Name'))
+            -> one($message2)->getFrom()->returns(array('foobar@bar.com'=>'Name'))
+            -> allowing($t1)->isStarted() -> returns(false) -> when($con1->is('off'))
+            -> allowing($t1)->isStarted() -> returns(true) -> when($con1->is('on'))
+            -> allowing($t1)->start() -> when($con1->is('off')) -> then($con1->is('on'))
+            -> one($t1)->send($message1, optional()) -> returns(1) -> when($con1->is('on'))
+            -> never($t1)->send($message2, optional())
+            -> ignoring($t1)
+            -> allowing($t2)->isStarted() -> returns(false) -> when($con2->is('off'))
+            -> allowing($t2)->isStarted() -> returns(true) -> when($con2->is('on'))
+            -> allowing($t2)->start() -> when($con2->is('off')) -> then($con2->is('on'))
+            -> one($t2)->send($message2, optional()) -> returns(1) -> when($con2->is('on'))
+            -> never($t2)->send($message1, optional())
+            -> ignoring($t2)
+            );
+
+        $transport = $this->_getTransport(array('t1' => $t1, 't2' => $t2), 't1');
+        $transport->setMappings('t2', array(array('getFrom' => '/^foobar@.*$/')));
+        $transport->start();
+        $this->assertEqual(1, $transport->send($message1));
+        $this->assertEqual(1, $transport->send($message2));
+
+        $context->assertIsSatisfied();
+    }
+    
+    public function testGetToMapping()
+    {
+        $context = new Mockery();
+        $message1 = $context->mock('Swift_Mime_Message');
+        $message2 = $context->mock('Swift_Mime_Message');
+        $t1 = $context->mock('Swift_Transport');
+        $t2 = $context->mock('Swift_Transport');
+        $con1 = $context->states('Connection 1')->startsAs('off');
+        $con2 = $context->states('Connection 2')->startsAs('off');
+        $context->checking(Expectations::create()
+            -> one($message1)->getTo()->returns(array('foo@bar.com'=>'Name'))
+            -> one($message2)->getTo()->returns(array('foobar@bar.com'=>'Name'))
+            -> allowing($t1)->isStarted() -> returns(false) -> when($con1->is('off'))
+            -> allowing($t1)->isStarted() -> returns(true) -> when($con1->is('on'))
+            -> allowing($t1)->start() -> when($con1->is('off')) -> then($con1->is('on'))
+            -> one($t1)->send($message1, optional()) -> returns(1) -> when($con1->is('on'))
+            -> never($t1)->send($message2, optional())
+            -> ignoring($t1)
+            -> allowing($t2)->isStarted() -> returns(false) -> when($con2->is('off'))
+            -> allowing($t2)->isStarted() -> returns(true) -> when($con2->is('on'))
+            -> allowing($t2)->start() -> when($con2->is('off')) -> then($con2->is('on'))
+            -> one($t2)->send($message2, optional()) -> returns(1) -> when($con2->is('on'))
+            -> never($t2)->send($message1, optional())
+            -> ignoring($t2)
+            );
+
+        $transport = $this->_getTransport(array('t1' => $t1, 't2' => $t2), 't1');
+        $transport->setMappings('t2', array(array('getTo' => 'foobar@bar.com')));
+        $transport->start();
+        $this->assertEqual(1, $transport->send($message1));
+        $this->assertEqual(1, $transport->send($message2));
+
+        $context->assertIsSatisfied();
+    }
+    
+    public function testGetSubjectMapping()
+    {
+        $context = new Mockery();
+        $message1 = $context->mock('Swift_Mime_Message');
+        $message2 = $context->mock('Swift_Mime_Message');
+        $t1 = $context->mock('Swift_Transport');
+        $t2 = $context->mock('Swift_Transport');
+        $con1 = $context->states('Connection 1')->startsAs('off');
+        $con2 = $context->states('Connection 2')->startsAs('off');
+        $context->checking(Expectations::create()
+            -> one($message1)->getSubject()->returns('notfoobar')
+            -> one($message2)->getSubject()->returns('foobar')
+            -> allowing($t1)->isStarted() -> returns(false) -> when($con1->is('off'))
+            -> allowing($t1)->isStarted() -> returns(true) -> when($con1->is('on'))
+            -> allowing($t1)->start() -> when($con1->is('off')) -> then($con1->is('on'))
+            -> one($t1)->send($message1, optional()) -> returns(1) -> when($con1->is('on'))
+            -> never($t1)->send($message2, optional())
+            -> ignoring($t1)
+            -> allowing($t2)->isStarted() -> returns(false) -> when($con2->is('off'))
+            -> allowing($t2)->isStarted() -> returns(true) -> when($con2->is('on'))
+            -> allowing($t2)->start() -> when($con2->is('off')) -> then($con2->is('on'))
+            -> one($t2)->send($message2, optional()) -> returns(1) -> when($con2->is('on'))
+            -> never($t2)->send($message1, optional())
+            -> ignoring($t2)
+            );
+
+        $transport = $this->_getTransport(array('t1' => $t1, 't2' => $t2), 't1');
+        $transport->setMappings('t2', array(array('getSubject' => 'foobar')));
+        $transport->start();
+        $this->assertEqual(1, $transport->send($message1));
+        $this->assertEqual(1, $transport->send($message2));
+
+        $context->assertIsSatisfied();
+    }
+
+    public function testGetHeaderMapping()
+    {
+        $context = new Mockery();
+        $message1 = $context->mock('Swift_Mime_Message');
+        $headers1 = $context->mock('Swift_Mime_SimpleHeaderSet');
+        $headerValue1 = $context->mock('Swift_Mime_Headers_UnstructuredHeader');
+        $message2 = $context->mock('Swift_Mime_Message');
+        $headers2 = $context->mock('Swift_Mime_SimpleHeaderSet');
+        $headerValue2 = $context->mock('Swift_Mime_Headers_UnstructuredHeader');
+        $t1 = $context->mock('Swift_Transport');
+        $t2 = $context->mock('Swift_Transport');
+        $con1 = $context->states('Connection 1')->startsAs('off');
+        $con2 = $context->states('Connection 2')->startsAs('off');
+        $context->checking(Expectations::create()
+            -> one($headerValue1)->getValue()->returns('notfoobar')
+            -> one($headers1)->getAll()->returns(array($headerValue1))
+            -> one($message1)->getHeaders()->returns($headers1)
+            -> allowing($t1)->isStarted() -> returns(false) -> when($con1->is('off'))
+            -> allowing($t1)->isStarted() -> returns(true) -> when($con1->is('on'))
+            -> allowing($t1)->start() -> when($con1->is('off')) -> then($con1->is('on'))
+            -> one($t1)->send($message1, optional()) -> returns(1) -> when($con1->is('on'))
+            -> never($t1)->send($message2, optional())
+            -> ignoring($t1)
+            -> one($headerValue2)->getValue()->returns('foobar')
+            -> one($headers2)->getAll()->returns(array($headerValue2))
+            -> one($message2)->getHeaders()->returns($headers2)
+            -> allowing($t2)->isStarted() -> returns(false) -> when($con2->is('off'))
+            -> allowing($t2)->isStarted() -> returns(true) -> when($con2->is('on'))
+            -> allowing($t2)->start() -> when($con2->is('off')) -> then($con2->is('on'))
+            -> one($t2)->send($message2, optional()) -> returns(1) -> when($con2->is('on'))
+            -> never($t2)->send($message1, optional())
+            -> ignoring($t2)
+            );
+
+        $transport = $this->_getTransport(array('t1' => $t1, 't2' => $t2), 't1');
+        $transport->setMappings('t2', array(array('getHeaders' => array('X-MappedTransport' => 'foobar'))));
+        $transport->start();
+        $this->assertEqual(1, $transport->send($message1));
+        $this->assertEqual(1, $transport->send($message2));
+
+        $context->assertIsSatisfied();
+    }
+
+    public function testComplexMapping()
+    {
+        $context = new Mockery();
+        
+        $message1 = $context->mock('Swift_Mime_Message');
+        $headers1 = $context->mock('Swift_Mime_SimpleHeaderSet');
+        $headerValue1 = $context->mock('Swift_Mime_Headers_UnstructuredHeader');
+        
+        $message2 = $context->mock('Swift_Mime_Message');
+        $headers2 = $context->mock('Swift_Mime_SimpleHeaderSet');
+        $headerValue2 = $context->mock('Swift_Mime_Headers_UnstructuredHeader');
+        
+        $message3 = $context->mock('Swift_Mime_Message');
+        $headers3 = $context->mock('Swift_Mime_SimpleHeaderSet');
+        $headerValue3 = $context->mock('Swift_Mime_Headers_UnstructuredHeader');
+        
+        $t1 = $context->mock('Swift_Transport');
+        $t2 = $context->mock('Swift_Transport');
+        $t3 = $context->mock('Swift_Transport');
+        
+        $con1 = $context->states('Connection 1')->startsAs('off');
+        $con2 = $context->states('Connection 2')->startsAs('off');
+        $con3 = $context->states('Connection 3')->startsAs('off');
+        
+        $context->checking(Expectations::create()
+            -> allowing($headerValue1)->getValue()->returns('t1')
+            -> allowing($headers1)->getAll()->returns(array($headerValue1))
+            -> allowing($message1)->getHeaders()->returns($headers1)
+            -> allowing($message1)->getFrom()->returns('a')
+            -> allowing($t1)->isStarted() -> returns(false) -> when($con1->is('off'))
+            -> allowing($t1)->isStarted() -> returns(true) -> when($con1->is('on'))
+            -> allowing($t1)->start() -> when($con1->is('off')) -> then($con1->is('on'))
+            -> allowing($t1)->send($message1, optional()) -> returns(1) -> when($con1->is('on'))
+            -> never($t1)->send($message2, optional())
+            -> ignoring($t1)
+            -> allowing($headerValue2)->getValue()->returns('2')
+            -> allowing($headers2)->getAll()->returns(array($headerValue2))
+            -> allowing($message2)->getHeaders()->returns($headers2)
+            -> allowing($message2)->getFrom()->returns('b')
+            -> allowing($t2)->isStarted() -> returns(false) -> when($con2->is('off'))
+            -> allowing($t2)->isStarted() -> returns(true) -> when($con2->is('on'))
+            -> allowing($t2)->start() -> when($con2->is('off')) -> then($con2->is('on'))
+            -> allowing($t2)->send($message2, optional()) -> returns(1) -> when($con2->is('on'))
+            -> never($t2)->send($message1, optional())
+            -> ignoring($t2)
+            -> allowing($headerValue3)->getValue()->returns('4')
+            -> allowing($headers3)->getAll()->returns(array($headerValue3))
+            -> allowing($message3)->getHeaders()->returns($headers3)
+            -> allowing($message3)->getFrom()->returns('b')
+            -> allowing($t3)->isStarted() -> returns(false) -> when($con3->is('off'))
+            -> allowing($t3)->isStarted() -> returns(true) -> when($con3->is('on'))
+            -> allowing($t3)->start() -> when($con3->is('off')) -> then($con3->is('on'))
+            -> allowing($t3)->send($message3, optional()) -> returns(1) -> when($con3->is('on'))
+            -> never($t3)->send($message1, optional())
+            -> never($t3)->send($message2, optional())
+            -> ignoring($t3)
+            );
+
+        $transport = $this->_getTransport(array('t1' => $t1, 't2' => $t2, 't3' => $t3), 't3');
+        $transport->setMappings('t1',
+                                array(array('getHeaders' => array('X-SWIFT-MAPPED-SENDER' => 't1')),
+                                      array('getHeaders' => array('X-SWIFT-MAPPED-DELIVERY' => '1')),
+                                      array('getFrom' => 't1@foo'),
+                                      array('getFrom' => '1@foo'),
+                                ));
+        $transport->setMappings('t2',
+                                array(array('getHeaders' => array('X-SWIFT-MAPPED-SENDER' => 't2')),
+                                      array('getHeaders' => array('X-SWIFT-MAPPED-DELIVERY' => '2')),
+                                      array('getFrom' => 't2@foo'),
+                                      array('getFrom' => '2@foo'),
+                                ));
+        $transport->setMappings('t3',
+                                array(array('getHeaders' => array('X-SWIFT-MAPPED-SENDER' => 't3')),
+                                      array('getHeaders' => array('X-SWIFT-MAPPED-DELIVERY' => '3')),
+                                      array('getFrom' => 't3@foo'),
+                                      array('getFrom' => '3@foo'),
+                                ));
+        $transport->start();
+        for ($i = 0; $i < 50; $i++) {
+          $this->assertEqual(1, $transport->send($message1));
+          $this->assertEqual(1, $transport->send($message2));
+          $this->assertEqual(1, $transport->send($message3));
+          $this->assertEqual(1, $transport->send($message2));
+          $this->assertEqual(1, $transport->send($message3));
+          $this->assertEqual(1, $transport->send($message1));
+        }
+        
+        $context->assertIsSatisfied();
+    }
+    
+    public function testRegisterPluginDelegatesToLoadedTransports()
+    {
+        $context = new Mockery();
+
+        $plugin = $this->_createPlugin($context);
+
+        $t1 = $context->mock('Swift_Transport');
+        $t2 = $context->mock('Swift_Transport');
+        $context->checking(Expectations::create()
+            -> one($t1)->registerPlugin($plugin)
+            -> one($t2)->registerPlugin($plugin)
+            -> ignoring($t1)
+            -> ignoring($t2)
+            );
+
+        $transport = $this->_getTransport(array('t1' => $t1, 't2' => $t2), 't1');
+        $transport->registerPlugin($plugin);
+
+        $context->assertIsSatisfied();
+    }
+    // -- Private helpers
+
+    private function _getTransport(array $transports, $defaultTransportName)
+    {
+        $transport = new Swift_Transport_MappedTransport();
+        $transport->setTransports($transports);
+        $transport->setDefaultTransportName($defaultTransportName);
+        
+        return $transport;
+    }
+
+    private function _createPlugin($context)
+    {
+        return $context->mock('Swift_Events_EventListener');
+    }
+
+    private function _createInnerTransport()
+    {
+        return $this->_mockery()->mock('Swift_Transport');
+    }
+
+}


### PR DESCRIPTION
We have several stmp gateways that we sent to and need to sent based on various rules (from, x-headers, etc).  This transport agent allows us to define the rules in config.