### PR TITLE
Handle correct exception type while reading IoBuffer output

### DIFF
--- a/lib/classes/Swift/Transport/AbstractSmtpTransport.php
+++ b/lib/classes/Swift/Transport/AbstractSmtpTransport.php
@@ -405,6 +405,8 @@ abstract class Swift_Transport_AbstractSmtpTransport implements Swift_Transport
                 new Swift_TransportException(
                     $e->getMessage())
                 );
+        } catch (Swift_TransportException $e) {
+            $this->_throwException($e);
         }
 
         return $response;


### PR DESCRIPTION
readLine function (currently only implemented in Swift_Transport_StreamBuffer) throws Swift_IoException that is unhandled so it bubbles up outside SwiftMailer.

I use FailoverTransport and its not working as expected unless this fix is applied.

Fixes #294
