### PR TITLE
Improve IDE code completion for Swift_SmtpTransport

### DIFF
--- a/lib/classes/Swift/SmtpTransport.php
+++ b/lib/classes/Swift/SmtpTransport.php
@@ -15,7 +15,11 @@
  * @subpackage Transport
  * @author     Chris Corbyn
  * @method Swift_SmtpTransport setUsername(string $username) Set the username to authenticate with.
+ * @method string              getUsername()                 Get the username to authenticate with.
  * @method Swift_SmtpTransport setPassword(string $password) Set the password to authenticate with.
+ * @method string              getPassword()                 Get the password to authenticate with.
+ * @method Swift_SmtpTransport setAuthMode(string $mode)     Set the auth mode to use to authenticate.
+ * @method string              getAuthMode()                 Get the auth mode to use to authenticate.
  */
 class Swift_SmtpTransport extends Swift_Transport_EsmtpTransport
 {


### PR DESCRIPTION
Add @method doc blocks to Swift_SmtpTransport for setUsername(), getUsername(), setPassword(), getPassword(), setAuthMode() and getAuthMode() to improve IDE code completion for Swift_SmtpTransport.
