### PR TITLE
[Singers] fixed openssl_pkcs7_encrypt() not using the encryptCipher

### DIFF
--- a/lib/classes/Swift/Signers/SMimeSigner.php
+++ b/lib/classes/Swift/Signers/SMimeSigner.php
@@ -307,7 +307,7 @@ class Swift_Signers_SMimeSigner implements Swift_Signers_BodySigner
     {
         $encryptedMessageStream = new Swift_ByteStream_TemporaryFileByteStream();
 
-        if (!openssl_pkcs7_encrypt($outputStream->getPath(), $encryptedMessageStream->getPath(), $this->encryptCert, array())) {
+        if (!openssl_pkcs7_encrypt($outputStream->getPath(), $encryptedMessageStream->getPath(), $this->encryptCert, array(), 0, $this->encryptCipher)) {
             throw new Swift_IoException(sprintf('Failed to encrypt S/Mime message. Error: "%s".', openssl_error_string()));
         }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #340 |
| License | MIT |

Swift_Signers_SMimeSigner did not use $encryptCipher, making it always use the the weakest cipher OPENSSL_CIPHER_RC2_40
