### PR TITLE
NullTransport should report that all emails have been delivered.

### DIFF
--- a/lib/classes/Swift/Transport/NullTransport.php
+++ b/lib/classes/Swift/Transport/NullTransport.php
@@ -73,7 +73,13 @@ class Swift_Transport_NullTransport implements Swift_Transport
             $this->_eventDispatcher->dispatchEvent($evt, 'sendPerformed');
         }
 
-        return 0;
+        $count = (
+            count((array) $message->getTo())
+            + count((array) $message->getCc())
+            + count((array) $message->getBcc())
+            );
+
+        return $count;
     }
 
     /**


### PR DESCRIPTION
The PHPDoc for `NullTransport` says:

> Pretends messages have been sent, but just ignores them.

However it returns `0` from `send()` method saying that no mail has been delivered.

It should return number of recipients.
