### PR TITLE
PHP Mail Transport to allow all recipients in BCC

### DIFF
--- a/lib/classes/Swift/Transport/MailTransport.php
+++ b/lib/classes/Swift/Transport/MailTransport.php
@@ -124,6 +124,11 @@ class Swift_Transport_MailTransport implements Swift_Transport
             + count((array) $message->getBcc())
             );
 
+        if ($count == 0) {
+            throw new Swift_TransportException(
+                'Cannot send message without a recipient');
+        }
+
         $toHeader = $message->getHeaders()->get('To');
         $subjectHeader = $message->getHeaders()->get('Subject');
 

--- a/lib/classes/Swift/Transport/MailTransport.php
+++ b/lib/classes/Swift/Transport/MailTransport.php
@@ -127,12 +127,7 @@ class Swift_Transport_MailTransport implements Swift_Transport
         $toHeader = $message->getHeaders()->get('To');
         $subjectHeader = $message->getHeaders()->get('Subject');
 
-        if (!$toHeader) {
-            throw new Swift_TransportException(
-                'Cannot send message without a recipient'
-                );
-        }
-        $to = $toHeader->getFieldBody();
+        $to = $toHeader ? $toHeader->getFieldBody() : '';
         $subject = $subjectHeader ? $subjectHeader->getFieldBody() : '';
 
         $reversePath = $this->_getReversePath($message);
@@ -143,7 +138,10 @@ class Swift_Transport_MailTransport implements Swift_Transport
 
         $messageStr = $message->toString();
 
-        $message->getHeaders()->set($toHeader);
+        if ($toHeader)
+        {
+            $message->getHeaders()->set($toHeader);
+        }
         $message->getHeaders()->set($subjectHeader);
 
         // Separate headers from body


### PR DESCRIPTION
It is sometimes usefull to send emails with all recipients as BCC.

The ESMTP transport does allow this usage, while the Mail transport doesn't.

In commit https://github.com/swiftmailer/swiftmailer/commit/476586b810a98d06be477fd01c4309c74993e1b4, the fix was to get rid of a fatal error in two situations: no recipient in 'TO' or missing 'Subject'. That fix then consisted in allowing a missing Subject, but sending an exception in case there is no recipient in TO.
My proposal is to allow both usage in the end.

Regards,
Romain