### PR TITLE
Fixes autoloader issue (Class 'Swift_Mailer' not found in..)

### DIFF
--- a/lib/swift_required.php
+++ b/lib/swift_required.php
@@ -12,11 +12,9 @@
  * Autoloader and dependency injection initialization for Swift Mailer.
  */
 
-if (defined('SWIFT_REQUIRED_LOADED')) {
+if (class_exists('Swift', false)) {
     return;
 }
-
-define('SWIFT_REQUIRED_LOADED', true);
 
 // Load Swift utility class
 require dirname(__FILE__) . '/classes/Swift.php';

--- a/lib/swift_required_pear.php
+++ b/lib/swift_required_pear.php
@@ -12,11 +12,9 @@
  * Autoloader and dependency injection initialization for Swift Mailer.
  */
 
-if (defined('SWIFT_REQUIRED_LOADED')) {
+if (class_exists('Swift', false)) {
     return;
 }
-
-define('SWIFT_REQUIRED_LOADED', true);
 
 // Load Swift utility class
 require dirname(__FILE__) . '/Swift.php';


### PR DESCRIPTION
Currently the autoloader fails when unit test are executed with the following conditions:
- Isolated processes
- Preserve global state

This is because in the subprocess the constant is preserved, but the autoload register will be clean. So the autoloader would not be added to any subprocess.
