### PR TITLE
Fix data writing to stream

### DIFF
--- a/lib/classes/Swift/Transport/StreamBuffer.php
+++ b/lib/classes/Swift/Transport/StreamBuffer.php
@@ -225,23 +225,22 @@ class Swift_Transport_StreamBuffer extends Swift_ByteStream_AbstractFilterableIn
         }
     }
 
-  /** Write this bytes to the stream */
-  protected function _commit($bytes)
-  {
-    if (isset($this->_in)) {        
-        $bytesToWrite = strlen($bytes);
-        $totalBytesWritten = 0;
-        
-        while ($totalBytesWritten < $bytesToWrite) {
-            $bytesWriten = fwrite($this->_in, substr($bytes, $totalBytesWritten));
-            $totalBytesWritten += $bytesWriten;
-        }
-        if ($totalBytesWritten > 0)
-        {
-            return ++$this->_sequence;
+    /** Write this bytes to the stream */
+    protected function _commit($bytes)
+    {
+        if (isset($this->_in)) {
+            $bytesToWrite = strlen($bytes);
+            $totalBytesWritten = 0;
+
+            while ($totalBytesWritten < $bytesToWrite) {
+                $bytesWriten = fwrite($this->_in, substr($bytes, $totalBytesWritten));
+                $totalBytesWritten += $bytesWriten;
+            }
+            if ($totalBytesWritten > 0) {
+                return ++$this->_sequence;
+            }
         }
     }
-  }
 
     // -- Private methods
 


### PR DESCRIPTION
There were problem with streaming data, when using embed images or while sending big message. Connection to SMTP server and email sending was an interrupted.
It was due to the fact that fwrite operations on non-blocking socket streams can be interrupted by the arrival of new packets.
After this fix writing continues  until all data is sent.
