### PR TITLE
Incorrect character encoding due to transposed arguments for mbstring_convert_encoding

### DIFF
--- a/lib/classes/Swift/Mime/MimePart.php
+++ b/lib/classes/Swift/Mime/MimePart.php
@@ -203,7 +203,7 @@ class Swift_Mime_MimePart extends Swift_Mime_SimpleMimeEntity
         if (!in_array($charset, array('utf-8', 'iso-8859-1', ''))) {
             // mb_convert_encoding must be the first one to check, since iconv cannot convert some words.
             if (function_exists('mb_convert_encoding')) {
-                $string = mb_convert_encoding($string, $charset, 'utf-8');
+                $string = mb_convert_encoding($string, 'utf-8', $charset);
             } elseif (function_exists('iconv')) {
                 $string = iconv($charset, 'utf-8//TRANSLIT//IGNORE', $string);
             } else {


### PR DESCRIPTION
Depending on which extension is installed, swiftmailer will call mb_convert_encoding($string, $charset, 'utf-8') or iconv($charset, 'utf-8//TRANSLIT//IGNORE', $string). 

The signatures of these functions are mb_convert_encoding($str, $to_encoding, $from_encoding) and iconv($in_charset, $out_charset, string $str). 

-> those two function calls do the exact opposite of each other. Users with installed mbstring extension will experience garbled output if the specified charset is any value other than utf-8 or iso-8850-1, in which case the conversion is skipped. 

This pull request fixes the transposed arguments so that both mbstring and iconv will convert _from_ $charset _to_ utf-8. 
