### PR TITLE
Added testing on PHP 5.2 and 5.6 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 language: php
 
 php:
+  - 5.2
   - 5.3
   - 5.4
   - 5.5
+  - 5.6
   - hhvm
 
 before_script:


### PR DESCRIPTION
According to @GrahamCampbell in #450, Travis supports PHP 5.2, so this will avoid breaking compatibility with it by mistake (once you drop support for 5.2, it can be disabled)
