### PR TITLE
Fix Swift_ByteStream_FileByteStream::read to match to the specification.

### DIFF
--- a/lib/classes/Swift/ByteStream/FileByteStream.php
+++ b/lib/classes/Swift/ByteStream/FileByteStream.php
@@ -77,7 +77,7 @@ class Swift_ByteStream_FileByteStream extends Swift_ByteStream_AbstractFilterabl
      *
      * @param integer $length
      *
-     * @return string
+     * @return string|boolean
      *
      * @throws Swift_IoException
      */
@@ -93,13 +93,21 @@ class Swift_ByteStream_FileByteStream extends Swift_ByteStream_AbstractFilterabl
                 ini_set('magic_quotes_runtime', 1);
             }
             $this->_offset = ftell($fp);
+            
+            // If we read one byte after reaching the end of the file
+            // feof() will return false and an empty string is returned
+            if ($bytes === '' && feof($fp)) {
+            	$this->_resetReadHandle();
+            	
+            	return false;
+            }
 
             return $bytes;
-        } else {
-            $this->_resetReadHandle();
-
-            return false;
         }
+
+        $this->_resetReadHandle();
+
+        return false;
     }
 
     /**


### PR DESCRIPTION
Issue discovered in #418

An explanation for the PHP behavior can be found here: http://us1.php.net/manual/en/function.feof.php#67261
