### PR TITLE
Fixing infinite loop with closed connection in SMTP transport

### DIFF
--- a/lib/classes/Swift/Transport/StreamBuffer.php
+++ b/lib/classes/Swift/Transport/StreamBuffer.php
@@ -233,8 +233,12 @@ class Swift_Transport_StreamBuffer extends Swift_ByteStream_AbstractFilterableIn
             $totalBytesWritten = 0;
 
             while ($totalBytesWritten < $bytesToWrite) {
-                $bytesWriten = fwrite($this->_in, substr($bytes, $totalBytesWritten));
-                $totalBytesWritten += $bytesWriten;
+                $bytesWritten = fwrite($this->_in, substr($bytes, $totalBytesWritten));
+                // 0 bytes written indicates a closed connection
+                if ($bytesWritten === 0) {
+                    break;
+                }
+                $totalBytesWritten += $bytesWritten;
             }
             if ($totalBytesWritten > 0) {
                 return ++$this->_sequence;


### PR DESCRIPTION
When a long-running script uses a connection to the SMTP server and that connection is already closed due to a timeout, `fwrite()` will return 0 when writing to the socket. This results in an infinite loop in `Swift_Transport_StreamBuffer`. See http://de2.php.net/fwrite#96951 for an explanation of the behavior.
