### PR TITLE
Removed Mockery Dev Flag

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "php": ">=5.2.4"
     },
     "require-dev": {
-        "mockery/mockery": "~0.9@dev"
+        "mockery/mockery": "~0.9"
     },
     "autoload": {
         "files": ["lib/swift_required.php"]


### PR DESCRIPTION
Now that mockery 0.9.1 has been released, we no longer need the `@dev` flag as discussed earlier.
