### PR TITLE
Add support for a standard way to handle OOF auto reply

### DIFF
--- a/lib/classes/Swift/Mime/SimpleMessage.php
+++ b/lib/classes/Swift/Mime/SimpleMessage.php
@@ -615,6 +615,20 @@ class Swift_Mime_SimpleMessage extends Swift_Mime_MimePart implements Swift_Mime
         }
     }
 
+    /** 
+     * Avoids to receive automatic email Out of office 
+     * 
+     * @return Swift_Mime_SimpleMessage
+     */
+    public function removeAutoReply()
+    {
+        $headers = $this->getHeaders();
+        $headers->addTextHeader('Precedence', 'bulk');
+        $headers->addTextHeader('Auto-Submitted', 'auto-generated');
+        
+        return $this;
+    }
+
     // -- Protected methods
 
     /** @see Swift_Mime_SimpleMimeEntity::_getIdField() */


### PR DESCRIPTION
We're delivering a lot of mail, something like 160.000 per month, and sometimes, users are "Out of office" for vacation. 
When we're in vacation periods, we receive tons of mail saying "I'm in vacation"... and this is annoying :).

I assume this is a common issue you have to deal with, this is why I'm asking that:
It would be great to have an option that automatically include the correct headers to avoid a reply when users are in vacation.

As far as we know, it exists these headers:
- Precedence: bulk
- X-Precedence: bulk
- X-Autoreply: yes
- Auto-Submitted: auto-generated
- X-Auto-Response-Suppress: all 
  But some headers lead to be seen as spammers by some anti-spam mechanisms.

I performed ​​some tests by playing with these different headers. I only kept Precedence: bulk and Auto-Submitted: auto-generated because the other had not the targeted effect.

Here is a draft that brings to swiftmailer a standard way to solve this issue.
