### PR TITLE
#444 fix is wrong

### DIFF
--- a/lib/classes/Swift/Mime/MimePart.php
+++ b/lib/classes/Swift/Mime/MimePart.php
@@ -203,9 +203,9 @@ class Swift_Mime_MimePart extends Swift_Mime_SimpleMimeEntity
         if (!in_array($charset, array('utf-8', 'iso-8859-1', ''))) {
             // mb_convert_encoding must be the first one to check, since iconv cannot convert some words.
             if (function_exists('mb_convert_encoding')) {
-                $string = mb_convert_encoding($string, 'utf-8', $charset);
+                $string = mb_convert_encoding($string, $charset, 'utf-8');
             } elseif (function_exists('iconv')) {
-                $string = iconv($charset, 'utf-8//TRANSLIT//IGNORE', $string);
+                $string = iconv('utf-8//TRANSLIT//IGNORE', $charset, $string);
             } else {
                 throw new Swift_SwiftException('No suitable convert encoding function (use UTF-8 as your charset or install the mbstring or iconv extension).');
             }


### PR DESCRIPTION
It is iconv that transpose arguments, not mb_convert_encoding.
_convertString encodes $string charset when Swift_Mime_MimePart charset ($this->getCharset()) is not utf-8. So mb_convert_encoding and iconv must convert from utf-8 to $charset.
