### PR TITLE
Catch Swift_TransportException before Swift_IoException

### DIFF
--- a/lib/classes/Swift/Transport/AbstractSmtpTransport.php
+++ b/lib/classes/Swift/Transport/AbstractSmtpTransport.php
@@ -400,13 +400,13 @@ abstract class Swift_Transport_AbstractSmtpTransport implements Swift_Transport
                 $line = $this->_buffer->readLine($seq);
                 $response .= $line;
             } while (null !== $line && false !== $line && ' ' != $line{3});
+        } catch (Swift_TransportException $e) {
+            $this->_throwException($e);
         } catch (Swift_IoException $e) {
             $this->_throwException(
                 new Swift_TransportException(
                     $e->getMessage())
                 );
-        } catch (Swift_TransportException $e) {
-            $this->_throwException($e);
         }
 
         return $response;


### PR DESCRIPTION
Swift_TransportException is a subclass of Swift_IoException so should be dealt with first if exists
