### PR TITLE
メールアドレスが RFC 2822, 3.6.2 に準拠しているかの確認を無効化

### DIFF
--- a/lib/classes/Swift/Mime/Headers/MailboxHeader.php
+++ b/lib/classes/Swift/Mime/Headers/MailboxHeader.php
@@ -346,13 +346,6 @@ class Swift_Mime_Headers_MailboxHeader extends Swift_Mime_Headers_AbstractHeader
      */
     private function _assertValidAddress($address)
     {
-        if (!preg_match('/^' . $this->getGrammar()->getDefinition('addr-spec') . '$/D',
-            $address))
-        {
-            throw new Swift_RfcComplianceException(
-                'Address in mailbox given [' . $address .
-                '] does not comply with RFC 2822, 3.6.2.'
-                );
-        }
+        return;
     }
 }


### PR DESCRIPTION
[メール送信時に送信先アドレスのバリデーションをしないようにする](https://r.mercariapp.com/issues/5823)
