### PR TITLE
Hash function now uses SSL resource instead of string version of key

### DIFF
--- a/lib/classes/Swift/Signers/DKIMSigner.php
+++ b/lib/classes/Swift/Signers/DKIMSigner.php
@@ -682,7 +682,7 @@ class Swift_Signers_DKIMSigner implements Swift_Signers_HeaderSigner
         if (!$pkeyId) {
             throw new Swift_SwiftException('Unable to load DKIM Private Key ['.openssl_error_string().']');
         }
-        if (openssl_sign($this->_headerCanonData, $signature, $this->_privateKey, $algorithm)) {
+        if (openssl_sign($this->_headerCanonData, $signature, $pkeyId, $algorithm)) {
             return $signature;
         }
         throw new Swift_SwiftException('Unable to sign DKIM Hash ['.openssl_error_string().']');


### PR DESCRIPTION
Changed hashing function to use the resource returned from open_ssl_get_privatekey() instead of the string version of key. Please note that this same change was made to DomainKeySigner.php on 9 Jan 2013.
