### PR TITLE
Fixing @return tag for getFrom method

### DIFF
--- a/lib/classes/Swift/Mime/SimpleMessage.php
+++ b/lib/classes/Swift/Mime/SimpleMessage.php
@@ -220,7 +220,7 @@ class Swift_Mime_SimpleMessage extends Swift_Mime_MimePart implements Swift_Mime
     /**
      * Get the from address of this message.
      *
-     * @return string
+     * @return mixed
      */
     public function getFrom()
     {


### PR DESCRIPTION
The @return tag for the Swift_Mime_SimpleMessage::getFrom method should be mixed instead of string because both null (e.g., when the 'From' header is, for some reason, not found) or array (e.g., when multiple-from's are specified, other cases as well) may be returned.
