### PR TITLE
Fix incorrect return type doc

### DIFF
--- a/lib/classes/Swift/Mime/MimeEntity.php
+++ b/lib/classes/Swift/Mime/MimeEntity.php
@@ -78,7 +78,7 @@ interface Swift_Mime_MimeEntity extends Swift_Mime_CharsetObserver, Swift_Mime_E
     /**
      * Get the collection of Headers in this Mime entity.
      *
-     * @return Swift_Mime_Header[]
+     * @return Swift_Mime_HeaderSet
      */
     public function getHeaders();
 


### PR DESCRIPTION
You can see it was incorrect by looking at RedirectPlugin::beforeSendPerformed
and at the implementations of the Swift_Mime_MimeEntity interface
