### PR TITLE
fix to-other cc-self issue when using gmail smtp

### DIFF
--- a/lib/classes/Swift/Transport/AbstractSmtpTransport.php
+++ b/lib/classes/Swift/Transport/AbstractSmtpTransport.php
@@ -166,13 +166,13 @@ abstract class Swift_Transport_AbstractSmtpTransport implements Swift_Transport
 
         $to = (array) $message->getTo();
         $cc = (array) $message->getCc();
+        $tos = array_merge($to, $cc);
         $bcc = (array) $message->getBcc();
 
         $message->setBcc(array());
 
         try {
-            $sent += $this->_sendTo($message, $reversePath, $to, $failedRecipients);
-            $sent += $this->_sendCc($message, $reversePath, $cc, $failedRecipients);
+            $sent += $this->_sendTo($message, $reversePath, $tos, $failedRecipients);
             $sent += $this->_sendBcc($message, $reversePath, $bcc, $failedRecipients);
         } catch (Exception $e) {
             $message->setBcc($bcc);
@@ -441,17 +441,6 @@ abstract class Swift_Transport_AbstractSmtpTransport implements Swift_Transport
         }
 
         return $this->_doMailTransaction($message, $reversePath, array_keys($to),
-            $failedRecipients);
-    }
-
-    /** Send a message to the given Cc: recipients */
-    private function _sendCc(Swift_Mime_Message $message, $reversePath, array $cc, array &$failedRecipients)
-    {
-        if (empty($cc)) {
-            return 0;
-        }
-
-        return $this->_doMailTransaction($message, $reversePath, array_keys($cc),
             $failedRecipients);
     }
 


### PR DESCRIPTION
Remove extra transaction when sending to & cc since a separate transaction only necessary for bcc.
This fixes an issue where sending to another address and CC-ing yourself would cause the message to NOT go into your inbox when using Google's SMTP.  This seems to be a bug in Google's smtp, but doing a single transaction for both to and cc fixes the issue (not to mention making it more efficient)
