### PR TITLE
Add support for Opendkim on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,11 @@ php:
 before_install:
     - cp tests/acceptance.conf.php.default tests/acceptance.conf.php
     - cp tests/smoke.conf.php.default tests/smoke.conf.php
+    - sh -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm-nightly" ]; then sudo apt-get install libopendkim-dev && cd /tmp/ && git clone https://github.com/xdecock/php-opendkim && cd /tmp/php-opendkim && phpize && ./configure && make && make install; fi;'
+    - sh  -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm-nightly" ]; then echo "extension = opendkim.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi;'
+    - gem install mailcatcher
 
 install:
-    - gem install mailcatcher
     - COMPOSER_ROOT_VERSION=dev-master composer --prefer-source install
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,15 @@ php:
   - 5.6
   - hhvm-nightly
 
-before_script:
+before_install:
     - cp tests/acceptance.conf.php.default tests/acceptance.conf.php
     - cp tests/smoke.conf.php.default tests/smoke.conf.php
-    - composer self-update
-    - composer update --no-interaction --prefer-source
+
+install:
     - gem install mailcatcher
+    - COMPOSER_ROOT_VERSION=dev-master composer --prefer-source install
+
+before_script:
     - mailcatcher --smtp-port 4456
 
 script:

--- a/lib/classes/Swift/Encoding.php
+++ b/lib/classes/Swift/Encoding.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of SwiftMailer.
+ * (c) 2004-2009 Chris Corbyn
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * Provides quick access to each encoding type.
+ *
+ * @author     Chris Corbyn
+ */
+class Swift_Encoding
+{
+    /**
+     * Get the Encoder that provides 7-bit encoding.
+     *
+     * @return Swift_Mime_ContentEncoder
+     */
+    public static function get7BitEncoding()
+    {
+        return self::_lookup('mime.7bitcontentencoder');
+    }
+
+    /**
+     * Get the Encoder that provides 8-bit encoding.
+     *
+     * @return Swift_Mime_ContentEncoder
+     */
+    public static function get8BitEncoding()
+    {
+        return self::_lookup('mime.8bitcontentencoder');
+    }
+
+    /**
+     * Get the Encoder that provides Quoted-Printable (QP) encoding.
+     *
+     * @return Swift_Mime_ContentEncoder
+     */
+    public static function getQpEncoding()
+    {
+        return self::_lookup('mime.qpcontentencoder');
+    }
+
+    /**
+     * Get the Encoder that provides Base64 encoding.
+     *
+     * @return Swift_Mime_ContentEncoder
+     */
+    public static function getBase64Encoding()
+    {
+        return self::_lookup('mime.base64contentencoder');
+    }
+
+    // -- Private Static Methods
+
+    private static function _lookup($key)
+    {
+        return Swift_DependencyContainer::getInstance()->lookup($key);
+    }
+}

--- a/tests/acceptance/Swift/EncodingAcceptanceTest.php
+++ b/tests/acceptance/Swift/EncodingAcceptanceTest.php
@@ -1,0 +1,30 @@
+<?php
+
+require_once 'swift_required.php';
+
+class Swift_EncodingAcceptanceTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGet7BitEncodingReturns7BitEncoder()
+    {
+        $encoder = Swift_Encoding::get7BitEncoding();
+        $this->assertEquals('7bit', $encoder->getName());
+    }
+
+    public function testGet8BitEncodingReturns8BitEncoder()
+    {
+        $encoder = Swift_Encoding::get8BitEncoding();
+        $this->assertEquals('8bit', $encoder->getName());
+    }
+
+    public function testGetQpEncodingReturnsQpEncoder()
+    {
+        $encoder = Swift_Encoding::getQpEncoding();
+        $this->assertEquals('quoted-printable', $encoder->getName());
+    }
+
+    public function testGetBase64EncodingReturnsBase64Encoder()
+    {
+        $encoder = Swift_Encoding::getBase64Encoding();
+        $this->assertEquals('base64', $encoder->getName());
+    }
+}


### PR DESCRIPTION
Unfortunately, adding the opendkim PHP extension makes PHP crash when running Composer.

@xdecock Can you have a look at it as it makes support for opendkim unusable for anyone using Composer?
