### PR TITLE
Fix invalid class referenced in docblock

### DIFF
--- a/lib/classes/Swift/Mime/SimpleMimeEntity.php
+++ b/lib/classes/Swift/Mime/SimpleMimeEntity.php
@@ -263,7 +263,7 @@ class Swift_Mime_SimpleMimeEntity implements Swift_Mime_MimeEntity
     /**
      * Get all children added to this entity.
      *
-     * @return array of Swift_Mime_Entity
+     * @return Swift_Mime_MimeEntity[]
      */
     public function getChildren()
     {
@@ -273,8 +273,8 @@ class Swift_Mime_SimpleMimeEntity implements Swift_Mime_MimeEntity
     /**
      * Set all children of this entity.
      *
-     * @param array   $children      Swift_Mime_Entity instances
-     * @param int     $compoundLevel For internal use only
+     * @param Swift_Mime_MimeEntity[] $children
+     * @param int                     $compoundLevel For internal use only
      *
      * @return Swift_Mime_SimpleMimeEntity
      */


### PR DESCRIPTION
Swift_Mime_SimpleMimeEntity references the non-existing class Swift_Mime_Entity.
