### PR TITLE
Ensure 'no sender' exception is passed through event dispatcher

### DIFF
--- a/lib/classes/Swift/Transport/AbstractSmtpTransport.php
+++ b/lib/classes/Swift/Transport/AbstractSmtpTransport.php
@@ -159,9 +159,10 @@ abstract class Swift_Transport_AbstractSmtpTransport implements Swift_Transport
         }
 
         if (!$reversePath = $this->_getReversePath($message)) {
-            throw new Swift_TransportException(
+            $this->_throwException(new Swift_TransportException(
                 'Cannot send message without a sender address'
-                );
+                )
+            );
         }
 
         $to = (array) $message->getTo();

--- a/lib/classes/Swift/Transport/MailTransport.php
+++ b/lib/classes/Swift/Transport/MailTransport.php
@@ -126,9 +126,7 @@ class Swift_Transport_MailTransport implements Swift_Transport
         $subjectHeader = $message->getHeaders()->get('Subject');
 
         if (!$toHeader) {
-            throw new Swift_TransportException(
-                'Cannot send message without a recipient'
-                );
+            $this->_throwException(new Swift_TransportException('Cannot send message without a recipient'));
         }
         $to = $toHeader->getFieldBody();
         $subject = $subjectHeader ? $subjectHeader->getFieldBody() : '';
@@ -202,6 +200,19 @@ class Swift_Transport_MailTransport implements Swift_Transport
     public function registerPlugin(Swift_Events_EventListener $plugin)
     {
         $this->_eventDispatcher->bindEventListener($plugin);
+    }
+
+    /** Throw a TransportException, first sending it to any listeners */
+    protected function _throwException(Swift_TransportException $e)
+    {
+        if ($evt = $this->_eventDispatcher->createTransportExceptionEvent($this, $e)) {
+            $this->_eventDispatcher->dispatchEvent($evt, 'exceptionThrown');
+            if (!$evt->bubbleCancelled()) {
+                throw $e;
+            }
+        } else {
+            throw $e;
+        }
     }
 
     /** Determine the best-use reverse path for this message */


### PR DESCRIPTION
When using FailoverTransport, all Swift_TransportException are caught and their messages are never passed through the event dispatcher (https://github.com/swiftmailer/swiftmailer/blob/master/lib/classes/Swift/Transport/FailoverTransport.php#L57).
This PR addresses this issue by passing "Cannot send message without a recipient" exceptions within MailTransport and SmtpTransport through the event dispatcher, allowing them to be collected by plugins such as logging.

This will provide 'missing sender' information within plugins when using FailoverTransport.
