### PR TITLE
fix issue #443 #139 spool send event result

### DIFF
--- a/lib/classes/Swift/Events/SendEvent.php
+++ b/lib/classes/Swift/Events/SendEvent.php
@@ -20,6 +20,9 @@ class Swift_Events_SendEvent extends Swift_Events_EventObject
     /** Sending has yet to occur */
     const RESULT_PENDING = 0x0001;
 
+    /** Email is spooled, ready to be sent */
+    const RESULT_SPOOLED = 0x0011;
+
     /** Sending was successful */
     const RESULT_SUCCESS = 0x0010;
 

--- a/lib/classes/Swift/Transport/SpoolTransport.php
+++ b/lib/classes/Swift/Transport/SpoolTransport.php
@@ -99,7 +99,7 @@ class Swift_Transport_SpoolTransport implements Swift_Transport
         $success = $this->_spool->queueMessage($message);
 
         if ($evt) {
-            $evt->setResult($success ? Swift_Events_SendEvent::RESULT_SUCCESS : Swift_Events_SendEvent::RESULT_FAILED);
+            $evt->setResult($success ? Swift_Events_SendEvent::RESULT_SPOOLED : Swift_Events_SendEvent::RESULT_FAILED);
             $this->_eventDispatcher->dispatchEvent($evt, 'sendPerformed');
         }
 


### PR DESCRIPTION
Here is a PR for issues #443 and #139.

We've added a new result status in SendEvents with code 0x11 (RESULT_PENDING | RESULT_SPOOLED). It seems logical to us because this status lies between those two status.

The SpoolTransport now set RESULT_SPOOLED instead of RESULT_SUCCESS in order to be able to make the difference between a spooled mail and a sent mail.

Unit tests fails, but it wasn't due to anything that we've added. The master branch unit tests was already broken when we cloned the project.