### PR TITLE
fixed autoloading of unit test classes

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,6 +1,7 @@
 <?php
 
-require_once dirname(__DIR__).'/vendor/autoload.php';
+$autoloader = require_once dirname(__DIR__).'/vendor/autoload.php';
+$autoloader->add('Swift_', __DIR__.'/unit');
 
 set_include_path(get_include_path().PATH_SEPARATOR.dirname(__DIR__).'/lib');
 


### PR DESCRIPTION
It works by chance (as PhpUnit load all files/classes in alphabetical order and abstract classes are loaded first), but when trying to run a single unit test, it might break without this fix.
