### PR TITLE
Implement Issue #571

### DIFF
--- a/lib/classes/Swift/Transport/EsmtpTransport.php
+++ b/lib/classes/Swift/Transport/EsmtpTransport.php
@@ -159,7 +159,31 @@ class Swift_Transport_EsmtpTransport extends Swift_Transport_AbstractSmtpTranspo
     {
         return $this->_params['tls'] ? 'tls' : $this->_params['protocol'];
     }
-
+	
+    /**
+     * Sets the connection options.
+     *
+     * @param array $options
+     *
+     * @return Swift_Transport_EsmtpTransport
+     */
+    public function setOptions($options)
+    {
+    	$this->_params['options'] = $options;
+    
+    	return $this;
+    }
+    
+    /**
+     * Returns the connection options.
+     *
+     * @return array
+     */
+    public function getOptions()
+    {
+    	return $this->_params['options'];
+    }
+    
     /**
      * Sets the source IP.
      *

--- a/lib/classes/Swift/Transport/StreamBuffer.php
+++ b/lib/classes/Swift/Transport/StreamBuffer.php
@@ -256,7 +256,7 @@ class Swift_Transport_StreamBuffer extends Swift_ByteStream_AbstractFilterableIn
         if (!empty($this->_params['timeout'])) {
             $timeout = $this->_params['timeout'];
         }
-        $options = array();
+        $options = $this->_params['options'];
         if (!empty($this->_params['sourceIp'])) {
             $options['socket']['bindto'] = $this->_params['sourceIp'].':0';
         }


### PR DESCRIPTION
Allow estmp connection options to be set.  Can be used to allow ssl / tls to use self-signed certificates with the following "options" set:  array('ssl' => array('allow_self_signed' => true, 'verify_peer' => false)).

Reference:
http://stackoverflow.com/questions/26896265/php-swiftmailer-using-starttls-and-self-signed-certificates
