### PR TITLE
Ignore /notes in git-generated .zip archives

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,6 @@
 *.pub -crlf
 *.priv -crlf
 *.txt -crlf
+
+# ignore /notes in the git-generated distributed .zip archive
+/notes export-ignore


### PR DESCRIPTION
Inspired by @barryvdh's comment in #268. This dramatically decreases the
size of the generated archive (a little more than a 50% size reduction).

```bash
$ git log --oneline -n 1
e29c7b6 bumped version to 5.3.2-DEV
$ git archive -o without_patch.zip HEAD .
$ echo "/notes export-ignore" >> ./.gitattributes
$ git ci -am "Ignore /notes in git-generated .zip archives"
$ git archive -o with_patch.zip HEAD .
$ du -h with{,out}_patch.zip
428K    with_patch.zip
1.0M    without_patch.zip
```

Is including the RFCs worth a 100% size increase for most developers?