### PR TITLE
Duplicate array key

### DIFF
--- a/lib/swiftmailer_generate_mimes_config.php
+++ b/lib/swiftmailer_generate_mimes_config.php
@@ -41,7 +41,6 @@ function generateUpToDateMimeArray()
             'css'  => 'text/css',
             'js'   => 'text/javascript',
             'txt'  => 'text/plain',
-            'xml'  => 'text/xml',
             'aif'  => 'audio/x-aiff',
             'aiff' => 'audio/x-aiff',
             'avi'  => 'video/avi',


### PR DESCRIPTION
If multiple elements in the array declaration use the same key, only the last one will be used as all others are overwritten.
I decided to delete 'xml'  => 'text/xml' and to keep 'xml'  => 'application/xml' for the reason explained here:
http://stackoverflow.com/questions/4832357/whats-the-difference-between-text-xml-vs-application-xml-for-webservice-respons