### PR TITLE
Prevent from dots in filespool filename

### DIFF
--- a/lib/classes/Swift/FileSpool.php
+++ b/lib/classes/Swift/FileSpool.php
@@ -196,7 +196,7 @@ class Swift_FileSpool extends Swift_ConfigurableSpool
     protected function getRandomString($count)
     {
         // This string MUST stay FS safe, avoid special chars
-        $base = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-.";
+        $base = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-";
         $ret = '';
         $strlen = strlen($base);
         for ($i = 0; $i < $count; ++$i) {


### PR DESCRIPTION
Currently message stored in a filesystem as a file can have dot in a filename. This can lead to dot appear at the beginning of a filename. In Unix-like operating systems, any file or folder that starts with a dot character is to be treated as hidden (via [Wikipedia](http://en.wikipedia.org/wiki/Hidden_file_and_hidden_directory#Unix_and_Unix-like_environments)). This can lead to unexpected errors. Eg. AFAIK [Symfony Finder](http://symfony.com/doc/current/components/finder.html) ignores such files by default.

IMHO there is no need in allowing files to have dots in their names.