### PR TITLE
DefaultSenderPlugin - allows to specify default sender that is used when a message with no sender is specified

### DIFF
--- a/lib/classes/Swift/Plugins/DefaultSenderPlugin.php
+++ b/lib/classes/Swift/Plugins/DefaultSenderPlugin.php
@@ -18,33 +18,34 @@ class Swift_Plugins_DefaultSenderPlugin implements Swift_Events_SendListener
     /**
      * The default sender email.
      *
-     * @var String
+     * @var string
      */
-    private $_defaultSenderEmail;
+    private $defaultSenderEmail;
 
     /**
      * The default sender name.
      *
-     * @var String
+     * @var string
      */
-    private $_defaultSenderName;
+    private $defaultSenderName;
 
     /**
      * List if IDs of handled messages
      *
-     * @var array
+     * @var string[]
      */
-    private $_handledMessageIds = array();
+    private $handledMessageIds = array();
 
     /**
      * Create a new ImpersonatePlugin to impersonate $sender.
      *
-     * @param string $sender address
+     * @param string $defaultSenderEmail
+     * @param string $defaultSenderName
      */
     public function __construct($defaultSenderEmail, $defaultSenderName = '')
     {
-        $this->_defaultSenderEmail = $defaultSenderEmail;
-        $this->_defaultSenderName = $defaultSenderName;
+        $this->defaultSenderEmail = $defaultSenderEmail;
+        $this->defaultSenderName = $defaultSenderName;
     }
 
     /**
@@ -59,8 +60,8 @@ class Swift_Plugins_DefaultSenderPlugin implements Swift_Events_SendListener
 
         // replace sender
         if (!count($message->getFrom())) {
-            $message->setFrom($this->_defaultSenderEmail, $this->_defaultSenderName);
-            $this->_handledMessageIds[$message->getId()] = true;
+            $message->setFrom($this->defaultSenderEmail, $this->defaultSenderName);
+            $this->handledMessageIds[$message->getId()] = true;
         }
     }
 
@@ -75,9 +76,9 @@ class Swift_Plugins_DefaultSenderPlugin implements Swift_Events_SendListener
 
         // restore original headers
         $id = $message->getId();
-        if (array_key_exists($id, $this->_handledMessageIds)) {
+        if (array_key_exists($id, $this->handledMessageIds)) {
             $message->setFrom(null);
-            unset($this->_handledMessageIds[$id]);
+            unset($this->handledMessageIds[$id]);
         }
     }
 }

--- a/lib/classes/Swift/Plugins/DefaultSenderPlugin.php
+++ b/lib/classes/Swift/Plugins/DefaultSenderPlugin.php
@@ -1,0 +1,84 @@
+<?php
+/*
+ * This file is part of SwiftMailer.
+ * (c) 2009 Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * Sets the sender of a message if none is set
+ *
+ * @author     Adam Zielinski
+ */
+class Swift_Plugins_DefaultSenderPlugin implements Swift_Events_SendListener
+{
+
+    /**
+     * The default sender email.
+     *
+     * @var String
+     */
+    private $_defaultSenderEmail;
+
+    /**
+     * The default sender name.
+     *
+     * @var String
+     */
+    private $_defaultSenderName;
+
+    /**
+     * List if IDs of handled messages
+     *
+     * @var array
+     */
+    private $_handledMessageIds = array();
+
+    /**
+     * Create a new ImpersonatePlugin to impersonate $sender.
+     *
+     * @param string $sender address
+     */
+    public function __construct($defaultSenderEmail, $defaultSenderName='')
+    {
+        $this->_defaultSenderEmail = $defaultSenderEmail;
+        $this->_defaultSenderName = $defaultSenderName;
+    }
+
+    /**
+     * Invoked immediately before the Message is sent.
+     *
+     * @param Swift_Events_SendEvent $evt
+     */
+    public function beforeSendPerformed(Swift_Events_SendEvent $evt)
+    {
+        $message = $evt->getMessage();
+        $headers = $message->getHeaders();
+
+        // replace sender
+        if(!count($message->getFrom())) {
+            $message->setFrom($this->_defaultSenderEmail, $this->_defaultSenderName);
+            $this->_handledMessageIds[$message->getId()] = true;
+        }
+    }
+
+    /**
+     * Invoked immediately after the Message is sent.
+     *
+     * @param Swift_Events_SendEvent $evt
+     */
+    public function sendPerformed(Swift_Events_SendEvent $evt)
+    {
+        $message = $evt->getMessage();
+
+        // restore original headers
+        $id = $message->getId();
+        if(array_key_exists($id, $this->_handledMessageIds)) {
+            $message->setFrom(null);
+            unset($this->_handledMessageIds[$id]);
+        }
+    }
+
+}

--- a/lib/classes/Swift/Plugins/DefaultSenderPlugin.php
+++ b/lib/classes/Swift/Plugins/DefaultSenderPlugin.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of SwiftMailer.
  * (c) 2009 Fabien Potencier
@@ -8,43 +9,21 @@
  */
 
 /**
- * Sets the sender of a message if none is set
+ * Sets the sender of a message if none is set.
  *
- * @author     Adam Zielinski
+ * @author Adam Zielinski
  */
 class Swift_Plugins_DefaultSenderPlugin implements Swift_Events_SendListener
 {
-
-    /**
-     * Email of sender to use in all messages that are sent
-     * without any sender information.
-     *
-     * @var string
-     */
     private $defaultSenderEmail;
 
-    /**
-     * Name of sender to use in all messages that are sent
-     * without any sender information.
-     *
-     * @var string
-     */
     private $defaultSenderName;
 
-    /**
-     * List if IDs of messages which got sender information set
-     * by this plugin.
-     *
-     * @var string[]
-     */
     private $handledMessageIds = array();
 
     /**
-     * Create a new DefaultSenderPlugin to use a $defaultSenderEmail and $defaultSenderName
-     * for all messages that are sent without any sender information.
-     *
-     * @param string $defaultSenderEmail
-     * @param string $defaultSenderName
+     * @param string $defaultSenderEmail Email of sender to use in all messages that are sent without any sender information.
+     * @param string $defaultSenderName Name of sender to use in all messages that are sent without any sender information.
      */
     public function __construct($defaultSenderEmail, $defaultSenderName = '')
     {
@@ -53,14 +32,11 @@ class Swift_Plugins_DefaultSenderPlugin implements Swift_Events_SendListener
     }
 
     /**
-     * Invoked immediately before the Message is sent.
-     *
-     * @param Swift_Events_SendEvent $evt
+     * @{inheritdoc}
      */
     public function beforeSendPerformed(Swift_Events_SendEvent $evt)
     {
         $message = $evt->getMessage();
-        $headers = $message->getHeaders();
 
         // replace sender
         if (!count($message->getFrom())) {
@@ -70,9 +46,7 @@ class Swift_Plugins_DefaultSenderPlugin implements Swift_Events_SendListener
     }
 
     /**
-     * Invoked immediately after the Message is sent.
-     *
-     * @param Swift_Events_SendEvent $evt
+     * @{inheritdoc}
      */
     public function sendPerformed(Swift_Events_SendEvent $evt)
     {

--- a/lib/classes/Swift/Plugins/DefaultSenderPlugin.php
+++ b/lib/classes/Swift/Plugins/DefaultSenderPlugin.php
@@ -40,7 +40,8 @@ class Swift_Plugins_DefaultSenderPlugin implements Swift_Events_SendListener
     private $handledMessageIds = array();
 
     /**
-     * Create a new ImpersonatePlugin to impersonate $sender.
+     * Create a new DefaultSenderPlugin to use a $defaultSenderEmail and $defaultSenderName
+     * for all messages that are sent without any sender information.
      *
      * @param string $defaultSenderEmail
      * @param string $defaultSenderName

--- a/lib/classes/Swift/Plugins/DefaultSenderPlugin.php
+++ b/lib/classes/Swift/Plugins/DefaultSenderPlugin.php
@@ -41,7 +41,7 @@ class Swift_Plugins_DefaultSenderPlugin implements Swift_Events_SendListener
      *
      * @param string $sender address
      */
-    public function __construct($defaultSenderEmail, $defaultSenderName='')
+    public function __construct($defaultSenderEmail, $defaultSenderName = '')
     {
         $this->_defaultSenderEmail = $defaultSenderEmail;
         $this->_defaultSenderName = $defaultSenderName;
@@ -58,7 +58,7 @@ class Swift_Plugins_DefaultSenderPlugin implements Swift_Events_SendListener
         $headers = $message->getHeaders();
 
         // replace sender
-        if(!count($message->getFrom())) {
+        if (!count($message->getFrom())) {
             $message->setFrom($this->_defaultSenderEmail, $this->_defaultSenderName);
             $this->_handledMessageIds[$message->getId()] = true;
         }
@@ -75,7 +75,7 @@ class Swift_Plugins_DefaultSenderPlugin implements Swift_Events_SendListener
 
         // restore original headers
         $id = $message->getId();
-        if(array_key_exists($id, $this->_handledMessageIds)) {
+        if (array_key_exists($id, $this->_handledMessageIds)) {
             $message->setFrom(null);
             unset($this->_handledMessageIds[$id]);
         }

--- a/lib/classes/Swift/Plugins/DefaultSenderPlugin.php
+++ b/lib/classes/Swift/Plugins/DefaultSenderPlugin.php
@@ -80,5 +80,4 @@ class Swift_Plugins_DefaultSenderPlugin implements Swift_Events_SendListener
             unset($this->_handledMessageIds[$id]);
         }
     }
-
 }

--- a/lib/classes/Swift/Plugins/DefaultSenderPlugin.php
+++ b/lib/classes/Swift/Plugins/DefaultSenderPlugin.php
@@ -16,21 +16,24 @@ class Swift_Plugins_DefaultSenderPlugin implements Swift_Events_SendListener
 {
 
     /**
-     * The default sender email.
+     * Email of sender to use in all messages that are sent
+     * without any sender information.
      *
      * @var string
      */
     private $defaultSenderEmail;
 
     /**
-     * The default sender name.
+     * Name of sender to use in all messages that are sent
+     * without any sender information.
      *
      * @var string
      */
     private $defaultSenderName;
 
     /**
-     * List if IDs of handled messages
+     * List if IDs of messages which got sender information set
+     * by this plugin.
      *
      * @var string[]
      */

--- a/tests/unit/Swift/Plugins/DefaultSenderPluginTest.php
+++ b/tests/unit/Swift/Plugins/DefaultSenderPluginTest.php
@@ -12,7 +12,7 @@ class Swift_Plugins_DefaultSenderPluginTest extends \PHPUnit_Framework_TestCase
 
         $plugin = new Swift_Plugins_DefaultSenderPlugin('john@example.com');
 
-        $evt = $this->_createSendEvent($message);
+        $evt = $this->createSendEvent($message);
 
         $this->assertEquals($message->getFrom(), array());
 
@@ -34,7 +34,7 @@ class Swift_Plugins_DefaultSenderPluginTest extends \PHPUnit_Framework_TestCase
 
         $plugin = new Swift_Plugins_DefaultSenderPlugin('john@example.com', 'John Doe');
 
-        $evt = $this->_createSendEvent($message);
+        $evt = $this->createSendEvent($message);
 
         $this->assertEquals($message->getFrom(), array());
 
@@ -49,7 +49,7 @@ class Swift_Plugins_DefaultSenderPluginTest extends \PHPUnit_Framework_TestCase
 
     // -- Creation Methods
 
-    private function _createSendEvent(Swift_Mime_Message $message)
+    private function createSendEvent(Swift_Mime_Message $message)
     {
         $evt = $this->getMockBuilder('Swift_Events_SendEvent')
                     ->disableOriginalConstructor()

--- a/tests/unit/Swift/Plugins/DefaultSenderPluginTest.php
+++ b/tests/unit/Swift/Plugins/DefaultSenderPluginTest.php
@@ -2,7 +2,6 @@
 
 class Swift_Plugins_DefaultSenderPluginTest extends \PHPUnit_Framework_TestCase
 {
-
     public function testPluginChangesSenderEmail()
     {
         $message = Swift_Message::newInstance()
@@ -46,8 +45,6 @@ class Swift_Plugins_DefaultSenderPluginTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($message->getFrom(), array());
     }
-
-    // -- Creation Methods
 
     private function createSendEvent(Swift_Mime_Message $message)
     {

--- a/tests/unit/Swift/Plugins/DefaultSenderPluginTest.php
+++ b/tests/unit/Swift/Plugins/DefaultSenderPluginTest.php
@@ -1,0 +1,63 @@
+<?php
+
+class Swift_Plugins_DefaultSenderPluginTest extends \PHPUnit_Framework_TestCase
+{
+
+    public function testPluginChangesSenderEmail()
+    {
+        $message = Swift_Message::newInstance()
+            ->setSubject('...')
+            ->setBody('...')
+        ;
+
+        $plugin = new Swift_Plugins_DefaultSenderPlugin('john@example.com');
+
+        $evt = $this->_createSendEvent($message);
+
+        $this->assertEquals($message->getFrom(), array());
+
+        $plugin->beforeSendPerformed($evt);
+
+        $this->assertEquals($message->getFrom(), array('john@example.com' => ''));
+
+        $plugin->sendPerformed($evt);
+
+        $this->assertEquals($message->getFrom(), array());
+    }
+
+    public function testPluginChangesSenderEmailAndName()
+    {
+        $message = Swift_Message::newInstance()
+            ->setSubject('...')
+            ->setBody('...')
+        ;
+
+        $plugin = new Swift_Plugins_DefaultSenderPlugin('john@example.com', 'John Doe');
+
+        $evt = $this->_createSendEvent($message);
+
+        $this->assertEquals($message->getFrom(), array());
+
+        $plugin->beforeSendPerformed($evt);
+
+        $this->assertEquals($message->getFrom(), array('john@example.com' => 'John Doe'));
+
+        $plugin->sendPerformed($evt);
+
+        $this->assertEquals($message->getFrom(), array());
+    }
+
+    // -- Creation Methods
+
+    private function _createSendEvent(Swift_Mime_Message $message)
+    {
+        $evt = $this->getMockBuilder('Swift_Events_SendEvent')
+                    ->disableOriginalConstructor()
+                    ->getMock();
+        $evt->expects($this->any())
+            ->method('getMessage')
+            ->will($this->returnValue($message));
+
+        return $evt;
+    }
+}


### PR DESCRIPTION
DefaultSenderPlugin - allows to specify default sender that is used when a message with no sender is sent
