### PR TITLE
Add $code as second parameter to (Transport/Io/Swift)Exception classes

### DIFF
--- a/lib/classes/Swift/IoException.php
+++ b/lib/classes/Swift/IoException.php
@@ -19,7 +19,7 @@ class Swift_IoException extends Swift_SwiftException
      * Create a new IoException with $message.
      *
      * @param string $message
-     * @param int $code
+     * @param int    $code
      */
     public function __construct($message, $code = 0)
     {

--- a/lib/classes/Swift/IoException.php
+++ b/lib/classes/Swift/IoException.php
@@ -18,11 +18,12 @@ class Swift_IoException extends Swift_SwiftException
     /**
      * Create a new IoException with $message.
      *
-     * @param string $message
-     * @param int    $code
+     * @param string    $message
+     * @param int       $code
+     * @param Exception $previous
      */
-    public function __construct($message, $code = 0)
+    public function __construct($message, $code = 0, Exception $previous = null)
     {
-        parent::__construct($message, $code);
+        parent::__construct($message, $code, $previous);
     }
 }

--- a/lib/classes/Swift/IoException.php
+++ b/lib/classes/Swift/IoException.php
@@ -19,9 +19,10 @@ class Swift_IoException extends Swift_SwiftException
      * Create a new IoException with $message.
      *
      * @param string $message
+     * @param int $code
      */
-    public function __construct($message)
+    public function __construct($message, $code = 0)
     {
-        parent::__construct($message);
+        parent::__construct($message, $code);
     }
 }

--- a/lib/classes/Swift/SwiftException.php
+++ b/lib/classes/Swift/SwiftException.php
@@ -18,11 +18,12 @@ class Swift_SwiftException extends Exception
     /**
      * Create a new SwiftException with $message.
      *
-     * @param string $message
-     * @param int    $code
+     * @param string    $message
+     * @param int       $code
+     * @param Exception $previous
      */
-    public function __construct($message, $code = 0)
+    public function __construct($message, $code = 0, Exception $previous = null)
     {
-        parent::__construct($message, $code);
+        parent::__construct($message, $code, $previous);
     }
 }

--- a/lib/classes/Swift/SwiftException.php
+++ b/lib/classes/Swift/SwiftException.php
@@ -19,9 +19,10 @@ class Swift_SwiftException extends Exception
      * Create a new SwiftException with $message.
      *
      * @param string $message
+     * @param int $code
      */
-    public function __construct($message)
+    public function __construct($message, $code = 0)
     {
-        parent::__construct($message);
+        parent::__construct($message, $code);
     }
 }

--- a/lib/classes/Swift/SwiftException.php
+++ b/lib/classes/Swift/SwiftException.php
@@ -19,7 +19,7 @@ class Swift_SwiftException extends Exception
      * Create a new SwiftException with $message.
      *
      * @param string $message
-     * @param int $code
+     * @param int    $code
      */
     public function __construct($message, $code = 0)
     {

--- a/lib/classes/Swift/TransportException.php
+++ b/lib/classes/Swift/TransportException.php
@@ -19,7 +19,7 @@ class Swift_TransportException extends Swift_IoException
      * Create a new TransportException with $message.
      *
      * @param string $message
-     * @param int $code
+     * @param int    $code
      */
     public function __construct($message, $code = 0)
     {

--- a/lib/classes/Swift/TransportException.php
+++ b/lib/classes/Swift/TransportException.php
@@ -19,9 +19,10 @@ class Swift_TransportException extends Swift_IoException
      * Create a new TransportException with $message.
      *
      * @param string $message
+     * @param int $code
      */
-    public function __construct($message)
+    public function __construct($message, $code = 0)
     {
-        parent::__construct($message);
+        parent::__construct($message, $code);
     }
 }

--- a/lib/classes/Swift/TransportException.php
+++ b/lib/classes/Swift/TransportException.php
@@ -18,11 +18,12 @@ class Swift_TransportException extends Swift_IoException
     /**
      * Create a new TransportException with $message.
      *
-     * @param string $message
-     * @param int    $code
+     * @param string    $message
+     * @param int       $code
+     * @param Exception $previous
      */
-    public function __construct($message, $code = 0)
+    public function __construct($message, $code = 0, Exception $previous = null)
     {
-        parent::__construct($message, $code);
+        parent::__construct($message, $code, $previous);
     }
 }


### PR DESCRIPTION
SwiftException extends \Exception, which takes $code as an optional second parameter.  Add support for this second parameter to SwiftException as well as IoException and TransportException.  This allows for things such as getting the status code of an error when sending a message fails.