### PR TITLE
Make LoggerPlugin keep track of the exception's code and previous exception

### DIFF
--- a/lib/classes/Swift/Plugins/LoggerPlugin.php
+++ b/lib/classes/Swift/Plugins/LoggerPlugin.php
@@ -131,11 +131,12 @@ class Swift_Plugins_LoggerPlugin implements Swift_Events_CommandListener, Swift_
     {
         $e = $evt->getException();
         $message = $e->getMessage();
-        $this->_logger->add(sprintf("!! %s", $message));
+        $code = $e->getCode();
+        $this->_logger->add(sprintf("!! %s (code: %s)", $message, $code));
         $message .= PHP_EOL;
         $message .= 'Log data:'.PHP_EOL;
         $message .= $this->_logger->dump();
         $evt->cancelBubble();
-        throw new Swift_TransportException($message);
+        throw new Swift_TransportException($message, $code, $e->getPrevious());
     }
 }


### PR DESCRIPTION
When LoggerPlugin catches a thrown exception, it modifies $message, and throws a new Swift_TransportException.  Previously, it only provided $message to the Swift_TransportException constructor.  Now, it will also pass the code and previous exception, so no information will be lost.

Also, it will append the code to the log message.