### PR TITLE
added getLastUsedTransport in Swift_Transport_LoadBalancedTransport

### DIFF
--- a/lib/classes/Swift/Transport/FailoverTransport.php
+++ b/lib/classes/Swift/Transport/FailoverTransport.php
@@ -56,6 +56,7 @@ class Swift_Transport_FailoverTransport extends Swift_Transport_LoadBalancedTran
 
                 if ($sent = $transport->send($message, $failedRecipients)) {
                     $this->_lastUsedTransport = $transport;
+
                     return $sent;
                 }
             } catch (Swift_TransportException $e) {

--- a/lib/classes/Swift/Transport/FailoverTransport.php
+++ b/lib/classes/Swift/Transport/FailoverTransport.php
@@ -45,6 +45,7 @@ class Swift_Transport_FailoverTransport extends Swift_Transport_LoadBalancedTran
     {
         $maxTransports = count($this->_transports);
         $sent = 0;
+        $this->_lastUsedTransport = null;
 
         for ($i = 0; $i < $maxTransports
             && $transport = $this->_getNextTransport(); ++$i) {
@@ -53,7 +54,10 @@ class Swift_Transport_FailoverTransport extends Swift_Transport_LoadBalancedTran
                     $transport->start();
                 }
 
-                return $transport->send($message, $failedRecipients);
+                if ($sent = $transport->send($message, $failedRecipients)) {
+                    $this->_lastUsedTransport = $transport;
+                    return $sent;
+                }
             } catch (Swift_TransportException $e) {
                 $this->_killCurrentTransport();
             }

--- a/lib/classes/Swift/Transport/LoadBalancedTransport.php
+++ b/lib/classes/Swift/Transport/LoadBalancedTransport.php
@@ -65,7 +65,7 @@ class Swift_Transport_LoadBalancedTransport implements Swift_Transport
     }
 
     /**
-     * Gets the Transport used in the last successful send operation.
+     * Get the Transport used in the last successful send operation.
      *
      * @return Swift_Transport
      */

--- a/lib/classes/Swift/Transport/LoadBalancedTransport.php
+++ b/lib/classes/Swift/Transport/LoadBalancedTransport.php
@@ -30,6 +30,13 @@ class Swift_Transport_LoadBalancedTransport implements Swift_Transport
     protected $_transports = array();
 
     /**
+     * The Transport used in the last successful send operation.
+     *
+     * @var Swift_Transport
+     */
+    protected $_lastUsedTransport = null;
+
+    /**
      * Creates a new LoadBalancedTransport.
      */
     public function __construct()
@@ -55,6 +62,16 @@ class Swift_Transport_LoadBalancedTransport implements Swift_Transport
     public function getTransports()
     {
         return array_merge($this->_transports, $this->_deadTransports);
+    }
+
+    /**
+     * Gets the Transport used in the last successful send operation.
+     *
+     * @return Swift_Transport
+     */
+    public function getLastUsedTransport()
+    {
+        return $this->_lastUsedTransport;
     }
 
     /**
@@ -100,6 +117,7 @@ class Swift_Transport_LoadBalancedTransport implements Swift_Transport
     {
         $maxTransports = count($this->_transports);
         $sent = 0;
+        $this->_lastUsedTransport = null;
 
         for ($i = 0; $i < $maxTransports
             && $transport = $this->_getNextTransport(); ++$i) {
@@ -108,6 +126,7 @@ class Swift_Transport_LoadBalancedTransport implements Swift_Transport
                     $transport->start();
                 }
                 if ($sent = $transport->send($message, $failedRecipients)) {
+                    $this->_lastUsedTransport = $transport;
                     break;
                 }
             } catch (Swift_TransportException $e) {


### PR DESCRIPTION
When using LoadBalancedTransport, I need to know (for tracking) which Transport it actually used. So I added this method to retrieve it.