### PR TITLE
Add email as a Composer keyword

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "swiftmailer/swiftmailer",
     "type": "library",
     "description": "Swiftmailer, free feature-rich PHP mailer",
-    "keywords": ["mail","mailer"],
+    "keywords": ["mail","mailer","email"],
     "homepage": "http://swiftmailer.org",
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
This is useful when you search for email Composer packages on packagist.org.

See these two searches for "mail" and "email" sorted by downloads:

- https://packagist.org/search/?q=mail&orderBys[0][sort]=downloads&orderBys[0][order]=desc
- https://packagist.org/search/?q=email&orderBys[0][sort]=downloads&orderBys[0][order]=desc

When you search for "email" Swiftmailer is not coming up in the results, because there is no "email" word in the name, keywords and description fields.