### PR TITLE
Separate message/content ID generator class

### DIFF
--- a/lib/classes/Swift/IdGenerator.php
+++ b/lib/classes/Swift/IdGenerator.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of SwiftMailer.
+ * (c) 2004-2009 Chris Corbyn
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * Message ID generator.
+ */
+interface Swift_IdGenerator
+{
+    /**
+     * Returns a globally unique string to use for Message-ID or Content-ID.
+     *
+     * @return string
+     */
+    public function generateId();
+}

--- a/lib/classes/Swift/Mime/Attachment.php
+++ b/lib/classes/Swift/Mime/Attachment.php
@@ -8,8 +8,6 @@
  * file that was distributed with this source code.
  */
 
-use Egulias\EmailValidator\EmailValidator;
-
 /**
  * An attachment, in a multipart message.
  *
@@ -26,12 +24,12 @@ class Swift_Mime_Attachment extends Swift_Mime_SimpleMimeEntity
      * @param Swift_Mime_HeaderSet      $headers
      * @param Swift_Mime_ContentEncoder $encoder
      * @param Swift_KeyCache            $cache
-     * @param EmailValidator            $emailValidator
+     * @param Swift_IdGenerator         $idGenerator
      * @param array                     $mimeTypes
      */
-    public function __construct(Swift_Mime_HeaderSet $headers, Swift_Mime_ContentEncoder $encoder, Swift_KeyCache $cache, EmailValidator $emailValidator, $mimeTypes = array())
+    public function __construct(Swift_Mime_HeaderSet $headers, Swift_Mime_ContentEncoder $encoder, Swift_KeyCache $cache, Swift_IdGenerator $idGenerator, $mimeTypes = array())
     {
-        parent::__construct($headers, $encoder, $cache, $emailValidator);
+        parent::__construct($headers, $encoder, $cache, $idGenerator);
         $this->setDisposition('attachment');
         $this->setContentType('application/octet-stream');
         $this->mimeTypes = $mimeTypes;

--- a/lib/classes/Swift/Mime/EmbeddedFile.php
+++ b/lib/classes/Swift/Mime/EmbeddedFile.php
@@ -8,8 +8,6 @@
  * file that was distributed with this source code.
  */
 
-use Egulias\EmailValidator\EmailValidator;
-
 /**
  * An embedded file, in a multipart message.
  *
@@ -23,11 +21,12 @@ class Swift_Mime_EmbeddedFile extends Swift_Mime_Attachment
      * @param Swift_Mime_HeaderSet      $headers
      * @param Swift_Mime_ContentEncoder $encoder
      * @param Swift_KeyCache            $cache
-     * @param array                     $mimeTypes optional
+     * @param Swift_IdGenerator         $idGenerator
+     * @param array                     $mimeTypes   optional
      */
-    public function __construct(Swift_Mime_HeaderSet $headers, Swift_Mime_ContentEncoder $encoder, Swift_KeyCache $cache, EmailValidator $emailValidator, $mimeTypes = array())
+    public function __construct(Swift_Mime_HeaderSet $headers, Swift_Mime_ContentEncoder $encoder, Swift_KeyCache $cache, Swift_IdGenerator $idGenerator, $mimeTypes = array())
     {
-        parent::__construct($headers, $encoder, $cache, $emailValidator, $mimeTypes);
+        parent::__construct($headers, $encoder, $cache, $idGenerator, $mimeTypes);
         $this->setDisposition('inline');
         $this->setId($this->getId());
     }

--- a/lib/classes/Swift/Mime/IdGenerator.php
+++ b/lib/classes/Swift/Mime/IdGenerator.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of SwiftMailer.
+ * (c) 2004-2009 Chris Corbyn
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Egulias\EmailValidator\EmailValidator;
+
+/**
+ * Message ID generator.
+ */
+class Swift_Mime_IdGenerator implements Swift_IdGenerator
+{
+    /**
+     * @param EmailValidator $emailValidator
+     * @param string|null    $idRight
+     */
+    public function __construct(EmailValidator $emailValidator, $idRight = null)
+    {
+        if ($idRight) {
+            $this->idRight = $idRight;
+        } else {
+            $this->idRight = !empty($_SERVER['SERVER_NAME']) ? $_SERVER['SERVER_NAME'] : 'swift.generated';
+            if (!$emailValidator->isValid('dummy@'.$this->idRight)) {
+                $this->idRight = 'swift.generated';
+            }
+        }
+    }
+
+    /**
+     * Returns the right-hand side of the "@" used in all generated IDs.
+     *
+     * @return string
+     */
+    public function getIdRight()
+    {
+        return $this->idRight;
+    }
+
+    /**
+     * Sets the right-hand side of the "@" to use in all generated IDs.
+     *
+     * @param string $idRight
+     */
+    public function setIdRight($idRight)
+    {
+        $this->idRight = $idRight;
+    }
+
+    /**
+     * @return string
+     */
+    public function generateId()
+    {
+        $idLeft = md5(getmypid().'.'.time().'.'.uniqid(mt_rand(), true));
+
+        return $idLeft.'@'.$this->idRight;
+    }
+}

--- a/lib/classes/Swift/Mime/MimePart.php
+++ b/lib/classes/Swift/Mime/MimePart.php
@@ -8,8 +8,6 @@
  * file that was distributed with this source code.
  */
 
-use Egulias\EmailValidator\EmailValidator;
-
 /**
  * A MIME part, in a multipart message.
  *
@@ -35,12 +33,12 @@ class Swift_Mime_MimePart extends Swift_Mime_SimpleMimeEntity
      * @param Swift_Mime_HeaderSet      $headers
      * @param Swift_Mime_ContentEncoder $encoder
      * @param Swift_KeyCache            $cache
-     * @param EmailValidator            $emailValidator
+     * @param Swift_IdGenerator         $idGenerator
      * @param string                    $charset
      */
-    public function __construct(Swift_Mime_HeaderSet $headers, Swift_Mime_ContentEncoder $encoder, Swift_KeyCache $cache, EmailValidator $emailValidator, $charset = null)
+    public function __construct(Swift_Mime_HeaderSet $headers, Swift_Mime_ContentEncoder $encoder, Swift_KeyCache $cache, Swift_IdGenerator $idGenerator, $charset = null)
     {
-        parent::__construct($headers, $encoder, $cache, $emailValidator);
+        parent::__construct($headers, $encoder, $cache, $idGenerator);
         $this->setContentType('text/plain');
         if (!is_null($charset)) {
             $this->setCharset($charset);

--- a/lib/classes/Swift/Mime/SimpleMessage.php
+++ b/lib/classes/Swift/Mime/SimpleMessage.php
@@ -8,8 +8,6 @@
  * file that was distributed with this source code.
  */
 
-use Egulias\EmailValidator\EmailValidator;
-
 /**
  * The default email message class.
  *
@@ -23,12 +21,12 @@ class Swift_Mime_SimpleMessage extends Swift_Mime_MimePart implements Swift_Mime
      * @param Swift_Mime_HeaderSet      $headers
      * @param Swift_Mime_ContentEncoder $encoder
      * @param Swift_KeyCache            $cache
-     * @param EmailValidator            $emailValidator
+     * @param Swift_IdGenerator         $idGenerator
      * @param string                    $charset
      */
-    public function __construct(Swift_Mime_HeaderSet $headers, Swift_Mime_ContentEncoder $encoder, Swift_KeyCache $cache, EmailValidator $emailValidator, $charset = null)
+    public function __construct(Swift_Mime_HeaderSet $headers, Swift_Mime_ContentEncoder $encoder, Swift_KeyCache $cache, Swift_IdGenerator $idGenerator, $charset = null)
     {
-        parent::__construct($headers, $encoder, $cache, $emailValidator, $charset);
+        parent::__construct($headers, $encoder, $cache, $idGenerator, $charset);
         $this->getHeaders()->defineOrdering(array(
             'Return-Path',
             'Received',
@@ -624,7 +622,7 @@ class Swift_Mime_SimpleMessage extends Swift_Mime_MimePart implements Swift_Mime
     protected function becomeMimePart()
     {
         $part = new parent($this->getHeaders()->newInstance(), $this->getEncoder(),
-            $this->getCache(), $this->getEmailValidator(), $this->userCharset
+            $this->getCache(), $this->getIdGenerator(), $this->userCharset
             );
         $part->setContentType($this->userContentType);
         $part->setBody($this->getBody());

--- a/lib/dependency_maps/mime_deps.php
+++ b/lib/dependency_maps/mime_deps.php
@@ -9,13 +9,19 @@ Swift_DependencyContainer::getInstance()
     ->register('email.validator')
     ->asSharedInstanceOf('Egulias\EmailValidator\EmailValidator')
 
+    ->register('mime.idgenerator')
+    ->asSharedInstanceOf('Swift_Mime_IdGenerator')
+    ->withDependencies(array(
+        'email.validator',
+    ))
+
     ->register('mime.message')
     ->asNewInstanceOf('Swift_Mime_SimpleMessage')
     ->withDependencies(array(
         'mime.headerset',
         'mime.qpcontentencoder',
         'cache',
-        'email.validator',
+        'mime.idgenerator',
         'properties.charset',
     ))
 
@@ -25,7 +31,7 @@ Swift_DependencyContainer::getInstance()
         'mime.headerset',
         'mime.qpcontentencoder',
         'cache',
-        'email.validator',
+        'mime.idgenerator',
         'properties.charset',
     ))
 
@@ -35,7 +41,7 @@ Swift_DependencyContainer::getInstance()
         'mime.headerset',
         'mime.base64contentencoder',
         'cache',
-        'email.validator',
+        'mime.idgenerator',
     ))
     ->addConstructorValue($swift_mime_types)
 
@@ -45,7 +51,7 @@ Swift_DependencyContainer::getInstance()
         'mime.headerset',
         'mime.base64contentencoder',
         'cache',
-        'email.validator',
+        'mime.idgenerator',
     ))
     ->addConstructorValue($swift_mime_types)
 

--- a/tests/acceptance/Swift/Mime/AttachmentAcceptanceTest.php
+++ b/tests/acceptance/Swift/Mime/AttachmentAcceptanceTest.php
@@ -24,6 +24,7 @@ class Swift_Mime_AttachmentAcceptanceTest extends \PHPUnit_Framework_TestCase
             new Swift_CharacterStream_ArrayCharacterStream($factory, 'utf-8')
             );
         $this->emailValidator = new EmailValidator();
+        $this->idGenerator = new Swift_Mime_IdGenerator($this->emailValidator);
         $this->headers = new Swift_Mime_SimpleHeaderSet(
             new Swift_Mime_SimpleHeaderFactory($headerEncoder, $paramEncoder, $this->emailValidator)
             );
@@ -119,7 +120,7 @@ class Swift_Mime_AttachmentAcceptanceTest extends \PHPUnit_Framework_TestCase
             $this->headers,
             $this->contentEncoder,
             $this->cache,
-            $this->emailValidator
+            $this->idGenerator
             );
 
         return $entity;

--- a/tests/acceptance/Swift/Mime/EmbeddedFileAcceptanceTest.php
+++ b/tests/acceptance/Swift/Mime/EmbeddedFileAcceptanceTest.php
@@ -24,6 +24,7 @@ class Swift_Mime_EmbeddedFileAcceptanceTest extends \PHPUnit_Framework_TestCase
             new Swift_CharacterStream_ArrayCharacterStream($factory, 'utf-8')
             );
         $this->emailValidator = new EmailValidator();
+        $this->idGenerator = new Swift_Mime_IdGenerator($this->emailValidator);
         $this->headers = new Swift_Mime_SimpleHeaderSet(
             new Swift_Mime_SimpleHeaderFactory($headerEncoder, $paramEncoder, $this->emailValidator)
             );
@@ -131,7 +132,7 @@ class Swift_Mime_EmbeddedFileAcceptanceTest extends \PHPUnit_Framework_TestCase
             $this->headers,
             $this->contentEncoder,
             $this->cache,
-            $this->emailValidator
+            $this->idGenerator
             );
 
         return $entity;

--- a/tests/acceptance/Swift/Mime/MimePartAcceptanceTest.php
+++ b/tests/acceptance/Swift/Mime/MimePartAcceptanceTest.php
@@ -30,6 +30,7 @@ class Swift_Mime_MimePartAcceptanceTest extends \PHPUnit_Framework_TestCase
             new Swift_CharacterStream_ArrayCharacterStream($factory, 'utf-8')
             );
         $this->emailValidator = new EmailValidator();
+        $this->idGenerator = new Swift_Mime_IdGenerator($this->emailValidator);
         $this->headers = new Swift_Mime_SimpleHeaderSet(
             new Swift_Mime_SimpleHeaderFactory($headerEncoder, $paramEncoder, $this->emailValidator)
             );
@@ -123,7 +124,7 @@ class Swift_Mime_MimePartAcceptanceTest extends \PHPUnit_Framework_TestCase
             $this->headers,
             $this->contentEncoder,
             $this->cache,
-            $this->emailValidator
+            $this->idGenerator
         );
 
         return $entity;

--- a/tests/unit/Swift/Mime/AttachmentTest.php
+++ b/tests/unit/Swift/Mime/AttachmentTest.php
@@ -293,7 +293,9 @@ class Swift_Mime_AttachmentTest extends Swift_Mime_AbstractMimeEntityTest
 
     protected function createAttachment($headers, $encoder, $cache, $mimeTypes = array())
     {
-        return new Swift_Mime_Attachment($headers, $encoder, $cache, new EmailValidator(), $mimeTypes);
+        $idGenerator = new Swift_Mime_IdGenerator(new EmailValidator());
+
+        return new Swift_Mime_Attachment($headers, $encoder, $cache, $idGenerator, $mimeTypes);
     }
 
     protected function createFileStream($path, $data, $stub = true)

--- a/tests/unit/Swift/Mime/EmbeddedFileTest.php
+++ b/tests/unit/Swift/Mime/EmbeddedFileTest.php
@@ -54,6 +54,8 @@ class Swift_Mime_EmbeddedFileTest extends Swift_Mime_AttachmentTest
 
     private function createEmbeddedFile($headers, $encoder, $cache)
     {
-        return new Swift_Mime_EmbeddedFile($headers, $encoder, $cache, new EmailValidator());
+        $idGenerator = new Swift_Mime_IdGenerator(new EmailValidator());
+
+        return new Swift_Mime_EmbeddedFile($headers, $encoder, $cache, $idGenerator);
     }
 }

--- a/tests/unit/Swift/Mime/IdGeneratorTest.php
+++ b/tests/unit/Swift/Mime/IdGeneratorTest.php
@@ -1,0 +1,73 @@
+<?php
+
+use Egulias\EmailValidator\EmailValidator;
+
+class Swift_Mime_IdGeneratorTest extends \PHPUnit_Framework_TestCase
+{
+    protected $emailValidator;
+    protected $originalServerName;
+
+    public function setUp()
+    {
+        $this->emailValidator = new EmailValidator();
+        $this->originalServerName = isset($_SERVER['SERVER_NAME']) ? $_SERVER['SERVER_NAME'] : null;
+        unset($_SERVER['SERVER_NAME']);
+    }
+
+    public function tearDown()
+    {
+        // Restore super-global variable.
+        if (isset($this->originalServerName)) {
+            $_SERVER['SERVER_NAME'] = $this->originalServerName;
+        } else {
+            unset($_SERVER['SERVER_NAME']);
+        }
+    }
+
+    public function testIdGeneratorServerName()
+    {
+        $_SERVER['SERVER_NAME'] = 'example.com';
+        $idGenerator = new Swift_Mime_IdGenerator($this->emailValidator);
+        $this->assertEquals('example.com', $idGenerator->getIdRight());
+    }
+
+    public function testIdGeneratorInvalidServerName()
+    {
+        $_SERVER['SERVER_NAME'] = 'not a valid hostname';
+        $idGenerator = new Swift_Mime_IdGenerator($this->emailValidator);
+        $this->assertEquals('swift.generated', $idGenerator->getIdRight());
+    }
+
+    public function testIdGeneratorFallback()
+    {
+        $idGenerator = new Swift_Mime_IdGenerator($this->emailValidator);
+        $this->assertEquals('swift.generated', $idGenerator->getIdRight());
+    }
+
+    public function testIdGeneratorExplicit()
+    {
+        $idGenerator = new Swift_Mime_IdGenerator($this->emailValidator, 'example.net');
+        $this->assertEquals('example.net', $idGenerator->getIdRight());
+    }
+
+    public function testIdGeneratorSetRightId()
+    {
+        $idGenerator = new Swift_Mime_IdGenerator($this->emailValidator, 'example.net');
+        $this->assertEquals('example.net', $idGenerator->getIdRight());
+
+        $idGenerator->setIdRight('example.com');
+        $this->assertEquals('example.com', $idGenerator->getIdRight());
+    }
+
+    public function testIdGenerateId()
+    {
+        $idGenerator = new Swift_Mime_IdGenerator($this->emailValidator, 'example.net');
+
+        $id = $idGenerator->generateId();
+        $this->assertTrue($this->emailValidator->isValid($id));
+        $this->assertEquals(1, preg_match('/^.{32}@example.net$/', $id));
+
+        $anotherId = $idGenerator->generateId();
+        $this->assertNotEquals($id, $anotherId);
+    }
+}

--- a/tests/unit/Swift/Mime/MimePartTest.php
+++ b/tests/unit/Swift/Mime/MimePartTest.php
@@ -230,6 +230,8 @@ class Swift_Mime_MimePartTest extends Swift_Mime_AbstractMimeEntityTest
 
     protected function createMimePart($headers, $encoder, $cache)
     {
-        return new Swift_Mime_MimePart($headers, $encoder, $cache, new EmailValidator());
+        $idGenerator = new Swift_Mime_IdGenerator(new EmailValidator());
+
+        return new Swift_Mime_MimePart($headers, $encoder, $cache, $idGenerator);
     }
 }

--- a/tests/unit/Swift/Mime/SimpleMessageTest.php
+++ b/tests/unit/Swift/Mime/SimpleMessageTest.php
@@ -826,6 +826,8 @@ class Swift_Mime_SimpleMessageTest extends Swift_Mime_MimePartTest
 
     private function createMessage($headers, $encoder, $cache)
     {
-        return new Swift_Mime_SimpleMessage($headers, $encoder, $cache, new EmailValidator());
+        $idGenerator = new Swift_Mime_IdGenerator(new EmailValidator());
+
+        return new Swift_Mime_SimpleMessage($headers, $encoder, $cache, $idGenerator);
     }
 }

--- a/tests/unit/Swift/Mime/SimpleMimeEntityTest.php
+++ b/tests/unit/Swift/Mime/SimpleMimeEntityTest.php
@@ -8,6 +8,8 @@ class Swift_Mime_SimpleMimeEntityTest extends Swift_Mime_AbstractMimeEntityTest
 
     protected function createEntity($headerFactory, $encoder, $cache)
     {
-        return new Swift_Mime_SimpleMimeEntity($headerFactory, $encoder, $cache, new EmailValidator());
+        $idGenerator = new Swift_Mime_IdGenerator(new EmailValidator());
+
+        return new Swift_Mime_SimpleMimeEntity($headerFactory, $encoder, $cache, $idGenerator);
     }
 }


### PR DESCRIPTION
I would like greater control over the Message-ID headers without having to specify it manually on each message using setId().

Currently the ID depends on the global $_SERVER['SERVER_NAME'] variable.

This PR adds an ID generator class that is injected into all relevant instances instead of the EmailValidator. This seems more natural. The EmailValidator is now a dependency of the new IdGenerator instead.

The Message-ID is written to my mail server log. Injecting my own custom ID generator would allow me to generate per-message message IDs containing some information about the message itself, e.g. indicating the type of message, and thus make it easier to identify the various emails in the log files.