### PR TITLE
More robust loading of autoload.php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,11 @@
     "autoload": {
         "files": ["lib/swift_required.php"]
     },
+    "autoload-dev": {
+        "psr-0": {
+            "Swift_": "tests/unit"
+        }
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "5.4-dev"

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,7 +1,6 @@
 <?php
 
-$autoloader = require_once dirname(__DIR__).'/vendor/autoload.php';
-$autoloader->add('Swift_', __DIR__.'/unit');
+require_once dirname(__DIR__).'/vendor/autoload.php';
 
 set_include_path(get_include_path().PATH_SEPARATOR.dirname(__DIR__).'/lib');
 


### PR DESCRIPTION
Depending on how you install PHPUnit, vender/autoload.php may already be loaded by PHPUnit itself.

If you include a file with require_once more than once, the second and consecutive calls will return true. This causes the script to die with a fatal error.