### PR TITLE
Adds methods to set custom stream context options; implements #571

### DIFF
--- a/lib/classes/Swift/Transport/EsmtpTransport.php
+++ b/lib/classes/Swift/Transport/EsmtpTransport.php
@@ -42,6 +42,7 @@ class Swift_Transport_EsmtpTransport extends Swift_Transport_AbstractSmtpTranspo
         'blocking' => 1,
         'tls' => false,
         'type' => Swift_Transport_IoBuffer::TYPE_SOCKET,
+        'stream_context_options' => array(),
         );
 
     /**
@@ -158,6 +159,30 @@ class Swift_Transport_EsmtpTransport extends Swift_Transport_AbstractSmtpTranspo
     public function getEncryption()
     {
         return $this->_params['tls'] ? 'tls' : $this->_params['protocol'];
+    }
+
+    /**
+     * Sets the stream context options.
+     *
+     * @param array $options
+     *
+     * @return Swift_Transport_EsmtpTransport
+     */
+    public function setStreamOptions($options)
+    {
+        $this->_params['stream_context_options'] = $options;
+
+        return $this;
+    }
+
+    /**
+     * Returns the stream context options.
+     *
+     * @return array
+     */
+    public function getStreamOptions()
+    {
+        return $this->_params['stream_context_options'];
     }
 
     /**

--- a/lib/classes/Swift/Transport/StreamBuffer.php
+++ b/lib/classes/Swift/Transport/StreamBuffer.php
@@ -260,7 +260,8 @@ class Swift_Transport_StreamBuffer extends Swift_ByteStream_AbstractFilterableIn
         if (!empty($this->_params['sourceIp'])) {
             $options['socket']['bindto'] = $this->_params['sourceIp'].':0';
         }
-        $this->_stream = @stream_socket_client($host.':'.$this->_params['port'], $errno, $errstr, $timeout, STREAM_CLIENT_CONNECT, stream_context_create($options));
+        $streamContext = stream_context_create(array_merge($options, $this->_params['stream_context_options']));
+        $this->_stream = @stream_socket_client($host.':'.$this->_params['port'], $errno, $errstr, $timeout, STREAM_CLIENT_CONNECT, $streamContext);
         if (false === $this->_stream) {
             throw new Swift_TransportException(
                 'Connection could not be established with host '.$this->_params['host'].

--- a/tests/acceptance/Swift/Transport/StreamBuffer/SocketTimeoutTest.php
+++ b/tests/acceptance/Swift/Transport/StreamBuffer/SocketTimeoutTest.php
@@ -41,6 +41,7 @@ class Swift_Transport_StreamBuffer_SocketTimeoutTest extends \PHPUnit_Framework_
             'protocol' => 'tcp',
             'blocking' => 1,
             'timeout' => 1,
+            'stream_context_options' => array(),
             ));
     }
 


### PR DESCRIPTION
Another try at #623 to fix #571.

This allows people to set (or override) any of the stream context options, including the SSL context, which in turn means we can use swiftmailer with SMTP over SSL/TLS with self-signed or otherwise invalid certificates.