### PR TITLE
Represent Date header as DateTimeImmutable object

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,8 @@ Changelog
  * removed the Swift_Transport_MailInvoker interface and Swift_Transport_SimpleMailInvoker class
  * removed the Swift_SignedMessage class
  * removed newInstance() methods everywhere
+ * methods operating on Date header now use DateTimeImmutable object instead of Unix timestamp;
+   Swift_Mime_Headers_DateHeader::getTimestamp()/setTimestamp() renamed to getDateTime()/setDateTime()
  * bumped minimum version to PHP 5.5
 
 5.4.2 (2015-XX-XX)

--- a/doc/headers.rst
+++ b/doc/headers.rst
@@ -310,10 +310,9 @@ Date headers contains an RFC 2822 formatted date (i.e. what PHP's ``date('r')``
 returns). They are used anywhere a date or time is needed to be presented as a
 message header.
 
-The data on which a date header is modeled is simply a UNIX timestamp such as
-that returned by ``time()`` or ``strtotime()``.  The timestamp is used to create
-a correctly structured RFC 2822 formatted date such as
-``Tue, 17 Feb 2009 22:26:31 +1100``.
+The data on which a date header is modeled as a DateTimeImmutable object.  The
+object is used to create a correctly structured RFC 2822 formatted date with
+timezone such as ``Tue, 17 Feb 2009 22:26:31 +1100``.
 
 The obvious place this header type is used is in the ``Date:`` header of the
 message itself.
@@ -327,16 +326,16 @@ the HeaderSet's ``addDateHeader()`` method.
 
     $headers = $message->getHeaders();
 
-    $headers->addDateHeader('Your-Header-Name', strtotime('3 days ago'));
+    $headers->addDateHeader('Your-Header', new DateTimeImmutable('3 days ago'));
 
 Changing the value of an existing date header is done by calling it's
-``setTimestamp()`` method.
+``setDateTime()`` method.
 
 .. code-block:: php
 
     $date = $message->getHeaders()->get('Date');
 
-    $date->setTimestamp(time());
+    $date->setDateTime(new DateTimeImmutable());
 
 When output via ``toString()``, a date header produces something like the
 following:

--- a/doc/messages.rst
+++ b/doc/messages.rst
@@ -93,8 +93,8 @@ headers will be familiar to the majority of users, but we'll list the basic
 ones. Although it's possible to work directly with the Headers of a Message
 (or other MIME entity), the standard Headers have accessor methods provided to
 abstract away the complex details for you. For example, although the Date on a
-message is written with a strict format, you only need to pass a UNIX
-timestamp to ``setDate()``.
+message is written with a strict format, you only need to pass a
+DateTimeInterface instance to ``setDate()``.
 
 +-------------------------------+------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------+
 | Header                        | Description                                                                                                                        | Accessors                                   |

--- a/lib/classes/Swift/Mime/HeaderFactory.php
+++ b/lib/classes/Swift/Mime/HeaderFactory.php
@@ -26,14 +26,14 @@ interface Swift_Mime_HeaderFactory extends Swift_Mime_CharsetObserver
     public function createMailboxHeader($name, $addresses = null);
 
     /**
-     * Create a new Date header using $timestamp (UNIX time).
+     * Create a new Date header using $dateTime.
      *
-     * @param string $name
-     * @param int    $timestamp
+     * @param string            $name
+     * @param DateTimeInterface $dateTime
      *
      * @return Swift_Mime_Header
      */
-    public function createDateHeader($name, $timestamp = null);
+    public function createDateHeader($name, DateTimeInterface $dateTime = null);
 
     /**
      * Create a new basic text header with $name and $value.

--- a/lib/classes/Swift/Mime/HeaderSet.php
+++ b/lib/classes/Swift/Mime/HeaderSet.php
@@ -24,12 +24,12 @@ interface Swift_Mime_HeaderSet extends Swift_Mime_CharsetObserver
     public function addMailboxHeader($name, $addresses = null);
 
     /**
-     * Add a new Date header using $timestamp (UNIX time).
+     * Add a new Date header using $dateTime.
      *
-     * @param string $name
-     * @param int    $timestamp
+     * @param string            $name
+     * @param DateTimeInterface $dateTime
      */
-    public function addDateHeader($name, $timestamp = null);
+    public function addDateHeader($name, DateTimeInterface $dateTime = null);
 
     /**
      * Add a new basic text header with $name and $value.

--- a/lib/classes/Swift/Mime/Headers/DateHeader.php
+++ b/lib/classes/Swift/Mime/Headers/DateHeader.php
@@ -16,21 +16,14 @@
 class Swift_Mime_Headers_DateHeader extends Swift_Mime_Headers_AbstractHeader
 {
     /**
-     * The UNIX timestamp value of this Header.
+     * Date-time value of this Header.
      *
-     * @var int
+     * @var DateTimeImmutable
      */
-    private $timestamp;
+    private $dateTime;
 
     /**
-     * Creates a new DateHeader with $name and $timestamp.
-     *
-     * Example:
-     * <code>
-     * <?php
-     * $header = new Swift_Mime_Headers_DateHeader('Date', time());
-     * ?>
-     * </code>
+     * Creates a new DateHeader with $name.
      *
      * @param string $name of Header
      */
@@ -55,49 +48,48 @@ class Swift_Mime_Headers_DateHeader extends Swift_Mime_Headers_AbstractHeader
     /**
      * Set the model for the field body.
      *
-     * This method takes a UNIX timestamp.
-     *
-     * @param int $model
+     * @param DateTimeInterface $model
      */
     public function setFieldBodyModel($model)
     {
-        $this->setTimestamp($model);
+        $this->setDateTime($model);
     }
 
     /**
      * Get the model for the field body.
      *
-     * This method returns a UNIX timestamp.
-     *
-     * @return mixed
+     * @return DateTimeImmutable
      */
     public function getFieldBodyModel()
     {
-        return $this->getTimestamp();
+        return $this->getDateTime();
     }
 
     /**
-     * Get the UNIX timestamp of the Date in this Header.
+     * Get the date-time representing the Date in this Header.
      *
-     * @return int
+     * @return DateTimeImmutable
      */
-    public function getTimestamp()
+    public function getDateTime()
     {
-        return $this->timestamp;
+        return $this->dateTime;
     }
 
     /**
-     * Set the UNIX timestamp of the Date in this Header.
+     * Set the date-time of the Date in this Header.
      *
-     * @param int $timestamp
+     * If a DateTime instance is provided, it is converted to DateTimeImmutable.
+     *
+     * @param DateTimeInterface $dateTime
      */
-    public function setTimestamp($timestamp)
+    public function setDateTime(DateTimeInterface $dateTime)
     {
-        if (!is_null($timestamp)) {
-            $timestamp = (int) $timestamp;
+        $this->clearCachedValueIf($this->getCachedValue() != $dateTime->format(DateTime::RFC2822));
+        if ($dateTime instanceof DateTime) {
+            $immutable = new DateTimeImmutable('@'.$dateTime->getTimestamp());
+            $dateTime = $immutable->setTimezone($dateTime->getTimezone());
         }
-        $this->clearCachedValueIf($this->timestamp != $timestamp);
-        $this->timestamp = $timestamp;
+        $this->dateTime = $dateTime;
     }
 
     /**
@@ -113,8 +105,8 @@ class Swift_Mime_Headers_DateHeader extends Swift_Mime_Headers_AbstractHeader
     public function getFieldBody()
     {
         if (!$this->getCachedValue()) {
-            if (isset($this->timestamp)) {
-                $this->setCachedValue(date('r', $this->timestamp));
+            if (isset($this->dateTime)) {
+                $this->setCachedValue($this->dateTime->format(DateTime::RFC2822));
             }
         }
 

--- a/lib/classes/Swift/Mime/Message.php
+++ b/lib/classes/Swift/Mime/Message.php
@@ -37,16 +37,16 @@ interface Swift_Mime_Message extends Swift_Mime_MimeEntity
     public function getSubject();
 
     /**
-     * Set the origination date of the message as a UNIX timestamp.
+     * Set the origination date of the message.
      *
-     * @param int $date
+     * @param DateTimeInterface $dateTime
      */
-    public function setDate($date);
+    public function setDate(DateTimeInterface $dateTime);
 
     /**
-     * Get the origination date of the message as a UNIX timestamp.
+     * Get the origination date of the message.
      *
-     * @return int
+     * @return DateTimeInterface
      */
     public function getDate();
 

--- a/lib/classes/Swift/Mime/SimpleHeaderFactory.php
+++ b/lib/classes/Swift/Mime/SimpleHeaderFactory.php
@@ -68,18 +68,18 @@ class Swift_Mime_SimpleHeaderFactory implements Swift_Mime_HeaderFactory
     }
 
     /**
-     * Create a new Date header using $timestamp (UNIX time).
+     * Create a new Date header using $dateTime.
      *
-     * @param string   $name
-     * @param int|null $timestamp
+     * @param string                 $name
+     * @param DateTimeInterface|null $dateTime
      *
      * @return Swift_Mime_Header
      */
-    public function createDateHeader($name, $timestamp = null)
+    public function createDateHeader($name, DateTimeInterface $dateTime = null)
     {
         $header = new Swift_Mime_Headers_DateHeader($name);
-        if (isset($timestamp)) {
-            $header->setFieldBodyModel($timestamp);
+        if (isset($dateTime)) {
+            $header->setFieldBodyModel($dateTime);
         }
         $this->setHeaderCharset($header);
 

--- a/lib/classes/Swift/Mime/SimpleHeaderSet.php
+++ b/lib/classes/Swift/Mime/SimpleHeaderSet.php
@@ -74,15 +74,15 @@ class Swift_Mime_SimpleHeaderSet implements Swift_Mime_HeaderSet
     }
 
     /**
-     * Add a new Date header using $timestamp (UNIX time).
+     * Add a new Date header using $dateTime.
      *
-     * @param string $name
-     * @param int    $timestamp
+     * @param string            $name
+     * @param DateTimeInterface $dateTime
      */
-    public function addDateHeader($name, $timestamp = null)
+    public function addDateHeader($name, DateTimeInterface $dateTime = null)
     {
         $this->storeHeader($name,
-        $this->factory->createDateHeader($name, $timestamp));
+        $this->factory->createDateHeader($name, $dateTime));
     }
 
     /**

--- a/lib/classes/Swift/Mime/SimpleMessage.php
+++ b/lib/classes/Swift/Mime/SimpleMessage.php
@@ -49,7 +49,7 @@ class Swift_Mime_SimpleMessage extends Swift_Mime_MimePart implements Swift_Mime
             ));
         $this->getHeaders()->setAlwaysDisplayed(array('Date', 'Message-ID', 'From'));
         $this->getHeaders()->addTextHeader('MIME-Version', '1.0');
-        $this->setDate(time());
+        $this->setDate(new DateTimeImmutable());
         $this->setId($this->getId());
         $this->getHeaders()->addMailboxHeader('From');
     }
@@ -93,14 +93,14 @@ class Swift_Mime_SimpleMessage extends Swift_Mime_MimePart implements Swift_Mime
     /**
      * Set the date at which this message was created.
      *
-     * @param int $date
+     * @param DateTimeInterface $dateTime
      *
      * @return Swift_Mime_SimpleMessage
      */
-    public function setDate($date)
+    public function setDate(DateTimeInterface $dateTime)
     {
-        if (!$this->setHeaderFieldModel('Date', $date)) {
-            $this->getHeaders()->addDateHeader('Date', $date);
+        if (!$this->setHeaderFieldModel('Date', $dateTime)) {
+            $this->getHeaders()->addDateHeader('Date', $dateTime);
         }
 
         return $this;
@@ -109,7 +109,7 @@ class Swift_Mime_SimpleMessage extends Swift_Mime_MimePart implements Swift_Mime
     /**
      * Get the date at which this message was created.
      *
-     * @return int
+     * @return DateTimeInterface
      */
     public function getDate()
     {

--- a/tests/acceptance/Swift/MessageAcceptanceTest.php
+++ b/tests/acceptance/Swift/MessageAcceptanceTest.php
@@ -21,7 +21,7 @@ class Swift_MessageAcceptanceTest extends Swift_Mime_SimpleMessageAcceptanceTest
 
         $this->assertEquals(
             'Message-ID: <'.$id.'>'."\r\n".
-            'Date: '.date('r', $date)."\r\n".
+            'Date: '.$date->format('r')."\r\n".
             'Subject: just a test subject'."\r\n".
             'From: Chris Corbyn <chris.corbyn@swiftmailer.org>'."\r\n".
             'MIME-Version: 1.0'."\r\n".

--- a/tests/acceptance/Swift/Mime/SimpleMessageAcceptanceTest.php
+++ b/tests/acceptance/Swift/Mime/SimpleMessageAcceptanceTest.php
@@ -17,7 +17,7 @@ class Swift_Mime_SimpleMessageAcceptanceTest extends \PHPUnit_Framework_TestCase
         $date = $message->getDate();
         $this->assertEquals(
             'Message-ID: <'.$id.'>'."\r\n".
-            'Date: '.date('r', $date)."\r\n".
+            'Date: '.$date->format('r')."\r\n".
             'From: '."\r\n".
             'MIME-Version: 1.0'."\r\n".
             'Content-Type: text/plain'."\r\n".
@@ -35,7 +35,7 @@ class Swift_Mime_SimpleMessageAcceptanceTest extends \PHPUnit_Framework_TestCase
         $date = $message->getDate();
         $this->assertEquals(
             'Message-ID: <'.$id.'>'."\r\n".
-            'Date: '.date('r', $date)."\r\n".
+            'Date: '.$date->format('r')."\r\n".
             'Subject: just a test subject'."\r\n".
             'From: '."\r\n".
             'MIME-Version: 1.0'."\r\n".
@@ -50,10 +50,11 @@ class Swift_Mime_SimpleMessageAcceptanceTest extends \PHPUnit_Framework_TestCase
         $message = $this->createMessage();
         $message->setSubject('just a test subject');
         $id = $message->getId();
-        $message->setDate(1234);
+        $date = new DateTimeImmutable();
+        $message->setDate($date);
         $this->assertEquals(
             'Message-ID: <'.$id.'>'."\r\n".
-            'Date: '.date('r', 1234)."\r\n".
+            'Date: '.$date->format('r')."\r\n".
             'Subject: just a test subject'."\r\n".
             'From: '."\r\n".
             'MIME-Version: 1.0'."\r\n".
@@ -71,7 +72,7 @@ class Swift_Mime_SimpleMessageAcceptanceTest extends \PHPUnit_Framework_TestCase
         $date = $message->getDate();
         $this->assertEquals(
             'Message-ID: <foo@bar>'."\r\n".
-            'Date: '.date('r', $date)."\r\n".
+            'Date: '.$date->format('r')."\r\n".
             'Subject: just a test subject'."\r\n".
             'From: '."\r\n".
             'MIME-Version: 1.0'."\r\n".
@@ -90,7 +91,7 @@ class Swift_Mime_SimpleMessageAcceptanceTest extends \PHPUnit_Framework_TestCase
         $date = $message->getDate();
         $this->assertEquals(
             'Message-ID: <'.$id.'>'."\r\n".
-            'Date: '.date('r', $date)."\r\n".
+            'Date: '.$date->format('r')."\r\n".
             'Subject: just a test subject'."\r\n".
             'From: '."\r\n".
             'MIME-Version: 1.0'."\r\n".
@@ -110,7 +111,7 @@ class Swift_Mime_SimpleMessageAcceptanceTest extends \PHPUnit_Framework_TestCase
         $date = $message->getDate();
         $this->assertEquals(
             'Message-ID: <'.$id.'>'."\r\n".
-            'Date: '.date('r', $date)."\r\n".
+            'Date: '.$date->format('r')."\r\n".
             'Subject: just a test subject'."\r\n".
             'From: '."\r\n".
             'MIME-Version: 1.0'."\r\n".
@@ -129,7 +130,7 @@ class Swift_Mime_SimpleMessageAcceptanceTest extends \PHPUnit_Framework_TestCase
         $date = $message->getDate();
         $this->assertEquals(
             'Message-ID: <'.$id.'>'."\r\n".
-            'Date: '.date('r', $date)."\r\n".
+            'Date: '.$date->format('r')."\r\n".
             'Subject: just a test subject'."\r\n".
             'From: '."\r\n".
             'MIME-Version: 1.0'."\r\n".
@@ -151,7 +152,7 @@ class Swift_Mime_SimpleMessageAcceptanceTest extends \PHPUnit_Framework_TestCase
         $date = $message->getDate();
         $this->assertEquals(
             'Message-ID: <'.$id.'>'."\r\n".
-            'Date: '.date('r', $date)."\r\n".
+            'Date: '.$date->format('r')."\r\n".
             'Subject: just a test subject'."\r\n".
             'From: '."\r\n".
             'MIME-Version: 1.0'."\r\n".
@@ -170,7 +171,7 @@ class Swift_Mime_SimpleMessageAcceptanceTest extends \PHPUnit_Framework_TestCase
         $date = $message->getDate();
         $this->assertEquals(
             'Message-ID: <'.$id.'>'."\r\n".
-            'Date: '.date('r', $date)."\r\n".
+            'Date: '.$date->format('r')."\r\n".
             'Subject: just a test subject'."\r\n".
             'From: chris.corbyn@swiftmailer.org'."\r\n".
             'MIME-Version: 1.0'."\r\n".
@@ -189,7 +190,7 @@ class Swift_Mime_SimpleMessageAcceptanceTest extends \PHPUnit_Framework_TestCase
         $date = $message->getDate();
         $this->assertEquals(
             'Message-ID: <'.$id.'>'."\r\n".
-            'Date: '.date('r', $date)."\r\n".
+            'Date: '.$date->format('r')."\r\n".
             'Subject: just a test subject'."\r\n".
             'From: Chris Corbyn <chris.corbyn@swiftmailer.org>'."\r\n".
             'MIME-Version: 1.0'."\r\n".
@@ -211,7 +212,7 @@ class Swift_Mime_SimpleMessageAcceptanceTest extends \PHPUnit_Framework_TestCase
         $date = $message->getDate();
         $this->assertEquals(
             'Message-ID: <'.$id.'>'."\r\n".
-            'Date: '.date('r', $date)."\r\n".
+            'Date: '.$date->format('r')."\r\n".
             'Subject: just a test subject'."\r\n".
             'From: Chris Corbyn <chris.corbyn@swiftmailer.org>, mark@swiftmailer.org'."\r\n".
             'MIME-Version: 1.0'."\r\n".
@@ -233,7 +234,7 @@ class Swift_Mime_SimpleMessageAcceptanceTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(
             'Return-Path: <chris@w3style.co.uk>'."\r\n".
             'Message-ID: <'.$id.'>'."\r\n".
-            'Date: '.date('r', $date)."\r\n".
+            'Date: '.$date->format('r')."\r\n".
             'Subject: just a test subject'."\r\n".
             'From: Chris Corbyn <chris.corbyn@swiftmailer.org>'."\r\n".
             'MIME-Version: 1.0'."\r\n".
@@ -255,7 +256,7 @@ class Swift_Mime_SimpleMessageAcceptanceTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(
             'Return-Path: <>'."\r\n".
             'Message-ID: <'.$id.'>'."\r\n".
-            'Date: '.date('r', $date)."\r\n".
+            'Date: '.$date->format('r')."\r\n".
             'Subject: just a test subject'."\r\n".
             'From: Chris Corbyn <chris.corbyn@swiftmailer.org>'."\r\n".
             'MIME-Version: 1.0'."\r\n".
@@ -275,7 +276,7 @@ class Swift_Mime_SimpleMessageAcceptanceTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(
             'Sender: chris.corbyn@swiftmailer.org'."\r\n".
             'Message-ID: <'.$id.'>'."\r\n".
-            'Date: '.date('r', $date)."\r\n".
+            'Date: '.$date->format('r')."\r\n".
             'Subject: just a test subject'."\r\n".
             'From: '."\r\n".
             'MIME-Version: 1.0'."\r\n".
@@ -295,7 +296,7 @@ class Swift_Mime_SimpleMessageAcceptanceTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(
             'Sender: Chris <chris.corbyn@swiftmailer.org>'."\r\n".
             'Message-ID: <'.$id.'>'."\r\n".
-            'Date: '.date('r', $date)."\r\n".
+            'Date: '.$date->format('r')."\r\n".
             'Subject: just a test subject'."\r\n".
             'From: '."\r\n".
             'MIME-Version: 1.0'."\r\n".
@@ -315,7 +316,7 @@ class Swift_Mime_SimpleMessageAcceptanceTest extends \PHPUnit_Framework_TestCase
         $date = $message->getDate();
         $this->assertEquals(
             'Message-ID: <'.$id.'>'."\r\n".
-            'Date: '.date('r', $date)."\r\n".
+            'Date: '.$date->format('r')."\r\n".
             'Subject: just a test subject'."\r\n".
             'From: Chris <chris.corbyn@swiftmailer.org>'."\r\n".
             'Reply-To: Myself <chris@w3style.co.uk>'."\r\n".
@@ -339,7 +340,7 @@ class Swift_Mime_SimpleMessageAcceptanceTest extends \PHPUnit_Framework_TestCase
         $date = $message->getDate();
         $this->assertEquals(
             'Message-ID: <'.$id.'>'."\r\n".
-            'Date: '.date('r', $date)."\r\n".
+            'Date: '.$date->format('r')."\r\n".
             'Subject: just a test subject'."\r\n".
             'From: Chris <chris.corbyn@swiftmailer.org>'."\r\n".
             'Reply-To: Myself <chris@w3style.co.uk>, Me <my.other@address.com>'."\r\n".
@@ -364,7 +365,7 @@ class Swift_Mime_SimpleMessageAcceptanceTest extends \PHPUnit_Framework_TestCase
         $date = $message->getDate();
         $this->assertEquals(
             'Message-ID: <'.$id.'>'."\r\n".
-            'Date: '.date('r', $date)."\r\n".
+            'Date: '.$date->format('r')."\r\n".
             'Subject: just a test subject'."\r\n".
             'From: Chris <chris.corbyn@swiftmailer.org>'."\r\n".
             'Reply-To: Myself <chris@w3style.co.uk>, Me <my.other@address.com>'."\r\n".
@@ -392,7 +393,7 @@ class Swift_Mime_SimpleMessageAcceptanceTest extends \PHPUnit_Framework_TestCase
         $date = $message->getDate();
         $this->assertEquals(
             'Message-ID: <'.$id.'>'."\r\n".
-            'Date: '.date('r', $date)."\r\n".
+            'Date: '.$date->format('r')."\r\n".
             'Subject: just a test subject'."\r\n".
             'From: Chris <chris.corbyn@swiftmailer.org>'."\r\n".
             'Reply-To: Myself <chris@w3style.co.uk>, Me <my.other@address.com>'."\r\n".
@@ -421,7 +422,7 @@ class Swift_Mime_SimpleMessageAcceptanceTest extends \PHPUnit_Framework_TestCase
         $date = $message->getDate();
         $this->assertEquals(
             'Message-ID: <'.$id.'>'."\r\n".
-            'Date: '.date('r', $date)."\r\n".
+            'Date: '.$date->format('r')."\r\n".
             'Subject: just a test subject'."\r\n".
             'From: Chris <chris.corbyn@swiftmailer.org>'."\r\n".
             'Reply-To: Myself <chris@w3style.co.uk>, Me <my.other@address.com>'."\r\n".
@@ -454,7 +455,7 @@ class Swift_Mime_SimpleMessageAcceptanceTest extends \PHPUnit_Framework_TestCase
         $date = $message->getDate();
         $this->assertEquals(
             'Message-ID: <'.$id.'>'."\r\n".
-            'Date: '.date('r', $date)."\r\n".
+            'Date: '.$date->format('r')."\r\n".
             'Subject: just a test subject'."\r\n".
             'From: Chris <chris.corbyn@swiftmailer.org>'."\r\n".
             'Reply-To: Myself <chris@w3style.co.uk>, Me <my.other@address.com>'."\r\n".
@@ -490,7 +491,7 @@ class Swift_Mime_SimpleMessageAcceptanceTest extends \PHPUnit_Framework_TestCase
         $date = $message->getDate();
         $this->assertEquals(
             'Message-ID: <'.$id.'>'."\r\n".
-            'Date: '.date('r', $date)."\r\n".
+            'Date: '.$date->format('r')."\r\n".
             'Subject: just a test subject'."\r\n".
             'From: Chris <chris.corbyn@swiftmailer.org>'."\r\n".
             'Reply-To: Myself <chris@w3style.co.uk>, Me <my.other@address.com>'."\r\n".
@@ -527,7 +528,7 @@ class Swift_Mime_SimpleMessageAcceptanceTest extends \PHPUnit_Framework_TestCase
         $date = $message->getDate();
         $this->assertEquals(
             'Message-ID: <'.$id.'>'."\r\n".
-            'Date: '.date('r', $date)."\r\n".
+            'Date: '.$date->format('r')."\r\n".
             'Subject: just a test subject'."\r\n".
             'From: Chris <chris.corbyn@swiftmailer.org>'."\r\n".
             'Reply-To: Myself <chris@w3style.co.uk>, Me <my.other@address.com>'."\r\n".
@@ -557,7 +558,7 @@ class Swift_Mime_SimpleMessageAcceptanceTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(
             'Return-Path: <chris@w3style.co.uk>'."\r\n".
             'Message-ID: <'.$id.'>'."\r\n".
-            'Date: '.date('r', $date)."\r\n".
+            'Date: '.$date->format('r')."\r\n".
             'Subject: just a test subject'."\r\n".
             'From: Chris Corbyn <chris.corbyn@swiftmailer.org>'."\r\n".
             'MIME-Version: 1.0'."\r\n".
@@ -586,7 +587,7 @@ class Swift_Mime_SimpleMessageAcceptanceTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(
             'Return-Path: <chris@w3style.co.uk>'."\r\n".
             'Message-ID: <'.$id.'>'."\r\n".
-            'Date: '.date('r', $date)."\r\n".
+            'Date: '.$date->format('r')."\r\n".
             'Subject: just a test subject'."\r\n".
             'From: Chris Corbyn <chris.corbyn@swiftmailer.org>'."\r\n".
             'MIME-Version: 1.0'."\r\n".
@@ -628,7 +629,7 @@ class Swift_Mime_SimpleMessageAcceptanceTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(
             'Return-Path: <chris@w3style.co.uk>'."\r\n".
             'Message-ID: <'.$id.'>'."\r\n".
-            'Date: '.date('r', $date)."\r\n".
+            'Date: '.$date->format('r')."\r\n".
             'Subject: just a test subject'."\r\n".
             'From: Chris Corbyn <chris.corbyn@swiftmailer.org>'."\r\n".
             'MIME-Version: 1.0'."\r\n".
@@ -661,7 +662,7 @@ class Swift_Mime_SimpleMessageAcceptanceTest extends \PHPUnit_Framework_TestCase
             'chris.corbyn@swiftmailer.org' => 'Chris Corbyn', ));
 
         $id = $message->getId();
-        $date = preg_quote(date('r', $message->getDate()), '~');
+        $date = preg_quote($message->getDate()->format('r'), '~');
         $boundary = $message->getBoundary();
 
         $part = $this->createMimePart();
@@ -723,7 +724,7 @@ class Swift_Mime_SimpleMessageAcceptanceTest extends \PHPUnit_Framework_TestCase
             'chris.corbyn@swiftmailer.org' => 'Chris Corbyn', ));
 
         $id = $message->getId();
-        $date = preg_quote(date('r', $message->getDate()), '~');
+        $date = preg_quote($message->getDate()->format('r'), '~');
         $boundary = $message->getBoundary();
 
         $part = $this->createMimePart();
@@ -809,7 +810,7 @@ class Swift_Mime_SimpleMessageAcceptanceTest extends \PHPUnit_Framework_TestCase
             'chris.corbyn@swiftmailer.org' => 'Chris Corbyn', ));
 
         $id = $message->getId();
-        $date = preg_quote(date('r', $message->getDate()), '~');
+        $date = preg_quote($message->getDate()->format('r'), '~');
         $boundary = $message->getBoundary();
 
         $attachment = $this->createAttachment();
@@ -886,7 +887,7 @@ class Swift_Mime_SimpleMessageAcceptanceTest extends \PHPUnit_Framework_TestCase
             'chris.corbyn@swiftmailer.org' => 'Chris Corbyn', ));
 
         $id = $message->getId();
-        $date = preg_quote(date('r', $message->getDate()), '~');
+        $date = preg_quote($message->getDate()->format('r'), '~');
         $boundary = $message->getBoundary();
 
         $part = $this->createMimePart();
@@ -984,7 +985,7 @@ class Swift_Mime_SimpleMessageAcceptanceTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(
             'Return-Path: <chris@w3style.co.uk>'."\r\n".
             'Message-ID: <'.$id.'>'."\r\n".
-            'Date: '.date('r', $date)."\r\n".
+            'Date: '.$date->format('r')."\r\n".
             'Subject: just a test subject'."\r\n".
             'From: Chris Corbyn <chris.corbyn@swiftmailer.org>'."\r\n".
             'MIME-Version: 1.0'."\r\n".
@@ -1027,7 +1028,7 @@ class Swift_Mime_SimpleMessageAcceptanceTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(
             'Return-Path: <chris@w3style.co.uk>'."\r\n".
             'Message-ID: <'.$id.'>'."\r\n".
-            'Date: '.date('r', $date)."\r\n".
+            'Date: '.$date->format('r')."\r\n".
             'Subject: just a test subject'."\r\n".
             'From: Chris Corbyn <chris.corbyn@swiftmailer.org>'."\r\n".
             'MIME-Version: 1.0'."\r\n".
@@ -1063,7 +1064,7 @@ class Swift_Mime_SimpleMessageAcceptanceTest extends \PHPUnit_Framework_TestCase
         $message->setBody('foo');
 
         $id = $message->getId();
-        $date = date('r', $message->getDate());
+        $date = $message->getDate()->format('r');
         $boundary = $message->getBoundary();
 
         $attachment = $this->createAttachment();
@@ -1110,7 +1111,7 @@ class Swift_Mime_SimpleMessageAcceptanceTest extends \PHPUnit_Framework_TestCase
             'chris.corbyn@swiftmailer.org' => 'Chris Corbyn', ));
 
         $id = $message->getId();
-        $date = date('r', $message->getDate());
+        $date = $message->getDate()->format('r');
         $boundary = $message->getBoundary();
 
         $part1 = $this->createMimePart();
@@ -1162,7 +1163,7 @@ class Swift_Mime_SimpleMessageAcceptanceTest extends \PHPUnit_Framework_TestCase
         $message->setBody('foo');
 
         $id = $message->getId();
-        $date = date('r', $message->getDate());
+        $date = $message->getDate()->format('r');
         $boundary = $message->getBoundary();
 
         $part2 = $this->createMimePart();
@@ -1214,7 +1215,7 @@ class Swift_Mime_SimpleMessageAcceptanceTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(
             'Return-Path: <chris@w3style.co.uk>'."\r\n".
             'Message-ID: <'.$id.'>'."\r\n".
-            'Date: '.date('r', $date)."\r\n".
+            'Date: '.$date->format('r')."\r\n".
             'Subject: just a test subject'."\r\n".
             'From: Chris Corbyn <chris.corbyn@swiftmailer.org>'."\r\n".
             'MIME-Version: 1.0'."\r\n".

--- a/tests/bug/Swift/Bug34Test.php
+++ b/tests/bug/Swift/Bug34Test.php
@@ -25,7 +25,7 @@ class Swift_Bug34Test extends \PHPUnit_Framework_TestCase
         $message->setSender(array('other@domain.tld' => 'Other'));
 
         $id = $message->getId();
-        $date = preg_quote(date('r', $message->getDate()), '~');
+        $date = preg_quote($message->getDate()->format('r'), '~');
         $boundary = $message->getBoundary();
         $cidVal = $image->getId();
 

--- a/tests/bug/Swift/Bug35Test.php
+++ b/tests/bug/Swift/Bug35Test.php
@@ -25,7 +25,7 @@ class Swift_Bug35Test extends \PHPUnit_Framework_TestCase
         $message->setSender(array('other@domain.tld' => 'Other'));
 
         $id = $message->getId();
-        $date = preg_quote(date('r', $message->getDate()), '~');
+        $date = preg_quote($message->getDate()->format('r'), '~');
         $boundary = $message->getBoundary();
 
         $this->assertRegExp(

--- a/tests/bug/Swift/Bug38Test.php
+++ b/tests/bug/Swift/Bug38Test.php
@@ -28,7 +28,7 @@ class Swift_Bug38Test extends \PHPUnit_Framework_TestCase
         $message->setBody('HTML part', 'text/html');
 
         $id = $message->getId();
-        $date = preg_quote(date('r', $message->getDate()), '~');
+        $date = preg_quote($message->getDate()->format('r'), '~');
         $boundary = $message->getBoundary();
         $imgId = $image->getId();
 
@@ -82,7 +82,7 @@ class Swift_Bug38Test extends \PHPUnit_Framework_TestCase
         $message->setBody('HTML part', 'text/html');
 
         $id = $message->getId();
-        $date = preg_quote(date('r', $message->getDate()), '~');
+        $date = preg_quote($message->getDate()->format('r'), '~');
         $boundary = $message->getBoundary();
         $imgId = $image->getId();
 
@@ -140,7 +140,7 @@ class Swift_Bug38Test extends \PHPUnit_Framework_TestCase
         $message->setBody('HTML part', 'text/html');
 
         $id = $message->getId();
-        $date = preg_quote(date('r', $message->getDate()), '~');
+        $date = preg_quote($message->getDate()->format('r'), '~');
         $boundary = $message->getBoundary();
 
         $streamA = new Swift_ByteStream_ArrayByteStream();

--- a/tests/unit/Swift/Mime/Headers/DateHeaderTest.php
+++ b/tests/unit/Swift/Mime/Headers/DateHeaderTest.php
@@ -12,52 +12,73 @@ class Swift_Mime_Headers_DateHeaderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(Swift_Mime_Header::TYPE_DATE, $header->getFieldType());
     }
 
-    public function testGetTimestamp()
+    public function testGetDateTime()
     {
-        $timestamp = time();
+        $dateTime = new DateTimeImmutable();
         $header = $this->getHeader('Date');
-        $header->setTimestamp($timestamp);
-        $this->assertSame($timestamp, $header->getTimestamp());
+        $header->setDateTime($dateTime);
+        $this->assertSame($dateTime, $header->getDateTime());
     }
 
-    public function testTimestampCanBeSetBySetter()
+    public function testDateTimeCanBeSetBySetter()
     {
-        $timestamp = time();
+        $dateTime = new DateTimeImmutable();
         $header = $this->getHeader('Date');
-        $header->setTimestamp($timestamp);
-        $this->assertSame($timestamp, $header->getTimestamp());
+        $header->setDateTime($dateTime);
+        $this->assertSame($dateTime, $header->getDateTime());
     }
 
-    public function testIntegerTimestampIsConvertedToRfc2822Date()
+    public function testDateTimeIsConvertedToImmutable()
     {
-        $timestamp = time();
+        $dateTime = new DateTime();
         $header = $this->getHeader('Date');
-        $header->setTimestamp($timestamp);
-        $this->assertEquals(date('r', $timestamp), $header->getFieldBody());
+        $header->setDateTime($dateTime);
+        $this->assertInstanceOf('DateTimeImmutable', $header->getDateTime());
+        $this->assertEquals($dateTime->getTimestamp(), $header->getDateTime()->getTimestamp());
+        $this->assertEquals($dateTime->getTimezone(), $header->getDateTime()->getTimezone());
+    }
+
+    public function testDateTimeIsImmutable()
+    {
+        $dateTime = new DateTime('2000-01-01 12:00:00 Europe/Berlin');
+        $header = $this->getHeader('Date');
+        $header->setDateTime($dateTime);
+
+        $dateTime->setDate(2002, 2, 2);
+        $this->assertEquals('Sat, 01 Jan 2000 12:00:00 +0100', $header->getDateTime()->format('r'));
+        $this->assertEquals('Sat, 01 Jan 2000 12:00:00 +0100', $header->getFieldBody());
+    }
+
+    public function testDateTimeIsConvertedToRfc2822Date()
+    {
+        $dateTime = new DateTimeImmutable('2000-01-01 12:00:00 Europe/Berlin');
+        $header = $this->getHeader('Date');
+        $header->setDateTime($dateTime);
+        $this->assertEquals('Sat, 01 Jan 2000 12:00:00 +0100', $header->getFieldBody());
     }
 
     public function testSetBodyModel()
     {
-        $timestamp = time();
+        $dateTime = new DateTimeImmutable();
         $header = $this->getHeader('Date');
-        $header->setFieldBodyModel($timestamp);
-        $this->assertEquals(date('r', $timestamp), $header->getFieldBody());
+        $header->setFieldBodyModel($dateTime);
+        $this->assertEquals($dateTime->format('r'), $header->getFieldBody());
     }
 
     public function testGetBodyModel()
     {
-        $timestamp = time();
+        $dateTime = new DateTimeImmutable();
         $header = $this->getHeader('Date');
-        $header->setTimestamp($timestamp);
-        $this->assertEquals($timestamp, $header->getFieldBodyModel());
+        $header->setDateTime($dateTime);
+        $this->assertEquals($dateTime, $header->getFieldBodyModel());
     }
 
     public function testToString()
     {
-        $timestamp = time();
+        $dateTime = new DateTimeImmutable('2000-01-01 12:00:00 Europe/Berlin');
         $header = $this->getHeader('Date');
-        $header->setTimestamp($timestamp);
-        $this->assertEquals('Date: '.date('r', $timestamp)."\r\n",
+        $header->setDateTime($dateTime);
+        $this->assertEquals("Date: Sat, 01 Jan 2000 12:00:00 +0100\r\n",
             $header->toString()
             );
     }

--- a/tests/unit/Swift/Mime/SimpleHeaderFactoryTest.php
+++ b/tests/unit/Swift/Mime/SimpleHeaderFactoryTest.php
@@ -45,8 +45,9 @@ class Swift_Mime_SimpleHeaderFactoryTest extends \PHPUnit_Framework_TestCase
 
     public function testDateHeaderHasCorrectModel()
     {
-        $header = $this->factory->createDateHeader('X-Date', 123);
-        $this->assertEquals(123, $header->getFieldBodyModel());
+        $dateTime = new \DateTimeImmutable();
+        $header = $this->factory->createDateHeader('X-Date', $dateTime);
+        $this->assertEquals($dateTime, $header->getFieldBodyModel());
     }
 
     public function testTextHeaderHasCorrectType()

--- a/tests/unit/Swift/Mime/SimpleHeaderSetTest.php
+++ b/tests/unit/Swift/Mime/SimpleHeaderSetTest.php
@@ -16,14 +16,16 @@ class Swift_Mime_SimpleHeaderSetTest extends \PHPUnit_Framework_TestCase
 
     public function testAddDateHeaderDelegatesToFactory()
     {
+        $dateTime = new DateTimeImmutable();
+
         $factory = $this->createFactory();
         $factory->expects($this->once())
                 ->method('createDateHeader')
-                ->with('Date', 1234)
+                ->with('Date', $dateTime)
                 ->will($this->returnValue($this->createHeader('Date')));
 
         $set = $this->createSet($factory);
-        $set->addDateHeader('Date', 1234);
+        $set->addDateHeader('Date', $dateTime);
     }
 
     public function testAddTextHeaderDelegatesToFactory()
@@ -97,14 +99,16 @@ class Swift_Mime_SimpleHeaderSetTest extends \PHPUnit_Framework_TestCase
 
     public function testAddedDateHeaderIsSeenByHas()
     {
+        $dateTime = new DateTimeImmutable();
+
         $factory = $this->createFactory();
         $factory->expects($this->once())
                 ->method('createDateHeader')
-                ->with('Date', 1234)
+                ->with('Date', $dateTime)
                 ->will($this->returnValue($this->createHeader('Date')));
 
         $set = $this->createSet($factory);
-        $set->addDateHeader('Date', 1234);
+        $set->addDateHeader('Date', $dateTime);
         $this->assertTrue($set->has('Date'));
     }
 

--- a/tests/unit/Swift/Mime/SimpleMessageTest.php
+++ b/tests/unit/Swift/Mime/SimpleMessageTest.php
@@ -21,20 +21,24 @@ class Swift_Mime_SimpleMessageTest extends Swift_Mime_MimePartTest
 
     public function testDateIsReturnedFromHeader()
     {
-        $date = $this->createHeader('Date', 123);
+        $dateTime = new DateTimeImmutable();
+
+        $date = $this->createHeader('Date', $dateTime);
         $message = $this->createMessage(
             $this->createHeaderSet(array('Date' => $date)),
             $this->createEncoder(), $this->createCache()
             );
-        $this->assertEquals(123, $message->getDate());
+        $this->assertEquals($dateTime, $message->getDate());
     }
 
     public function testDateIsSetInHeader()
     {
-        $date = $this->createHeader('Date', 123, array(), false);
+        $dateTime = new DateTimeImmutable();
+
+        $date = $this->createHeader('Date', new DateTimeImmutable(), array(), false);
         $date->shouldReceive('setFieldBodyModel')
              ->once()
-             ->with(1234);
+             ->with($dateTime);
         $date->shouldReceive('setFieldBodyModel')
              ->zeroOrMoreTimes();
 
@@ -42,22 +46,24 @@ class Swift_Mime_SimpleMessageTest extends Swift_Mime_MimePartTest
             $this->createHeaderSet(array('Date' => $date)),
             $this->createEncoder(), $this->createCache()
             );
-        $message->setDate(1234);
+        $message->setDate($dateTime);
     }
 
     public function testDateHeaderIsCreatedIfNonePresent()
     {
+        $dateTime = new DateTimeImmutable();
+
         $headers = $this->createHeaderSet(array(), false);
         $headers->shouldReceive('addDateHeader')
                 ->once()
-                ->with('Date', 1234);
+                ->with('Date', $dateTime);
         $headers->shouldReceive('addDateHeader')
                 ->zeroOrMoreTimes();
 
         $message = $this->createMessage($headers, $this->createEncoder(),
             $this->createCache()
             );
-        $message->setDate(1234);
+        $message->setDate($dateTime);
     }
 
     public function testDateHeaderIsAddedDuringConstruction()
@@ -65,7 +71,7 @@ class Swift_Mime_SimpleMessageTest extends Swift_Mime_MimePartTest
         $headers = $this->createHeaderSet(array(), false);
         $headers->shouldReceive('addDateHeader')
                 ->once()
-                ->with('Date', '/^[0-9]+$/D');
+                ->with('Date', Mockery::type('DateTimeImmutable'));
 
         $message = $this->createMessage($headers, $this->createEncoder(),
             $this->createCache()
@@ -796,7 +802,7 @@ class Swift_Mime_SimpleMessageTest extends Swift_Mime_MimePartTest
             ->setFormat('flowed')
             ->setDelSp(false)
             ->setSubject('subj')
-            ->setDate(123)
+            ->setDate(new DateTimeImmutable())
             ->setReturnPath('foo@bar')
             ->setSender('foo@bar')
             ->setFrom(array('x@y' => 'XY'))


### PR DESCRIPTION
Representing a Date header with a DateTimeInterface object seems more obvious than a current Unix timestamp.

I suggest using DateTimeImmutable internally and automatically converting (mutable) DateTime instances supplied by the user. This prevents changing the value with breaking the cache inside Swift_Mime_Headers_AbstractHeader.
