### PR TITLE
Escape command-line args to Sendmail

### DIFF
--- a/lib/classes/Swift/Transport/MailTransport.php
+++ b/lib/classes/Swift/Transport/MailTransport.php
@@ -164,7 +164,7 @@ class Swift_Transport_MailTransport implements Swift_Transport
         }
 
         if ($this->_invoker->mail($to, $subject, $body, $headers,
-            sprintf($this->_extraParams, $reversePath))) {
+            sprintf($this->_extraParams, escapeshellarg($reversePath)))) {
             if ($evt) {
                 $evt->setResult(Swift_Events_SendEvent::RESULT_SUCCESS);
                 $evt->setFailedRecipients($failedRecipients);


### PR DESCRIPTION
As reported in #520, we should escape command-line arguments. It is sufficient to escape the email address, not the entire $_extraParams string.