### PR TITLE
Only add soft line break when necessary

### DIFF
--- a/lib/classes/Swift/Encoder/QpEncoder.php
+++ b/lib/classes/Swift/Encoder/QpEncoder.php
@@ -198,14 +198,25 @@ class Swift_Encoder_QpEncoder implements Swift_Encoder
             }
 
             $enc = $this->_encodeByteSequence($bytes, $size);
-            if ($currentLine && $lineLen + $size >= $thisLineLength) {
+
+            $i = strpos($enc, '=0D=0A');
+            $newLineLength = $lineLen + ($i === false ? $size : $i);
+
+            if ($currentLine && $newLineLength >= $thisLineLength) {
                 $lines[$lNo] = '';
                 $currentLine = &$lines[$lNo++];
                 $thisLineLength = $maxLineLength;
                 $lineLen = 0;
             }
-            $lineLen += $size;
+
             $currentLine .= $enc;
+
+            if ($i === false) {
+                $lineLen += $size;
+            } else {
+                // 6 is the length of '=0D=0A'.
+                $lineLen = $size - strrpos($enc, '=0D=0A') - 6;
+            }
         }
 
         return $this->_standardize(implode("=\r\n", $lines));

--- a/lib/classes/Swift/Mime/ContentEncoder/QpContentEncoder.php
+++ b/lib/classes/Swift/Mime/ContentEncoder/QpContentEncoder.php
@@ -95,15 +95,26 @@ class Swift_Mime_ContentEncoder_QpContentEncoder extends Swift_Encoder_QpEncoder
             }
 
             $enc = $this->_encodeByteSequence($bytes, $size);
-            if ($currentLine && $lineLen + $size >= $thisLineLength) {
+
+            $i = strpos($enc, '=0D=0A');
+            $newLineLength = $lineLen + ($i === false ? $size : $i);
+
+            if ($currentLine && $newLineLength >= $thisLineLength) {
                 $is->write($prepend.$this->_standardize($currentLine));
                 $currentLine = '';
                 $prepend = "=\r\n";
                 $thisLineLength = $maxLineLength;
                 $lineLen = 0;
             }
-            $lineLen += $size;
+
             $currentLine .= $enc;
+
+            if ($i === false) {
+                $lineLen += $size;
+            } else {
+                // 6 is the length of '=0D=0A'.
+                $lineLen = $size - strrpos($enc, '=0D=0A') - 6;
+            }
         }
         if (strlen($currentLine)) {
             $is->write($prepend.$this->_standardize($currentLine));

--- a/tests/acceptance/Swift/Encoder/QpEncoderAcceptanceTest.php
+++ b/tests/acceptance/Swift/Encoder/QpEncoderAcceptanceTest.php
@@ -36,6 +36,10 @@ class Swift_Encoder_QpEncoderAcceptanceTest extends \PHPUnit_Framework_TestCase
                     $text = file_get_contents($sampleDir.'/'.$sampleFile);
                     $encodedText = $encoder->encodeString($text);
 
+                    foreach (explode("\r\n", $encodedText) as $line) {
+                        $this->assertLessThanOrEqual(76, strlen($line));
+                    }
+
                     $this->assertEquals(
                         quoted_printable_decode($encodedText), $text,
                         '%s: Encoded string should decode back to original string for sample '.

--- a/tests/unit/Swift/Encoder/QpEncoderTest.php
+++ b/tests/unit/Swift/Encoder/QpEncoderTest.php
@@ -372,10 +372,31 @@ class Swift_Encoder_QpEncoderTest extends \SwiftMailerTestCase
             );
     }
 
+    public function testTextIsPreWrapped()
+    {
+        $encoder = $this->createEncoder();
+
+        $input = str_repeat('a', 70)."\r\n".
+                 str_repeat('a', 70)."\r\n".
+                 str_repeat('a', 70);
+
+        $this->assertEquals(
+            $input, $encoder->encodeString($input)
+            );
+    }
+
     // -- Creation methods
 
     private function _createCharStream()
     {
         return $this->getMockery('Swift_CharacterStream')->shouldIgnoreMissing();
+    }
+
+    private function createEncoder()
+    {
+        $factory = new Swift_CharacterReaderFactory_SimpleCharacterReaderFactory();
+        $charStream = new Swift_CharacterStream_NgCharacterStream($factory, 'utf-8');
+
+        return new Swift_Encoder_QpEncoder($charStream);
     }
 }

--- a/tests/unit/Swift/Mime/ContentEncoder/QpContentEncoderTest.php
+++ b/tests/unit/Swift/Mime/ContentEncoder/QpContentEncoderTest.php
@@ -472,6 +472,25 @@ class Swift_Mime_ContentEncoder_QpContentEncoderTest extends \SwiftMailerTestCas
         $encoder->charsetChanged('windows-1252');
     }
 
+    public function testTextIsPreWrapped()
+    {
+        $encoder = $this->createEncoder();
+
+        $input = str_repeat('a', 70)."\r\n".
+                 str_repeat('a', 70)."\r\n".
+                 str_repeat('a', 70);
+
+        $os = new Swift_ByteStream_ArrayByteStream();
+        $is = new Swift_ByteStream_ArrayByteStream();
+        $is->write($input);
+
+        $encoder->encodeByteStream($is, $os);
+
+        $this->assertEquals(
+            $input, $os->read(PHP_INT_MAX)
+            );
+    }
+
     // -- Creation Methods
 
     private function _createCharacterStream($stub = false)
@@ -479,9 +498,12 @@ class Swift_Mime_ContentEncoder_QpContentEncoderTest extends \SwiftMailerTestCas
         return $this->getMockery('Swift_CharacterStream')->shouldIgnoreMissing();
     }
 
-    private function _createEncoder($charStream)
+    private function createEncoder()
     {
-        return new Swift_Mime_HeaderEncoder_QpHeaderEncoder($charStream);
+        $factory = new Swift_CharacterReaderFactory_SimpleCharacterReaderFactory();
+        $charStream = new Swift_CharacterStream_NgCharacterStream($factory, 'utf-8');
+
+        return new Swift_Mime_ContentEncoder_QpContentEncoder($charStream);
     }
 
     private function _createOutputByteStream($stub = false)


### PR DESCRIPTION
In quoted-printable encoding, the encoding lines should not exceed 76 characters. If there are longer lines in the source text, a soft line break should be added.

It is only necessary to add soft line breaks when a line in the source exceeds 76 characters. However, Swift_Encoder_QpEncoder and Swift_Mime_ContentEncoder_QpContentEncoder add soft line breaks every 76 character, ignoring any line breaks already present in the source.

This behaviour does not violate the spec, but it makes the encoded text harder to read with the human eye. Of course most people don't do this, but it is annoying when debugging, or when using a very primitive mail reader. One of the design goals of quoted-printable is to make the encoded text human-readable (unlike base64 encoding).

With this PR, the line length counter is reset every time a line break is encountered in the source text.

The change is implemented symmetrically for QpEncoder and QpContentEncoder. However, I did not add a change to QpContentEncoderAcceptanceTest similar to that made to QpEncoderAcceptanceTest,   because that revealed another bug, #620.