### PR TITLE
changed hhvm-nightly to hhvm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: php
 php:
   - 5.5
   - 5.6
-  - hhvm-nightly
+  - hhvm
 
 before_script:
     - cp tests/acceptance.conf.php.default tests/acceptance.conf.php
@@ -19,5 +19,5 @@ script:
 matrix:
   allow_failures:
     - php: 5.6
-    - php: hhvm-nightly
+    - php: hhvm
   fast_finish: true


### PR DESCRIPTION
as per https://travis-ci.org/swiftmailer/swiftmailer/jobs/70777435
`HHVM nightly is no longer supported on Ubuntu Precise. See https://github.com/travis-ci/travis-ci/issues/3788 and https://github.com/facebook/hhvm/issues/5220`