### PR TITLE
Pass charsetChanged() call to the safeEncoder

### DIFF
--- a/lib/classes/Swift/Mime/ContentEncoder/QpContentEncoderProxy.php
+++ b/lib/classes/Swift/Mime/ContentEncoder/QpContentEncoderProxy.php
@@ -61,6 +61,7 @@ class Swift_Mime_ContentEncoder_QpContentEncoderProxy implements Swift_Mime_Cont
     public function charsetChanged($charset)
     {
         $this->charset = $charset;
+        $this->safeEncoder->charsetChanged($charset);
     }
 
     /**


### PR DESCRIPTION
As mentioned in issue #645 we've created a fix to pass the charsetChanged call over to the safeEncoder.