### PR TITLE
Fixing crlf for subject using mail

### DIFF
--- a/lib/classes/Swift/Transport/MailTransport.php
+++ b/lib/classes/Swift/Transport/MailTransport.php
@@ -156,10 +156,12 @@ class Swift_Transport_MailTransport implements Swift_Transport
         if ("\r\n" != PHP_EOL) {
             // Non-windows (not using SMTP)
             $headers = str_replace("\r\n", PHP_EOL, $headers);
+            $subject = str_replace("\r\n", PHP_EOL, $subject);
             $body = str_replace("\r\n", PHP_EOL, $body);
         } else {
             // Windows, using SMTP
             $headers = str_replace("\r\n.", "\r\n..", $headers);
+            $subject = str_replace("\r\n.", "\r\n..", $subject);
             $body = str_replace("\r\n.", "\r\n..", $body);
         }
 

--- a/tests/unit/Swift/Transport/MailTransportTest.php
+++ b/tests/unit/Swift/Transport/MailTransportTest.php
@@ -259,7 +259,7 @@ class Swift_Transport_MailTransportTest extends \SwiftMailerTestCase
 		$subject->shouldReceive('getFieldBody')->andReturn("Foo\r\nBar");
 
 		$headers = $this->_createHeaders(array(
-			'Subject' => $subject
+			'Subject' => $subject,
 		));
 		$message = $this->_createMessage($headers);
 		$message->shouldReceive('toString')


### PR DESCRIPTION
The line endings get fixed for headers and body, but without the subject. That breaks subjects wich are too long. Especially when they contain quoted printables