### PR TITLE
Fix - Consecutive read calls in Swift_ByteStream_FileByteStream should have the same behaviour

### DIFF
--- a/lib/classes/Swift/ByteStream/FileByteStream.php
+++ b/lib/classes/Swift/ByteStream/FileByteStream.php
@@ -139,11 +139,13 @@ class Swift_ByteStream_FileByteStream extends Swift_ByteStream_AbstractFilterabl
     private function getReadHandle()
     {
         if (!isset($this->reader)) {
-            if (!$this->reader = fopen($this->path, 'rb')) {
+            $pointer = @fopen($this->path, 'rb');
+            if (!$pointer) {
                 throw new Swift_IoException(
                     'Unable to open file for reading ['.$this->path.']'
                 );
             }
+            $this->reader = $pointer;
             if ($this->offset != 0) {
                 $this->getReadStreamSeekableStatus();
                 $this->seekReadStreamToPosition($this->offset);

--- a/tests/bug/Swift/BugFileByteStreamConsecutiveReadCallsTest.php
+++ b/tests/bug/Swift/BugFileByteStreamConsecutiveReadCallsTest.php
@@ -1,0 +1,19 @@
+<?php
+
+
+class Swift_FileByteStreamConsecutiveReadCalls extends  \PHPUnit_Framework_TestCase
+{
+    /**
+     * @test
+     * @expectedException \Swift_IoException
+     */
+    public function shouldThrowExceptionOnConsecutiveRead()
+    {
+        $fbs = new \Swift_ByteStream_FileByteStream('tralala');
+        try {
+            $fbs->read(100);
+        } catch (\Swift_IoException $exc) {
+            $fbs->read(100);
+        }
+    }
+}


### PR DESCRIPTION
On first read method call with not successful fopen, return value from fopen is assigned to reader and exception is thrown.
For example: if exception is catched, on another read call on this object exception is not thrown because false is assigned to reader and this value is returned.