### PR TITLE
Adjustments for handling an IPv6 socket.

### DIFF
--- a/lib/classes/Swift/Transport/AbstractSmtpTransport.php
+++ b/lib/classes/Swift/Transport/AbstractSmtpTransport.php
@@ -462,17 +462,18 @@ abstract class Swift_Transport_AbstractSmtpTransport implements Swift_Transport
     private function _lookupHostname()
     {
         if (!empty($_SERVER['SERVER_NAME'])
-            && $this->_isFqdn($_SERVER['SERVER_NAME'])) {
+            && $this->_isFqdn($_SERVER['SERVER_NAME'])
+        ) {
             $this->_domain = $_SERVER['SERVER_NAME'];
         } elseif (!empty($_SERVER['SERVER_ADDR'])) {
             // Set the address literal tag (See RFC 5321, section: 4.1.3)
-            if (strpos($_SERVER['SERVER_ADDR'], ':') === False) {
-                $tag = ''; // IPv4 addresses are not tagged.
+            if (false === strpos($_SERVER['SERVER_ADDR'], ':')) {
+                $prefix = ''; // IPv4 addresses are not tagged.
             } else {
-                $tag = 'IPv6:'; // Add prefix in case of IPv6.
+                $prefix = 'IPv6:'; // Adding prefix in case of IPv6.
             }
 
-            $this->_domain = sprintf('[%s%s]', $tag, $_SERVER['SERVER_ADDR']);
+            $this->_domain = sprintf('[%s%s]', $prefix, $_SERVER['SERVER_ADDR']);
         }
     }
 

--- a/lib/classes/Swift/Transport/AbstractSmtpTransport.php
+++ b/lib/classes/Swift/Transport/AbstractSmtpTransport.php
@@ -465,7 +465,14 @@ abstract class Swift_Transport_AbstractSmtpTransport implements Swift_Transport
             && $this->_isFqdn($_SERVER['SERVER_NAME'])) {
             $this->_domain = $_SERVER['SERVER_NAME'];
         } elseif (!empty($_SERVER['SERVER_ADDR'])) {
-            $this->_domain = sprintf('[%s]', $_SERVER['SERVER_ADDR']);
+            // Set the address literal tag (See RFC 5321, section: 4.1.3)
+            if (strpos($_SERVER['SERVER_ADDR'], ':') === False) {
+                $tag = ''; // IPv4 addresses are not tagged.
+            } else {
+                $tag = 'IPv6:'; // Add prefix in case of IPv6.
+            }
+
+            $this->_domain = sprintf('[%s%s]', $tag, $_SERVER['SERVER_ADDR']);
         }
     }
 


### PR DESCRIPTION
While resolving to IPv6, SwiftMailer produce malformed SMTP commands eg: "HELO [::1]".
According to following SMTP RFC "IPv6:" a tag is needed:
https://tools.ietf.org/html/rfc5321#section-4.1.3
The System should send "HELO [IPv6:::1]", then both mail server will be able to communicate.
As of now, whenever system uses an IPv6 address literal in the HELO command, it sends a malformed command. IPv4 mail servers are handling it, while IPv6 aren't.