### PR TITLE
fix removing a header in SimpleHeaderSet

### DIFF
--- a/lib/classes/Swift/Mime/SimpleHeaderSet.php
+++ b/lib/classes/Swift/Mime/SimpleHeaderSet.php
@@ -232,7 +232,12 @@ class Swift_Mime_SimpleHeaderSet implements Swift_Mime_HeaderSet
     public function remove($name, $index = 0)
     {
         $lowerName = strtolower($name);
-        unset($this->_headers[$lowerName][$index]);
+        if (array_key_exists($lowerName, $this->_headers)) {
+            array_splice($this->_headers[$lowerName], $index, 1);
+            if (empty($this->_headers[$lowerName])) {
+                $this->removeAll($lowerName);
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
I got an unexpected result from my code (attachments and S/MIME encryption+signing): There were multiple Content-Transfer-Encoding headers.

Multiple Content-Transfer-Encoding headers are added. When calling remove() one time, the has() function does return false, because it checked for index 0 by default which does not exist. The problem is PHP's unset() function, which does not update indices.

I'm far from an expert, so sorry If my assumption of this behavior being wrong is premature and indeed expected.