### PR TITLE
use LF instead of CRLF for wider compatibility

### DIFF
--- a/lib/classes/Swift/Mime/Headers/AbstractHeader.php
+++ b/lib/classes/Swift/Mime/Headers/AbstractHeader.php
@@ -393,7 +393,7 @@ abstract class Swift_Mime_Headers_AbstractHeader implements Swift_Mime_Header
             }
         }
 
-        return implode("\r\n ", $encodedTextLines);
+        return implode("\n ", $encodedTextLines);
     }
 
     /**

--- a/tests/unit/Swift/Mime/Headers/UnstructuredHeaderTest.php
+++ b/tests/unit/Swift/Mime/Headers/UnstructuredHeaderTest.php
@@ -236,8 +236,8 @@ class Swift_Mime_Headers_UnstructuredHeaderTest extends \SwiftMailerTestCase
         $header->setValue($nonAsciiChar);
 
         $this->assertEquals(
-            'X-Test: =?'.$this->_charset.'?Q?line_one_here?='."\r\n".
-            ' =?'.$this->_charset.'?Q?line_two_here?='."\r\n",
+            'X-Test: =?'.$this->_charset.'?Q?line_one_here?='."\n".
+            ' =?'.$this->_charset.'?Q?line_two_here?='."\n",
             $header->toString()
             );
     }


### PR DESCRIPTION
* fixes #393 
* fails with postfix on CentOS 6 otherwise

Fix is from #549 - Hopefully fix the tests that are failing in #549