### PR TITLE
Update RedirectingPlugin.php

### DIFF
--- a/lib/classes/Swift/Plugins/RedirectingPlugin.php
+++ b/lib/classes/Swift/Plugins/RedirectingPlugin.php
@@ -20,14 +20,14 @@ class Swift_Plugins_RedirectingPlugin implements Swift_Events_SendListener
      *
      * @var mixed
      */
-    private $_recipient;
+    protected $_recipient;
 
     /**
      * List of regular expression for recipient whitelisting.
      *
      * @var array
      */
-    private $_whitelist = array();
+    protected $_whitelist = array();
 
     /**
      * Create a new RedirectingPlugin.


### PR DESCRIPTION
When extending the class method ``_isWhitelisted`` there is no access to ``$this->_recipient`` or ``$this->_whitelist`` so it might be good to make the local properties protected.