### PR TITLE
bug #723 fixed php mail extra params on missing from, sender or returnPath

### DIFF
--- a/lib/classes/Swift/Transport/MailTransport.php
+++ b/lib/classes/Swift/Transport/MailTransport.php
@@ -166,7 +166,7 @@ class Swift_Transport_MailTransport implements Swift_Transport
         }
 
         if ($this->_invoker->mail($to, $subject, $body, $headers,
-            sprintf($this->_extraParams, escapeshellarg($reversePath)))) {
+            $this->_formatExtraParams($this->_extraParams, $reversePath))) {
             if ($evt) {
                 $evt->setResult(Swift_Events_SendEvent::RESULT_SUCCESS);
                 $evt->setFailedRecipients($failedRecipients);
@@ -235,5 +235,22 @@ class Swift_Transport_MailTransport implements Swift_Transport
         }
 
         return $path;
+    }
+
+    /**
+     * Return php mail extra params to use for invoker->mail
+     *
+     * @param $extraParams
+     * @param $reversePath
+     * @return mixed <string|null>
+     */
+    private function _formatExtraParams($extraParams, $reversePath)
+    {
+        if (strpos($extraParams, '-f%s') !== false) {
+            $extraParams = empty($reversePath)
+                         ? str_replace('-f%s', '', $extraParams)
+                         : sprintf($extraParams, escapeshellarg($reversePath));
+        }
+        return !empty($extraParams) ? $extraParams : null;
     }
 }

--- a/tests/unit/Swift/Transport/MailTransportTest.php
+++ b/tests/unit/Swift/Transport/MailTransportTest.php
@@ -84,6 +84,108 @@ class Swift_Transport_MailTransportTest extends \SwiftMailerTestCase
         $transport->send($message);
     }
 
+    public function testTransportSettingUsingReturnPathForExtraParams()
+    {
+        $invoker = $this->_createInvoker();
+        $dispatcher = $this->_createEventDispatcher();
+        $transport = $this->_createTransport($invoker, $dispatcher);
+
+        $headers = $this->_createHeaders();
+        $message = $this->_createMessage($headers);
+
+        $message->shouldReceive('getReturnPath')
+             ->zeroOrMoreTimes()
+             ->andReturn(
+                "foo@bar"
+             );
+        $invoker->shouldReceive('mail')
+                ->once()
+                ->with(\Mockery::any(), \Mockery::any(), \Mockery::any(), \Mockery::any(), '-f\'foo@bar\'');
+
+        $transport->send($message);
+    }
+
+    public function testTransportSettingEmptyExtraParams()
+    {
+        $invoker = $this->_createInvoker();
+        $dispatcher = $this->_createEventDispatcher();
+        $transport = $this->_createTransport($invoker, $dispatcher);
+
+        $headers = $this->_createHeaders();
+        $message = $this->_createMessage($headers);
+
+        $message->shouldReceive('getReturnPath')
+            ->zeroOrMoreTimes()
+            ->andReturn(null);
+        $message->shouldReceive('getSender')
+            ->zeroOrMoreTimes()
+            ->andReturn(null);
+        $message->shouldReceive('getFrom')
+            ->zeroOrMoreTimes()
+            ->andReturn(null);
+        $invoker->shouldReceive('mail')
+            ->once()
+            ->with(\Mockery::any(), \Mockery::any(), \Mockery::any(), \Mockery::any(), null);
+
+        $transport->send($message);
+    }
+
+    public function testTransportSettingSettingExtraParamsWithF()
+    {
+        $invoker = $this->_createInvoker();
+        $dispatcher = $this->_createEventDispatcher();
+        $transport = $this->_createTransport($invoker, $dispatcher);
+        $transport->setExtraParams('-x\'foo\' -f%s');
+
+        $headers = $this->_createHeaders();
+        $message = $this->_createMessage($headers);
+
+        $message->shouldReceive('getReturnPath')
+            ->zeroOrMoreTimes()
+            ->andReturn(
+                    "foo@bar"
+                );
+        $message->shouldReceive('getSender')
+            ->zeroOrMoreTimes()
+            ->andReturn(null);
+        $message->shouldReceive('getFrom')
+            ->zeroOrMoreTimes()
+            ->andReturn(null);
+        $invoker->shouldReceive('mail')
+            ->once()
+            ->with(\Mockery::any(), \Mockery::any(), \Mockery::any(), \Mockery::any(), '-x\'foo\' -f\'foo@bar\'');
+
+        $transport->send($message);
+    }
+
+    public function testTransportSettingSettingExtraParamsWithoutF()
+    {
+        $invoker = $this->_createInvoker();
+        $dispatcher = $this->_createEventDispatcher();
+        $transport = $this->_createTransport($invoker, $dispatcher);
+        $transport->setExtraParams('-x\'foo\'');
+
+        $headers = $this->_createHeaders();
+        $message = $this->_createMessage($headers);
+
+        $message->shouldReceive('getReturnPath')
+            ->zeroOrMoreTimes()
+            ->andReturn(
+                "foo@bar"
+            );
+        $message->shouldReceive('getSender')
+            ->zeroOrMoreTimes()
+            ->andReturn(null);
+        $message->shouldReceive('getFrom')
+            ->zeroOrMoreTimes()
+            ->andReturn(null);
+        $invoker->shouldReceive('mail')
+            ->once()
+            ->with(\Mockery::any(), \Mockery::any(), \Mockery::any(), \Mockery::any(), '-x\'foo\'');
+
+        $transport->send($message);
+    }
+
     public function testTransportUsesHeadersFromMessage()
     {
         $invoker = $this->_createInvoker();
@@ -94,15 +196,15 @@ class Swift_Transport_MailTransportTest extends \SwiftMailerTestCase
         $message = $this->_createMessage($headers);
 
         $message->shouldReceive('toString')
-             ->zeroOrMoreTimes()
-             ->andReturn(
+            ->zeroOrMoreTimes()
+            ->andReturn(
                 "Subject: Stuff\r\n".
                 "\r\n".
                 'This body'
-             );
+            );
         $invoker->shouldReceive('mail')
-                ->once()
-                ->with(\Mockery::any(), \Mockery::any(), \Mockery::any(), 'Subject: Stuff'.PHP_EOL, \Mockery::any());
+            ->once()
+            ->with(\Mockery::any(), \Mockery::any(), \Mockery::any(), 'Subject: Stuff'.PHP_EOL, \Mockery::any());
 
         $transport->send($message);
     }


### PR DESCRIPTION
Fix for issue #723 
Check reversePath before adding extraParams to php mail.