### PR TITLE
convert encryption protocol value to lower case

### DIFF
--- a/lib/classes/Swift/Transport/EsmtpTransport.php
+++ b/lib/classes/Swift/Transport/EsmtpTransport.php
@@ -140,6 +140,10 @@ class Swift_Transport_EsmtpTransport extends Swift_Transport_AbstractSmtpTranspo
      */
     public function setEncryption($encryption)
     {
+        if (is_string($encryption)) {
+            $encryption = strtolower($encryption);    
+        }
+        
         if ('tls' == $encryption) {
             $this->_params['protocol'] = 'tcp';
             $this->_params['tls'] = true;

--- a/lib/classes/Swift/Transport/EsmtpTransport.php
+++ b/lib/classes/Swift/Transport/EsmtpTransport.php
@@ -143,7 +143,7 @@ class Swift_Transport_EsmtpTransport extends Swift_Transport_AbstractSmtpTranspo
         if (is_string($encryption)) {
             $encryption = strtolower($encryption);    
         }
-        
+
         if ('tls' == $encryption) {
             $this->_params['protocol'] = 'tcp';
             $this->_params['tls'] = true;


### PR DESCRIPTION
I spent the whole day could not understand why I am unable to send mail and I get the next error
`Connection could not be established with host smtp.yandex.ru [Unable to find the socket transport "SSL" - did you forget to enable it when you configured PHP? #1]`
I soon realized that the Protocol specify the encryption systems in the upper register. I was very pleasantly surprised that no one has foreseen such a possibility. So I decided to fix it