### PR TITLE
Removed getmypid function

### DIFF
--- a/lib/classes/Swift/Mime/SimpleMimeEntity.php
+++ b/lib/classes/Swift/Mime/SimpleMimeEntity.php
@@ -80,7 +80,7 @@ class Swift_Mime_SimpleMimeEntity implements Swift_Mime_MimeEntity
      */
     public function __construct(Swift_Mime_HeaderSet $headers, Swift_Mime_ContentEncoder $encoder, Swift_KeyCache $cache, Swift_Mime_Grammar $grammar)
     {
-        $this->_cacheKey = md5(uniqid(getmypid().mt_rand(), true));
+        $this->_cacheKey = md5(uniqid(mt_rand(), true));
         $this->_cache = $cache;
         $this->_headers = $headers;
         $this->_grammar = $grammar;
@@ -409,7 +409,7 @@ class Swift_Mime_SimpleMimeEntity implements Swift_Mime_MimeEntity
     public function getBoundary()
     {
         if (!isset($this->_boundary)) {
-            $this->_boundary = '_=_swift_v4_'.time().'_'.md5(getmypid().mt_rand().uniqid('', true)).'_=_';
+            $this->_boundary = '_=_swift_v4_'.time().'_'.md5(uniqid(mt_rand(), true)).'_=_';
         }
 
         return $this->_boundary;
@@ -672,7 +672,7 @@ class Swift_Mime_SimpleMimeEntity implements Swift_Mime_MimeEntity
      */
     protected function getRandomId()
     {
-        $idLeft = md5(getmypid().'.'.time().'.'.uniqid(mt_rand(), true));
+        $idLeft = md5(time().'.'.uniqid(mt_rand(), true));
         $idRight = !empty($_SERVER['SERVER_NAME']) ? $_SERVER['SERVER_NAME'] : 'swift.generated';
         $id = $idLeft.'@'.$idRight;
 


### PR DESCRIPTION
It's removed in previous commit https://github.com/swiftmailer/swiftmailer/commit/84ff290871c3436c3703ce15ec5e344da0b59472
refs #445

But reverted back due to boundary length limit 
https://github.com/swiftmailer/swiftmailer/commit/84ff290871c3436c3703ce15ec5e344da0b59472#commitcomment-8746773

However, the issue which is mentioned in #445 is still there. So, I removed getmypid function and left the hash algorithm as md5