### PR TITLE
Fix constructing of Swift_LoadBalancedTransport

### DIFF
--- a/lib/classes/Swift/Transport/LoadBalancedTransport.php
+++ b/lib/classes/Swift/Transport/LoadBalancedTransport.php
@@ -37,6 +37,13 @@ class Swift_Transport_LoadBalancedTransport implements Swift_Transport
     protected $_lastUsedTransport = null;
 
     /**
+     * Constructor.
+     */
+    public function __construct()
+    {
+    }
+
+    /**
      * Set $transports to delegate to.
      *
      * @param Swift_Transport[] $transports


### PR DESCRIPTION
Class LoadBalancedTransport for constructing uses call_user_func_array which calls Swift_Transport_LoadBalancedTransport::__construct but Swift_Transport_LoadBalancedTransport class does not have explicitly defined constructor which causes PHP Warning in php 7 .
https://github.com/swiftmailer/swiftmailer/blob/5.x/lib/classes/Swift/LoadBalancedTransport.php#L25

Adding Swift_Transport_LoadBalancedTransport::__construct fixes this issue.