### PR TITLE
Can't use Swift_Transport_FailoverTransport because it no longer has a constructor.

### DIFF
--- a/lib/classes/Swift/Transport/FailoverTransport.php
+++ b/lib/classes/Swift/Transport/FailoverTransport.php
@@ -21,7 +21,7 @@ class Swift_Transport_FailoverTransport extends Swift_Transport_LoadBalancedTran
      * @var Swift_Transport
      */
     private $_currentTransport;
-    
+
     /**
      * Creates a new FailoverTransport.		
      */		

--- a/lib/classes/Swift/Transport/FailoverTransport.php
+++ b/lib/classes/Swift/Transport/FailoverTransport.php
@@ -21,6 +21,14 @@ class Swift_Transport_FailoverTransport extends Swift_Transport_LoadBalancedTran
      * @var Swift_Transport
      */
     private $_currentTransport;
+    
+    /**
+     * Creates a new FailoverTransport.		
+     */		
+    public function __construct()		
+    {		
+        parent::__construct();		
+    }
 
     /**
      * Send the given Message.


### PR DESCRIPTION
When using `Swift_FailoverTransport::newInstance($transports);`, it no longer works because the failover transport no longer has a __construct, and Swift_FailoverTransport [tries to call it](https://github.com/swiftmailer/swiftmailer/blob/5.x/lib/classes/Swift/FailoverTransport.php#L26).

This happened in the ["[Swift] various dead code cleanups, simplifications and phpdoc fixes"](https://github.com/swiftmailer/swiftmailer/commit/dae3bc6c530b86bcaca97ff2cf171b43328d569d) commit.