### PR TITLE
Add a return value description to Swift_Mailer::send method

### DIFF
--- a/lib/classes/Swift/Mailer.php
+++ b/lib/classes/Swift/Mailer.php
@@ -69,7 +69,7 @@ class Swift_Mailer
      * @param Swift_Mime_Message $message
      * @param array              $failedRecipients An array of failures by-reference
      *
-     * @return int
+     * @return int The number of successful recipients. Can be 0 which indicates failure
      */
     public function send(Swift_Mime_Message $message, &$failedRecipients = null)
     {


### PR DESCRIPTION
I was trying to figure out what are the possible return types for send method, and send method PHPDoc was not helpful at all. I had to go through documentation and look for that, but it would be so much easier if the comment was a little bit more descriptive.

**Feature**: Add a description for Swift_Mailer::send method return type.

I hope this PR will help people like me and will save someone those precious couple of minutes