### PR TITLE
Fix Travis Build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ before_script:
     - cp tests/smoke.conf.php.default tests/smoke.conf.php
     - composer self-update
     - composer update --no-interaction --prefer-source
+    - gem install mime-types -v 2.99.1
     - gem install mailcatcher
     - mailcatcher --smtp-port 4456
 


### PR DESCRIPTION
The mailcatcher gem has a dependency that tries to install mime-types>=3 and needs Ruby >= 2.0. Travis bails out due to the Ruby Version. This PR should fix this.