### PR TITLE
Add Swift_Transport::ping()

### DIFF
--- a/lib/classes/Swift/Transport.php
+++ b/lib/classes/Swift/Transport.php
@@ -33,6 +33,29 @@ interface Swift_Transport
     public function stop();
 
     /**
+     * Check if this Transport mechanism is alive.
+     *
+     * If a Transport mechanism session is no longer functional, the method
+     * returns FALSE. It is the responsibility of the developer to handle this
+     * case and restart the Transport mechanism manually.
+     *
+     * @example
+     *
+     *   if (!$transport->ping()) {
+     *      $transport->stop();
+     *      $transport->start();
+     *   }
+     *
+     * The Transport mechanism will be started, if it is not already.
+     *
+     * It is undefined if the Transport mechanism attempts to restart as long as
+     * the return value reflects whether the mechanism is now functional.
+     *
+     * @return bool TRUE if the transport is alive
+     */
+    public function ping();
+
+    /**
      * Send the given Message.
      *
      * Recipient/sender data will be retrieved from the Message API.

--- a/lib/classes/Swift/Transport/AbstractSmtpTransport.php
+++ b/lib/classes/Swift/Transport/AbstractSmtpTransport.php
@@ -231,6 +231,47 @@ abstract class Swift_Transport_AbstractSmtpTransport implements Swift_Transport
     }
 
     /**
+     * Check if this Transport mechanism is alive.
+     *
+     * If a Transport mechanism session is no longer functional, the method
+     * returns FALSE. It is the responsibility of the developer to handle this
+     * case and restart the Transport mechanism manually.
+     *
+     * @example
+     *
+     *   if (!$transport->ping()) {
+     *      $transport->stop();
+     *      $transport->start();
+     *   }
+     *
+     * The Transport mechanism will be started, if it is not already.
+     *
+     * It is undefined if the Transport mechanism attempts to restart as long as
+     * the return value reflects whether the mechanism is now functional.
+     *
+     * @return bool TRUE if the transport is alive
+     */
+    public function ping()
+    {
+        try {
+            if (!$this->isStarted()) {
+                $this->start();
+            }
+
+            $this->executeCommand("NOOP\r\n", array(250));
+        } catch (Swift_TransportException $e) {
+            try {
+                $this->stop();
+            } catch (Swift_TransportException $e) {
+            }
+
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
      * Register a plugin.
      *
      * @param Swift_Events_EventListener $plugin

--- a/lib/classes/Swift/Transport/FailoverTransport.php
+++ b/lib/classes/Swift/Transport/FailoverTransport.php
@@ -29,6 +29,42 @@ class Swift_Transport_FailoverTransport extends Swift_Transport_LoadBalancedTran
     }
 
     /**
+     * Check if this Transport mechanism is alive.
+     *
+     * If a Transport mechanism session is no longer functional, the method
+     * returns FALSE. It is the responsibility of the developer to handle this
+     * case and restart the Transport mechanism manually.
+     *
+     * @example
+     *
+     *   if (!$transport->ping()) {
+     *      $transport->stop();
+     *      $transport->start();
+     *   }
+     *
+     * The Transport mechanism will be started, if it is not already.
+     *
+     * It is undefined if the Transport mechanism attempts to restart as long as
+     * the return value reflects whether the mechanism is now functional.
+     *
+     * @return bool TRUE if the transport is alive
+     */
+    public function ping()
+    {
+        $maxTransports = count($this->transports);
+        for ($i = 0; $i < $maxTransports
+            && $transport = $this->getNextTransport(); ++$i) {
+            if ($transport->ping()) {
+                return true;
+            } else {
+                $this->killCurrentTransport();
+            }
+        }
+
+        return count($this->transports) > 0;
+    }
+
+    /**
      * Send the given Message.
      *
      * Recipient/sender data will be retrieved from the Message API.

--- a/lib/classes/Swift/Transport/LoadBalancedTransport.php
+++ b/lib/classes/Swift/Transport/LoadBalancedTransport.php
@@ -101,6 +101,38 @@ class Swift_Transport_LoadBalancedTransport implements Swift_Transport
     }
 
     /**
+     * Check if this Transport mechanism is alive.
+     *
+     * If a Transport mechanism session is no longer functional, the method
+     * returns FALSE. It is the responsibility of the developer to handle this
+     * case and restart the Transport mechanism manually.
+     *
+     * @example
+     *
+     *   if (!$transport->ping()) {
+     *      $transport->stop();
+     *      $transport->start();
+     *   }
+     *
+     * The Transport mechanism will be started, if it is not already.
+     *
+     * It is undefined if the Transport mechanism attempts to restart as long as
+     * the return value reflects whether the mechanism is now functional.
+     *
+     * @return bool TRUE if the transport is alive
+     */
+    public function ping()
+    {
+        foreach ($this->transports as $transport) {
+            if (!$transport->ping()) {
+                $this->killCurrentTransport();
+            }
+        }
+
+        return count($this->transports) > 0;
+    }
+
+    /**
      * Send the given Message.
      *
      * Recipient/sender data will be retrieved from the Message API.

--- a/lib/classes/Swift/Transport/MailTransport.php
+++ b/lib/classes/Swift/Transport/MailTransport.php
@@ -62,6 +62,32 @@ class Swift_Transport_MailTransport implements Swift_Transport
     }
 
     /**
+     * Check if this Transport mechanism is alive.
+     *
+     * If a Transport mechanism session is no longer functional, the method
+     * returns FALSE. It is the responsibility of the developer to handle this
+     * case and restart the Transport mechanism manually.
+     *
+     * @example
+     *
+     *   if (!$transport->ping()) {
+     *      $transport->stop();
+     *      $transport->start();
+     *   }
+     *
+     * The Transport mechanism will be started, if it is not already.
+     *
+     * It is undefined if the Transport mechanism attempts to restart as long as
+     * the return value reflects whether the mechanism is now functional.
+     *
+     * @return bool TRUE if the transport is alive
+     */
+    public function ping()
+    {
+        return true;
+    }
+
+    /**
      * Set the additional parameters used on the mail() function.
      *
      * This string is formatted for sprintf() where %s is the sender address.

--- a/lib/classes/Swift/Transport/NullTransport.php
+++ b/lib/classes/Swift/Transport/NullTransport.php
@@ -51,6 +51,32 @@ class Swift_Transport_NullTransport implements Swift_Transport
     }
 
     /**
+     * Check if this Transport mechanism is alive.
+     *
+     * If a Transport mechanism session is no longer functional, the method
+     * returns FALSE. It is the responsibility of the developer to handle this
+     * case and restart the Transport mechanism manually.
+     *
+     * @example
+     *
+     *   if (!$transport->ping()) {
+     *      $transport->stop();
+     *      $transport->start();
+     *   }
+     *
+     * The Transport mechanism will be started, if it is not already.
+     *
+     * It is undefined if the Transport mechanism attempts to restart as long as
+     * the return value reflects whether the mechanism is now functional.
+     *
+     * @return bool TRUE if the transport is alive
+     */
+    public function ping()
+    {
+        return true;
+    }
+
+    /**
      * Sends the given message.
      *
      * @param Swift_Mime_Message $message

--- a/lib/classes/Swift/Transport/SpoolTransport.php
+++ b/lib/classes/Swift/Transport/SpoolTransport.php
@@ -79,6 +79,32 @@ class Swift_Transport_SpoolTransport implements Swift_Transport
     }
 
     /**
+     * Check if this Transport mechanism is alive.
+     *
+     * If a Transport mechanism session is no longer functional, the method
+     * returns FALSE. It is the responsibility of the developer to handle this
+     * case and restart the Transport mechanism manually.
+     *
+     * @example
+     *
+     *   if (!$transport->ping()) {
+     *      $transport->stop();
+     *      $transport->start();
+     *   }
+     *
+     * The Transport mechanism will be started, if it is not already.
+     *
+     * It is undefined if the Transport mechanism attempts to restart as long as
+     * the return value reflects whether the mechanism is now functional.
+     *
+     * @return bool TRUE if the transport is alive
+     */
+    public function ping()
+    {
+        return true;
+    }
+
+    /**
      * Sends the given message.
      *
      * @param Swift_Mime_Message $message

--- a/tests/unit/Swift/Transport/AbstractSmtpTest.php
+++ b/tests/unit/Swift/Transport/AbstractSmtpTest.php
@@ -1174,6 +1174,53 @@ abstract class Swift_Transport_AbstractSmtpTest extends \SwiftMailerTestCase
         $smtp->send($message);
     }
 
+    public function testPing()
+    {
+        $buf = $this->getBuffer();
+        $smtp = $this->getTransport($buf);
+
+        $buf->shouldReceive('initialize')
+            ->once();
+        $buf->shouldReceive('readLine')
+            ->once()
+            ->with(0)
+            ->andReturn("220 some.server.tld bleh\r\n");
+        $buf->shouldReceive('write')
+            ->once()
+            ->with('~^NOOP\r\n$~D')
+            ->andReturn(1);
+        $buf->shouldReceive('readLine')
+            ->once()
+            ->with(1)
+            ->andReturn('250 OK'."\r\n");
+
+        $this->finishBuffer($buf);
+        $this->assertTrue($smtp->ping());
+    }
+
+    public function testPingOnDeadConnection()
+    {
+        $buf = $this->getBuffer();
+        $smtp = $this->getTransport($buf);
+
+        $buf->shouldReceive('initialize')
+            ->once();
+        $buf->shouldReceive('readLine')
+            ->once()
+            ->with(0)
+            ->andReturn("220 some.server.tld bleh\r\n");
+        $buf->shouldReceive('write')
+            ->once()
+            ->with('~^NOOP\r\n$~D')
+            ->andThrow('Swift_TransportException');
+
+        $this->finishBuffer($buf);
+        $smtp->start();
+        $this->assertTrue($smtp->isStarted());
+        $this->assertFalse($smtp->ping());
+        $this->assertFalse($smtp->isStarted());
+    }
+
     protected function getBuffer()
     {
         return $this->getMockery('Swift_Transport_IoBuffer')->shouldIgnoreMissing();


### PR DESCRIPTION
I have a long-running PHP job that occasionally sends email.

Unless I explicitly stop the SMTP connection after each use, the SMTP server may eventually close the connection if it has not been used for an extended period. This will make the next send() operation throw an exception.

This patch adds a ping() method similar to that in [Doctrine\DBAL\Connection::ping()](https://github.com/doctrine/dbal/blob/master/lib/Doctrine/DBAL/Connection.php#L1560).

Apart from the addition of ping() to the Swift_Transport interface, this change is backwards compatible and can be merged into the current release branch.
