### PR TITLE
Fix tests failing on PHP7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,5 @@ matrix:
         - php: 7.0
         - php: hhvm
     allow_failures:
-        - php: 7.0
         - php: hhvm
     fast_finish: true

--- a/lib/classes/Swift/CharacterReader/GenericFixedWidthReader.php
+++ b/lib/classes/Swift/CharacterReader/GenericFixedWidthReader.php
@@ -48,7 +48,7 @@ class Swift_CharacterReader_GenericFixedWidthReader implements Swift_CharacterRe
         $strlen = strlen($string);
         // % and / are CPU intensive, so, maybe find a better way
         $ignored = $strlen % $this->_width;
-        $ignoredChars = substr($string, -$ignored);
+        $ignoredChars = $ignored ? substr($string, -$ignored) : '';
         $currentMap = $this->_width;
 
         return ($strlen - $ignored) / $this->_width;

--- a/lib/classes/Swift/CharacterStream/NgCharacterStream.php
+++ b/lib/classes/Swift/CharacterStream/NgCharacterStream.php
@@ -215,7 +215,7 @@ class Swift_CharacterStream_NgCharacterStream implements Swift_CharacterStream
      *
      * @param int $length
      *
-     * @return integer[]
+     * @return int[]
      */
     public function readBytes($length)
     {

--- a/tests/acceptance/Swift/Mime/ContentEncoder/QpContentEncoderAcceptanceTest.php
+++ b/tests/acceptance/Swift/Mime/ContentEncoder/QpContentEncoderAcceptanceTest.php
@@ -11,6 +11,11 @@ class Swift_Mime_ContentEncoder_QpContentEncoderAcceptanceTest extends \PHPUnit_
         $this->_factory = new Swift_CharacterReaderFactory_SimpleCharacterReaderFactory();
     }
 
+    public function tearDown()
+    {
+        Swift_Preferences::getInstance()->setQPDotEscape(false);
+    }
+
     public function testEncodingAndDecodingSamples()
     {
         $sampleFp = opendir($this->_samplesDir);
@@ -144,8 +149,6 @@ class Swift_Mime_ContentEncoder_QpContentEncoderAcceptanceTest extends \PHPUnit_
         // Enable DotEscaping
         Swift_Preferences::getInstance()->setQPDotEscape(true);
         $this->testEncodingAndDecodingSamplesFromDiConfiguredInstance();
-        // Disable DotStuffing to continue
-        Swift_Preferences::getInstance()->setQPDotEscape(false);
     }
 
     private function _createEncoderFromContainer()

--- a/tests/unit/Swift/Events/SimpleEventDispatcherTest.php
+++ b/tests/unit/Swift/Events/SimpleEventDispatcherTest.php
@@ -87,7 +87,7 @@ class Swift_Events_SimpleEventDispatcherTest extends \PHPUnit_Framework_TestCase
         $evt = $this->_dispatcher->createSendEvent($transport, $message);
 
         $targetListener = $this->getMock('Swift_Events_SendListener');
-        $otherListener = $this->getMock('Swift_Events_TransportChangeListener');
+        $otherListener = $this->getMock('DummyListener');
 
         $this->_dispatcher->bindEventListener($targetListener);
         $this->_dispatcher->bindEventListener($otherListener);
@@ -131,5 +131,12 @@ class Swift_Events_SimpleEventDispatcherTest extends \PHPUnit_Framework_TestCase
     private function _createDispatcher(array $map)
     {
         return new Swift_Events_SimpleEventDispatcher($map);
+    }
+}
+
+class DummyListener implements Swift_Events_EventListener
+{
+    public function sendPerformed(Swift_Events_SendEvent $evt)
+    {
     }
 }


### PR DESCRIPTION
With these changes, the test suite runs without errors on PHP7.

The change in Swift_CharacterStream_NgCharacterStream is due to this BC break: https://bugs.php.net/bug.php?id=69931