### PR TITLE
Dependency-inject idRight into IdGenerator

### DIFF
--- a/lib/classes/Swift/Mime/IdGenerator.php
+++ b/lib/classes/Swift/Mime/IdGenerator.php
@@ -8,27 +8,17 @@
  * file that was distributed with this source code.
  */
 
-use Egulias\EmailValidator\EmailValidator;
-
 /**
  * Message ID generator.
  */
 class Swift_Mime_IdGenerator implements Swift_IdGenerator
 {
     /**
-     * @param EmailValidator $emailValidator
-     * @param string|null    $idRight
+     * @param string $idRight
      */
-    public function __construct(EmailValidator $emailValidator, $idRight = null)
+    public function __construct($idRight)
     {
-        if ($idRight) {
-            $this->idRight = $idRight;
-        } else {
-            $this->idRight = !empty($_SERVER['SERVER_NAME']) ? $_SERVER['SERVER_NAME'] : 'swift.generated';
-            if (!$emailValidator->isValid('dummy@'.$this->idRight)) {
-                $this->idRight = 'swift.generated';
-            }
-        }
+        $this->idRight = $idRight;
     }
 
     /**

--- a/lib/dependency_maps/mime_deps.php
+++ b/lib/dependency_maps/mime_deps.php
@@ -9,10 +9,13 @@ Swift_DependencyContainer::getInstance()
     ->register('email.validator')
     ->asSharedInstanceOf('Egulias\EmailValidator\EmailValidator')
 
+    ->register('mime.idgenerator.idright')
+    ->asValue(!empty($_SERVER['SERVER_NAME']) ? $_SERVER['SERVER_NAME'] : 'swift.generated')
+
     ->register('mime.idgenerator')
     ->asSharedInstanceOf('Swift_Mime_IdGenerator')
     ->withDependencies(array(
-        'email.validator',
+        'mime.idgenerator.idright',
     ))
 
     ->register('mime.message')

--- a/tests/acceptance/Swift/Mime/AttachmentAcceptanceTest.php
+++ b/tests/acceptance/Swift/Mime/AttachmentAcceptanceTest.php
@@ -24,7 +24,7 @@ class Swift_Mime_AttachmentAcceptanceTest extends \PHPUnit_Framework_TestCase
             new Swift_CharacterStream_ArrayCharacterStream($factory, 'utf-8')
             );
         $this->emailValidator = new EmailValidator();
-        $this->idGenerator = new Swift_Mime_IdGenerator($this->emailValidator);
+        $this->idGenerator = new Swift_Mime_IdGenerator('example.com');
         $this->headers = new Swift_Mime_SimpleHeaderSet(
             new Swift_Mime_SimpleHeaderFactory($headerEncoder, $paramEncoder, $this->emailValidator)
             );

--- a/tests/acceptance/Swift/Mime/EmbeddedFileAcceptanceTest.php
+++ b/tests/acceptance/Swift/Mime/EmbeddedFileAcceptanceTest.php
@@ -24,7 +24,7 @@ class Swift_Mime_EmbeddedFileAcceptanceTest extends \PHPUnit_Framework_TestCase
             new Swift_CharacterStream_ArrayCharacterStream($factory, 'utf-8')
             );
         $this->emailValidator = new EmailValidator();
-        $this->idGenerator = new Swift_Mime_IdGenerator($this->emailValidator);
+        $this->idGenerator = new Swift_Mime_IdGenerator('example.com');
         $this->headers = new Swift_Mime_SimpleHeaderSet(
             new Swift_Mime_SimpleHeaderFactory($headerEncoder, $paramEncoder, $this->emailValidator)
             );

--- a/tests/acceptance/Swift/Mime/MimePartAcceptanceTest.php
+++ b/tests/acceptance/Swift/Mime/MimePartAcceptanceTest.php
@@ -30,7 +30,7 @@ class Swift_Mime_MimePartAcceptanceTest extends \PHPUnit_Framework_TestCase
             new Swift_CharacterStream_ArrayCharacterStream($factory, 'utf-8')
             );
         $this->emailValidator = new EmailValidator();
-        $this->idGenerator = new Swift_Mime_IdGenerator($this->emailValidator);
+        $this->idGenerator = new Swift_Mime_IdGenerator('example.com');
         $this->headers = new Swift_Mime_SimpleHeaderSet(
             new Swift_Mime_SimpleHeaderFactory($headerEncoder, $paramEncoder, $this->emailValidator)
             );

--- a/tests/unit/Swift/Mime/AttachmentTest.php
+++ b/tests/unit/Swift/Mime/AttachmentTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use Egulias\EmailValidator\EmailValidator;
 
 class Swift_Mime_AttachmentTest extends Swift_Mime_AbstractMimeEntityTest
 {
@@ -293,7 +292,7 @@ class Swift_Mime_AttachmentTest extends Swift_Mime_AbstractMimeEntityTest
 
     protected function createAttachment($headers, $encoder, $cache, $mimeTypes = array())
     {
-        $idGenerator = new Swift_Mime_IdGenerator(new EmailValidator());
+        $idGenerator = new Swift_Mime_IdGenerator('example.com');
 
         return new Swift_Mime_Attachment($headers, $encoder, $cache, $idGenerator, $mimeTypes);
     }

--- a/tests/unit/Swift/Mime/EmbeddedFileTest.php
+++ b/tests/unit/Swift/Mime/EmbeddedFileTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use Egulias\EmailValidator\EmailValidator;
 
 class Swift_Mime_EmbeddedFileTest extends Swift_Mime_AttachmentTest
 {
@@ -54,7 +53,7 @@ class Swift_Mime_EmbeddedFileTest extends Swift_Mime_AttachmentTest
 
     private function createEmbeddedFile($headers, $encoder, $cache)
     {
-        $idGenerator = new Swift_Mime_IdGenerator(new EmailValidator());
+        $idGenerator = new Swift_Mime_IdGenerator('example.com');
 
         return new Swift_Mime_EmbeddedFile($headers, $encoder, $cache, $idGenerator);
     }

--- a/tests/unit/Swift/Mime/IdGeneratorTest.php
+++ b/tests/unit/Swift/Mime/IdGeneratorTest.php
@@ -7,52 +7,9 @@ class Swift_Mime_IdGeneratorTest extends \PHPUnit_Framework_TestCase
     protected $emailValidator;
     protected $originalServerName;
 
-    public function setUp()
-    {
-        $this->emailValidator = new EmailValidator();
-        $this->originalServerName = isset($_SERVER['SERVER_NAME']) ? $_SERVER['SERVER_NAME'] : null;
-        unset($_SERVER['SERVER_NAME']);
-    }
-
-    public function tearDown()
-    {
-        // Restore super-global variable.
-        if (isset($this->originalServerName)) {
-            $_SERVER['SERVER_NAME'] = $this->originalServerName;
-        } else {
-            unset($_SERVER['SERVER_NAME']);
-        }
-    }
-
-    public function testIdGeneratorServerName()
-    {
-        $_SERVER['SERVER_NAME'] = 'example.com';
-        $idGenerator = new Swift_Mime_IdGenerator($this->emailValidator);
-        $this->assertEquals('example.com', $idGenerator->getIdRight());
-    }
-
-    public function testIdGeneratorInvalidServerName()
-    {
-        $_SERVER['SERVER_NAME'] = 'not a valid hostname';
-        $idGenerator = new Swift_Mime_IdGenerator($this->emailValidator);
-        $this->assertEquals('swift.generated', $idGenerator->getIdRight());
-    }
-
-    public function testIdGeneratorFallback()
-    {
-        $idGenerator = new Swift_Mime_IdGenerator($this->emailValidator);
-        $this->assertEquals('swift.generated', $idGenerator->getIdRight());
-    }
-
-    public function testIdGeneratorExplicit()
-    {
-        $idGenerator = new Swift_Mime_IdGenerator($this->emailValidator, 'example.net');
-        $this->assertEquals('example.net', $idGenerator->getIdRight());
-    }
-
     public function testIdGeneratorSetRightId()
     {
-        $idGenerator = new Swift_Mime_IdGenerator($this->emailValidator, 'example.net');
+        $idGenerator = new Swift_Mime_IdGenerator('example.net');
         $this->assertEquals('example.net', $idGenerator->getIdRight());
 
         $idGenerator->setIdRight('example.com');
@@ -61,10 +18,11 @@ class Swift_Mime_IdGeneratorTest extends \PHPUnit_Framework_TestCase
 
     public function testIdGenerateId()
     {
-        $idGenerator = new Swift_Mime_IdGenerator($this->emailValidator, 'example.net');
+        $idGenerator = new Swift_Mime_IdGenerator('example.net');
+        $emailValidator = new EmailValidator();
 
         $id = $idGenerator->generateId();
-        $this->assertTrue($this->emailValidator->isValid($id));
+        $this->assertTrue($emailValidator->isValid($id));
         $this->assertEquals(1, preg_match('/^.{32}@example.net$/', $id));
 
         $anotherId = $idGenerator->generateId();

--- a/tests/unit/Swift/Mime/MimePartTest.php
+++ b/tests/unit/Swift/Mime/MimePartTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use Egulias\EmailValidator\EmailValidator;
 
 class Swift_Mime_MimePartTest extends Swift_Mime_AbstractMimeEntityTest
 {
@@ -230,7 +229,7 @@ class Swift_Mime_MimePartTest extends Swift_Mime_AbstractMimeEntityTest
 
     protected function createMimePart($headers, $encoder, $cache)
     {
-        $idGenerator = new Swift_Mime_IdGenerator(new EmailValidator());
+        $idGenerator = new Swift_Mime_IdGenerator('example.com');
 
         return new Swift_Mime_MimePart($headers, $encoder, $cache, $idGenerator);
     }

--- a/tests/unit/Swift/Mime/SimpleMessageTest.php
+++ b/tests/unit/Swift/Mime/SimpleMessageTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use Egulias\EmailValidator\EmailValidator;
 
 class Swift_Mime_SimpleMessageTest extends Swift_Mime_MimePartTest
 {
@@ -832,7 +831,7 @@ class Swift_Mime_SimpleMessageTest extends Swift_Mime_MimePartTest
 
     private function createMessage($headers, $encoder, $cache)
     {
-        $idGenerator = new Swift_Mime_IdGenerator(new EmailValidator());
+        $idGenerator = new Swift_Mime_IdGenerator('example.com');
 
         return new Swift_Mime_SimpleMessage($headers, $encoder, $cache, $idGenerator);
     }

--- a/tests/unit/Swift/Mime/SimpleMimeEntityTest.php
+++ b/tests/unit/Swift/Mime/SimpleMimeEntityTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use Egulias\EmailValidator\EmailValidator;
 
 class Swift_Mime_SimpleMimeEntityTest extends Swift_Mime_AbstractMimeEntityTest
 {
@@ -8,7 +7,7 @@ class Swift_Mime_SimpleMimeEntityTest extends Swift_Mime_AbstractMimeEntityTest
 
     protected function createEntity($headerFactory, $encoder, $cache)
     {
-        $idGenerator = new Swift_Mime_IdGenerator(new EmailValidator());
+        $idGenerator = new Swift_Mime_IdGenerator('example.com');
 
         return new Swift_Mime_SimpleMimeEntity($headerFactory, $encoder, $cache, $idGenerator);
     }


### PR DESCRIPTION
Instead of accessing `$_SERVER['SERVER_NAME']` directly from `Swift_Mime_IdGenerator`, it would be cleaner to inject `idRight` through the dependency injection container.

This patch also avoids the need to inject the email validator into the IdGenerator. The validator is only used to validate the config value. Elsewhere in Swiftmailer configuration values are not subject to such thorough validation.