### PR TITLE
Bugfix for broken MIME header encoding with quotes/colons and non-ascii chars

### DIFF
--- a/lib/classes/Swift/Mime/Headers/MailboxHeader.php
+++ b/lib/classes/Swift/Mime/Headers/MailboxHeader.php
@@ -277,9 +277,7 @@ class Swift_Mime_Headers_MailboxHeader extends Swift_Mime_Headers_AbstractHeader
      */
     protected function createDisplayNameString($displayName, $shorten = false)
     {
-        return $this->createPhrase($this, $displayName,
-            $this->getCharset(), $this->getEncoder(), $shorten
-            );
+        return $this->createPhrase($this, $displayName, $this->getCharset(), $this->getEncoder(), $shorten);
     }
 
     /**
@@ -299,8 +297,9 @@ class Swift_Mime_Headers_MailboxHeader extends Swift_Mime_Headers_AbstractHeader
     /**
      * Redefine the encoding requirements for mailboxes.
      *
-     * Commas and semicolons are used to separate
-     * multiple addresses, and should therefore be encoded
+     * All "specials" must be encoded as the full header value will not be quoted
+     * 
+     * @see RFC 2822 3.2.1
      *
      * @param string $token
      *
@@ -308,7 +307,7 @@ class Swift_Mime_Headers_MailboxHeader extends Swift_Mime_Headers_AbstractHeader
      */
     protected function tokenNeedsEncoding($token)
     {
-        return preg_match('/[,;]/', $token) || parent::tokenNeedsEncoding($token);
+        return preg_match('/[()<>\[\]:;@\,."]/', $token) || parent::tokenNeedsEncoding($token);
     }
 
     /**

--- a/tests/bug/Swift/Bug650Test.php
+++ b/tests/bug/Swift/Bug650Test.php
@@ -1,0 +1,36 @@
+<?php
+
+class Swift_Bug650Test extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider encodingDataProvider
+     *
+     * @param string $name
+     * @param string $expectedEncodedName
+     */
+    public function testMailboxHeaderEncoding($name, $expectedEncodedName)
+    {
+        $factory = new Swift_CharacterReaderFactory_SimpleCharacterReaderFactory();
+        $charStream = new Swift_CharacterStream_NgCharacterStream($factory, 'utf-8');
+        $encoder = new Swift_Mime_HeaderEncoder_QpHeaderEncoder($charStream);
+        $header = new Swift_Mime_Headers_MailboxHeader('To', $encoder, new Swift_Mime_Grammar());
+        $header->setCharset('utf-8');
+
+        $header->setNameAddresses(array(
+            'test@example.com' => $name,
+        ));
+
+        $this->assertSame('To: '.$expectedEncodedName." <test@example.com>\r\n", $header->toString());
+    }
+
+    public function encodingDataProvider()
+    {
+        return array(
+            array('this is " a test ö', 'this is =?utf-8?Q?=22?= a test =?utf-8?Q?=C3=B6?='),
+            array(': this is a test ö', '=?utf-8?Q?=3A?= this is a test =?utf-8?Q?=C3=B6?='),
+            array('( test ö', '=?utf-8?Q?=28?= test =?utf-8?Q?=C3=B6?='),
+            array('[ test ö', '=?utf-8?Q?=5B?= test =?utf-8?Q?=C3=B6?='),
+            array('@ test ö)', '=?utf-8?Q?=40?= test =?utf-8?Q?=C3=B6=29?='),
+        );
+    }
+}


### PR DESCRIPTION
This PR fixes bugs https://github.com/swiftmailer/swiftmailer/issues/763 and https://github.com/swiftmailer/swiftmailer/issues/650.

It is quite similar to the fix for bug https://github.com/swiftmailer/swiftmailer/issues/206 which has been merged with https://github.com/swiftmailer/swiftmailer/pull/211.

The problem again was that when a token contains valid alphanumeric characters and/or some RFC 2822 "specials" and there are other tokens with special characters then the whole header value was not quoted (as the special characters were already properly Q-encoded) and so the "specials" were left unescaped.

