### PR TITLE
escapeshellarg() has been disabled for security reasons

### DIFF
--- a/lib/classes/Swift/Transport/MailTransport.php
+++ b/lib/classes/Swift/Transport/MailTransport.php
@@ -249,9 +249,24 @@ class Swift_Transport_MailTransport implements Swift_Transport
     private function _formatExtraParams($extraParams, $reversePath)
     {
         if (false !== strpos($extraParams, '-f%s')) {
-            $extraParams = empty($reversePath) ? str_replace('-f%s', '', $extraParams) : sprintf($extraParams, escapeshellarg($reversePath));
+            $extraParams = empty($reversePath) ? str_replace('-f%s', '', $extraParams) : sprintf($extraParams, $this->_escapeShellArg($reversePath));
         }
 
         return !empty($extraParams) ? $extraParams : null;
     }
+    
+     /**
+     * Escape a string to be used as a shell argument
+     *
+     * @param $input
+     *
+     * @return string|null
+     */
+    private function _escapeShellArg($input)
+    {
+      $input = str_replace('\'', '\\\'', $input);
+    
+      return '\''.$input.'\'';
+    }
+    
 }

--- a/lib/classes/Swift/Transport/MailTransport.php
+++ b/lib/classes/Swift/Transport/MailTransport.php
@@ -254,19 +254,18 @@ class Swift_Transport_MailTransport implements Swift_Transport
 
         return !empty($extraParams) ? $extraParams : null;
     }
-    
-     /**
-     * Escape a string to be used as a shell argument
+
+    /**
+     * Escape a string to be used as a shell argument.
      *
      * @param $input
      *
-     * @return string|null
+     * @return string
      */
     private function _escapeShellArg($input)
     {
-      $input = str_replace('\'', '\\\'', $input);
-    
-      return '\''.$input.'\'';
+        $input = str_replace('\'', '\\\'', $input);
+
+        return '\''.$input.'\'';
     }
-    
 }


### PR DESCRIPTION
I'm getting this error. Some shared hostings can not enable this function for security reasons. 
Is it possible to replace it? I found this: http://stackoverflow.com/a/23592397

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/swiftmailer/swiftmailer/780)

<!-- Reviewable:end -->
