### PR TITLE
Fix #426: Prevent fatal error during unserialization

### DIFF
--- a/lib/classes/Swift/Mime/SimpleMimeEntity.php
+++ b/lib/classes/Swift/Mime/SimpleMimeEntity.php
@@ -809,7 +809,9 @@ class Swift_Mime_SimpleMimeEntity implements Swift_Mime_MimeEntity
      */
     public function __destruct()
     {
-        $this->_cache->clearAll($this->_cacheKey);
+        if ($this->_cache instanceof Swift_KeyCache) {
+            $this->_cache->clearAll($this->_cacheKey);
+        }
     }
 
     /**


### PR DESCRIPTION
## Description

Refer to #426 .
## Solution

I've looked for all of `__destruct()` implementations regarding cache usage. That was the only one - so it should completely fix the aforementioned issue.
