### PR TITLE
fixes #782: prevent fatal error in FileSpool.php when unserializing of message fails

### DIFF
--- a/lib/classes/Swift/FileSpool.php
+++ b/lib/classes/Swift/FileSpool.php
@@ -164,15 +164,14 @@ class Swift_FileSpool extends Swift_ConfigurableSpool
 
             /* We try a rename, it's an atomic operation, and avoid locking the file */
             if (rename($file, $file.'.sending')) {
-            	$message = unserialize(file_get_contents($file.'.sending'));
-            	if ($message !== false) {
-            	    $count += $transport->send($message, $failedRecipients);
+                $message = unserialize(file_get_contents($file.'.sending'));
+                if ($message !== false) {
+                    $count += $transport->send($message, $failedRecipients);
 
                     unlink($file.'.sending');
-            	}
-            	else {
-            	    rename($file, $file.'.unserialize_error');
-            	}
+                } else {
+                    rename($file, $file.'.unserialize_error');
+                }
             } else {
                 /* This message has just been catched by another process */
                 continue;

--- a/lib/classes/Swift/FileSpool.php
+++ b/lib/classes/Swift/FileSpool.php
@@ -164,11 +164,15 @@ class Swift_FileSpool extends Swift_ConfigurableSpool
 
             /* We try a rename, it's an atomic operation, and avoid locking the file */
             if (rename($file, $file.'.sending')) {
-                $message = unserialize(file_get_contents($file.'.sending'));
+            	$message = unserialize(file_get_contents($file.'.sending'));
+            	if ($message !== false) {
+            	    $count += $transport->send($message, $failedRecipients);
 
-                $count += $transport->send($message, $failedRecipients);
-
-                unlink($file.'.sending');
+                    unlink($file.'.sending');
+            	}
+            	else {
+            	    rename($file, $file.'.unserialize_error');
+            	}
             } else {
                 /* This message has just been catched by another process */
                 continue;


### PR DESCRIPTION
### Description

Refer to #782 .
### Solution

Check the result of unserialize before calling send(). Rename file to indicate unserialization error.
