### PR TITLE
account for case of no domain passed with username in NTLMAuthenticator

### DIFF
--- a/lib/classes/Swift/Transport/Esmtp/Auth/NTLMAuthenticator.php
+++ b/lib/classes/Swift/Transport/Esmtp/Auth/NTLMAuthenticator.php
@@ -296,9 +296,14 @@ class Swift_Transport_Esmtp_Auth_NTLMAuthenticator implements Swift_Transport_Es
             return explode('\\', $name);
         }
 
-        list($user, $domain) = explode('@', $name);
+        if (strpos($name, '@') !== false) {
+            list($user, $domain) = explode('@', $name);
 
-        return array($domain, $user);
+            return array($domain, $user);
+        }
+
+        // no domain passed
+        return array('', $name);
     }
 
     /**

--- a/tests/unit/Swift/Transport/Esmtp/Auth/NTLMAuthenticatorTest.php
+++ b/tests/unit/Swift/Transport/Esmtp/Auth/NTLMAuthenticatorTest.php
@@ -154,6 +154,21 @@ class Swift_Transport_Esmtp_Auth_NTLMAuthenticatorTest extends \SwiftMailerTestC
         );
     }
 
+    public function testGetDomainAndUsernameWithoutDomain()
+    {
+        $username = 'user';
+
+        $login = $this->_getAuthenticator();
+        list($domain, $user) = $this->_invokePrivateMethod('getDomainAndUsername', $login, array($username));
+
+        $this->assertEquals('', $domain,
+            '%s: the fetched domain did not match'
+        );
+        $this->assertEquals('user', $user,
+            '%s: the fetched user did not match'
+        );
+    }
+
     public function testSuccessfulAuthentication()
     {
         $domain = 'TESTNT';


### PR DESCRIPTION
Fixes [issue 794](https://github.com/swiftmailer/swiftmailer/issues/794)
