### PR TITLE
Sanitize SERVER_NAME

### DIFF
--- a/lib/dependency_maps/mime_deps.php
+++ b/lib/dependency_maps/mime_deps.php
@@ -10,7 +10,10 @@ Swift_DependencyContainer::getInstance()
     ->asSharedInstanceOf('Egulias\EmailValidator\EmailValidator')
 
     ->register('mime.idgenerator.idright')
-    ->asValue(!empty($_SERVER['SERVER_NAME']) ? $_SERVER['SERVER_NAME'] : 'swift.generated')
+    // As SERVER_NAME can come from the user in certain configurations, check that
+    // it does not contain forbidden characters (see RFC 952 and RFC 2181). Use
+    // preg_replace() instead of preg_match() to prevent DoS attacks with long host names.
+    ->asValue(!empty($_SERVER['SERVER_NAME']) && preg_replace('/(?:^\[)?[a-zA-Z0-9-:\]_]+\.?/', '', $_SERVER['SERVER_NAME']) === '' ? $_SERVER['SERVER_NAME'] : 'swift.generated')
 
     ->register('mime.idgenerator')
     ->asSharedInstanceOf('Swift_Mime_IdGenerator')


### PR DESCRIPTION
We need to sanitize `$_SERVER['SERVER_NAME']`.

The regexp is copied from Symfony\Component\HttpFoundation\Request.

This only affects master. The code in question was added in PR #760.