### PR TITLE
Dependency-inject local-domain into AbstractSmtpTransport

### DIFF
--- a/lib/classes/Swift/Transport/EsmtpTransport.php
+++ b/lib/classes/Swift/Transport/EsmtpTransport.php
@@ -51,10 +51,11 @@ class Swift_Transport_EsmtpTransport extends Swift_Transport_AbstractSmtpTranspo
      * @param Swift_Transport_IoBuffer       $buf
      * @param Swift_Transport_EsmtpHandler[] $extensionHandlers
      * @param Swift_Events_EventDispatcher   $dispatcher
+     * @param string                         $localDomain
      */
-    public function __construct(Swift_Transport_IoBuffer $buf, array $extensionHandlers, Swift_Events_EventDispatcher $dispatcher)
+    public function __construct(Swift_Transport_IoBuffer $buf, array $extensionHandlers, Swift_Events_EventDispatcher $dispatcher, $localDomain)
     {
-        parent::__construct($buf, $dispatcher);
+        parent::__construct($buf, $dispatcher, $localDomain);
         $this->setExtensionHandlers($extensionHandlers);
     }
 
@@ -140,7 +141,7 @@ class Swift_Transport_EsmtpTransport extends Swift_Transport_AbstractSmtpTranspo
      */
     public function setEncryption($encryption)
     {
-        $encryption = strtolower($encryption);    
+        $encryption = strtolower($encryption);
         if ('tls' == $encryption) {
             $this->params['protocol'] = 'tcp';
             $this->params['tls'] = true;

--- a/lib/classes/Swift/Transport/SendmailTransport.php
+++ b/lib/classes/Swift/Transport/SendmailTransport.php
@@ -36,10 +36,11 @@ class Swift_Transport_SendmailTransport extends Swift_Transport_AbstractSmtpTran
      *
      * @param Swift_Transport_IoBuffer     $buf
      * @param Swift_Events_EventDispatcher $dispatcher
+     * @param string                       $localDomain
      */
-    public function __construct(Swift_Transport_IoBuffer $buf, Swift_Events_EventDispatcher $dispatcher)
+    public function __construct(Swift_Transport_IoBuffer $buf, Swift_Events_EventDispatcher $dispatcher, $localDomain)
     {
-        parent::__construct($buf, $dispatcher);
+        parent::__construct($buf, $dispatcher, $localDomain);
     }
 
     /**

--- a/lib/dependency_maps/transport_deps.php
+++ b/lib/dependency_maps/transport_deps.php
@@ -1,12 +1,19 @@
 <?php
 
 Swift_DependencyContainer::getInstance()
+    ->register('transport.localdomain')
+    // As SERVER_NAME can come from the user in certain configurations, check that
+    // it does not contain forbidden characters (see RFC 952 and RFC 2181). Use
+    // preg_replace() instead of preg_match() to prevent DoS attacks with long host names.
+    ->asValue(!empty($_SERVER['SERVER_NAME']) && preg_replace('/(?:^\[)?[a-zA-Z0-9-:\]_]+\.?/', '', $_SERVER['SERVER_NAME']) === '' ? trim($_SERVER['SERVER_NAME'], '[]') : '127.0.0.1')
+
     ->register('transport.smtp')
     ->asNewInstanceOf('Swift_Transport_EsmtpTransport')
     ->withDependencies(array(
         'transport.buffer',
         array('transport.authhandler'),
         'transport.eventdispatcher',
+        'transport.localdomain',
     ))
 
     ->register('transport.sendmail')
@@ -14,6 +21,7 @@ Swift_DependencyContainer::getInstance()
     ->withDependencies(array(
         'transport.buffer',
         'transport.eventdispatcher',
+        'transport.localdomain',
     ))
 
     ->register('transport.mail')

--- a/tests/unit/Swift/Transport/AbstractSmtpTest.php
+++ b/tests/unit/Swift/Transport/AbstractSmtpTest.php
@@ -104,7 +104,7 @@ abstract class Swift_Transport_AbstractSmtpTest extends \SwiftMailerTestCase
             ->andReturn("220 some.server.tld bleh\r\n");
         $buf->shouldReceive('write')
             ->once()
-            ->with('~^HELO .*?\r\n$~D')
+            ->with('~^HELO example.org\r\n$~D')
             ->andReturn(1);
         $buf->shouldReceive('readLine')
             ->once()
@@ -132,7 +132,7 @@ abstract class Swift_Transport_AbstractSmtpTest extends \SwiftMailerTestCase
             ->andReturn("220 some.server.tld bleh\r\n");
         $buf->shouldReceive('write')
             ->once()
-            ->with('~^HELO .*?\r\n$~D')
+            ->with('~^HELO example.org\r\n$~D')
             ->andReturn(1);
         $buf->shouldReceive('readLine')
             ->once()
@@ -1172,6 +1172,27 @@ abstract class Swift_Transport_AbstractSmtpTest extends \SwiftMailerTestCase
         $this->finishBuffer($buf);
         $smtp->start();
         $smtp->send($message);
+    }
+
+    public function testSetLocalDomain()
+    {
+        $buf = $this->getBuffer();
+        $smtp = $this->getTransport($buf);
+
+        $smtp->setLocalDomain('example.com');
+        $this->assertEquals('example.com', $smtp->getLocalDomain());
+
+        $smtp->setLocalDomain('192.168.0.1');
+        $this->assertEquals('[192.168.0.1]', $smtp->getLocalDomain());
+
+        $smtp->setLocalDomain('[192.168.0.1]');
+        $this->assertEquals('[192.168.0.1]', $smtp->getLocalDomain());
+
+        $smtp->setLocalDomain('fd00::');
+        $this->assertEquals('[IPv6:fd00::]', $smtp->getLocalDomain());
+
+        $smtp->setLocalDomain('[IPv6:fd00::]');
+        $this->assertEquals('[IPv6:fd00::]', $smtp->getLocalDomain());
     }
 
     protected function getBuffer()

--- a/tests/unit/Swift/Transport/EsmtpTransport/ExtensionSupportTest.php
+++ b/tests/unit/Swift/Transport/EsmtpTransport/ExtensionSupportTest.php
@@ -140,7 +140,7 @@ class Swift_Transport_EsmtpTransport_ExtensionSupportTest extends Swift_Transpor
     {
         $buf = $this->getBuffer();
         $dispatcher = $this->createEventDispatcher();
-        $smtp = new Swift_Transport_EsmtpTransport($buf, array(), $dispatcher);
+        $smtp = new Swift_Transport_EsmtpTransport($buf, array(), $dispatcher, 'example.org');
         $ext1 = $this->getMockery('Swift_Transport_EsmtpHandler')->shouldIgnoreMissing();
         $ext2 = $this->getMockery('Swift_Transport_EsmtpHandler')->shouldIgnoreMissing();
         $ext3 = $this->getMockery('Swift_Transport_EsmtpHandler')->shouldIgnoreMissing();
@@ -242,7 +242,7 @@ class Swift_Transport_EsmtpTransport_ExtensionSupportTest extends Swift_Transpor
     {
         $buf = $this->getBuffer();
         $dispatcher = $this->createEventDispatcher();
-        $smtp = new Swift_Transport_EsmtpTransport($buf, array(), $dispatcher);
+        $smtp = new Swift_Transport_EsmtpTransport($buf, array(), $dispatcher, 'example.org');
         $ext1 = $this->getMockery('Swift_Transport_EsmtpHandler')->shouldIgnoreMissing();
         $ext2 = $this->getMockery('Swift_Transport_EsmtpHandler')->shouldIgnoreMissing();
         $ext3 = $this->getMockery('Swift_Transport_EsmtpHandler')->shouldIgnoreMissing();

--- a/tests/unit/Swift/Transport/EsmtpTransportTest.php
+++ b/tests/unit/Swift/Transport/EsmtpTransportTest.php
@@ -9,7 +9,7 @@ class Swift_Transport_EsmtpTransportTest
             $dispatcher = $this->createEventDispatcher();
         }
 
-        return new Swift_Transport_EsmtpTransport($buf, array(), $dispatcher);
+        return new Swift_Transport_EsmtpTransport($buf, array(), $dispatcher, 'example.org');
     }
 
     public function testHostCanBeSetAndFetched()

--- a/tests/unit/Swift/Transport/SendmailTransportTest.php
+++ b/tests/unit/Swift/Transport/SendmailTransportTest.php
@@ -8,7 +8,7 @@ class Swift_Transport_SendmailTransportTest
         if (!$dispatcher) {
             $dispatcher = $this->createEventDispatcher();
         }
-        $transport = new Swift_Transport_SendmailTransport($buf, $dispatcher);
+        $transport = new Swift_Transport_SendmailTransport($buf, $dispatcher, 'example.org');
         $transport->setCommand($command);
 
         return $transport;
@@ -19,7 +19,7 @@ class Swift_Transport_SendmailTransportTest
         if (!$dispatcher) {
             $dispatcher = $this->createEventDispatcher();
         }
-        $sendmail = new Swift_Transport_SendmailTransport($buf, $dispatcher);
+        $sendmail = new Swift_Transport_SendmailTransport($buf, $dispatcher, 'example.org');
 
         return $sendmail;
     }


### PR DESCRIPTION
Instead of accessing `$_SERVER['SERVER_NAME']` directly from `Swift_Transport_AbstractSmtpTransport`, it would be cleaner to inject `localDomain` through the dependency injection container.
