### PR TITLE
Provide return type hinting of null, and default null result as empty…

### DIFF
--- a/lib/classes/Swift/Mime/Attachment.php
+++ b/lib/classes/Swift/Mime/Attachment.php
@@ -52,7 +52,7 @@ class Swift_Mime_Attachment extends Swift_Mime_SimpleMimeEntity
      *
      * By default attachments have a disposition of "attachment".
      *
-     * @return string
+     * @return string|null
      */
     public function getDisposition()
     {
@@ -78,7 +78,7 @@ class Swift_Mime_Attachment extends Swift_Mime_SimpleMimeEntity
     /**
      * Get the filename of this attachment when downloaded.
      *
-     * @return string
+     * @return string|null
      */
     public function getFilename()
     {
@@ -103,7 +103,7 @@ class Swift_Mime_Attachment extends Swift_Mime_SimpleMimeEntity
     /**
      * Get the file size of this attachment.
      *
-     * @return int
+     * @return int|null
      */
     public function getSize()
     {

--- a/lib/classes/Swift/Mime/MimePart.php
+++ b/lib/classes/Swift/Mime/MimePart.php
@@ -70,7 +70,7 @@ class Swift_Mime_MimePart extends Swift_Mime_SimpleMimeEntity
     /**
      * Get the character set of this entity.
      *
-     * @return string
+     * @return string|null
      */
     public function getCharset()
     {
@@ -99,7 +99,7 @@ class Swift_Mime_MimePart extends Swift_Mime_SimpleMimeEntity
     /**
      * Get the format of this entity (i.e. flowed or fixed).
      *
-     * @return string
+     * @return string|null
      */
     public function getFormat()
     {

--- a/lib/classes/Swift/Mime/SimpleMessage.php
+++ b/lib/classes/Swift/Mime/SimpleMessage.php
@@ -489,6 +489,7 @@ class Swift_Mime_SimpleMessage extends Swift_Mime_MimePart implements Swift_Mime
                 '%[1-5]'
             );
         }
+        
         return $priority;
     }
 

--- a/lib/classes/Swift/Mime/SimpleMessage.php
+++ b/lib/classes/Swift/Mime/SimpleMessage.php
@@ -81,7 +81,7 @@ class Swift_Mime_SimpleMessage extends Swift_Mime_MimePart implements Swift_Mime
     /**
      * Get the subject of this message.
      *
-     * @return string
+     * @return string|null
      */
     public function getSubject()
     {
@@ -107,7 +107,7 @@ class Swift_Mime_SimpleMessage extends Swift_Mime_MimePart implements Swift_Mime
     /**
      * Get the date at which this message was created.
      *
-     * @return int
+     * @return int|null
      */
     public function getDate()
     {
@@ -133,7 +133,7 @@ class Swift_Mime_SimpleMessage extends Swift_Mime_MimePart implements Swift_Mime
     /**
      * Get the return-path (bounce address) of this message.
      *
-     * @return string
+     * @return string|null
      */
     public function getReturnPath()
     {
@@ -166,7 +166,7 @@ class Swift_Mime_SimpleMessage extends Swift_Mime_MimePart implements Swift_Mime
     /**
      * Get the sender of this message.
      *
-     * @return string
+     * @return string|null
      */
     public function getSender()
     {
@@ -185,7 +185,7 @@ class Swift_Mime_SimpleMessage extends Swift_Mime_MimePart implements Swift_Mime
      */
     public function addFrom($address, $name = null)
     {
-        $current = $this->getFrom();
+        $current = is_null($this->getFrom()) ? $this->getForm() : array();
         $current[$address] = $name;
 
         return $this->setFrom($current);
@@ -220,7 +220,7 @@ class Swift_Mime_SimpleMessage extends Swift_Mime_MimePart implements Swift_Mime
     /**
      * Get the from address of this message.
      *
-     * @return mixed
+     * @return mixed|null
      */
     public function getFrom()
     {
@@ -239,7 +239,7 @@ class Swift_Mime_SimpleMessage extends Swift_Mime_MimePart implements Swift_Mime
      */
     public function addReplyTo($address, $name = null)
     {
-        $current = $this->getReplyTo();
+        $current = is_null($this->getReplyTo()) ? $this->getReplyTo() : array();
         $current[$address] = $name;
 
         return $this->setReplyTo($current);
@@ -274,7 +274,7 @@ class Swift_Mime_SimpleMessage extends Swift_Mime_MimePart implements Swift_Mime
     /**
      * Get the reply-to address of this message.
      *
-     * @return string
+     * @return string|null
      */
     public function getReplyTo()
     {
@@ -333,7 +333,7 @@ class Swift_Mime_SimpleMessage extends Swift_Mime_MimePart implements Swift_Mime
      */
     public function getTo()
     {
-        return $this->_getHeaderFieldModel('To');
+        return is_null($this->_getHeaderFieldModel('To')) ? $this->_getHeaderFieldModel('To') : array();
     }
 
     /**
@@ -385,7 +385,7 @@ class Swift_Mime_SimpleMessage extends Swift_Mime_MimePart implements Swift_Mime
      */
     public function getCc()
     {
-        return $this->_getHeaderFieldModel('Cc');
+        return is_null($this->_getHeaderFieldModel('Cc')) ? $this->_getHeaderFieldModel('Cc') : array();
     }
 
     /**
@@ -437,7 +437,7 @@ class Swift_Mime_SimpleMessage extends Swift_Mime_MimePart implements Swift_Mime
      */
     public function getBcc()
     {
-        return $this->_getHeaderFieldModel('Bcc');
+        return is_null($this->_getHeaderFieldModel('Bcc')) ? $this->_getHeaderFieldModel('Bcc') : array();
     }
 
     /**
@@ -483,11 +483,13 @@ class Swift_Mime_SimpleMessage extends Swift_Mime_MimePart implements Swift_Mime
      */
     public function getPriority()
     {
-        list($priority) = sscanf($this->_getHeaderFieldModel('X-Priority'),
-            '%[1-5]'
+        $priority = 3;
+        if (!is_null($this->_getHeaderFieldModel('X-Priority'))) {
+            list($priority) = sscanf($this->_getHeaderFieldModel('X-Priority'),
+                '%[1-5]'
             );
-
-        return isset($priority) ? $priority : 3;
+        }
+        return $priority;
     }
 
     /**
@@ -510,7 +512,7 @@ class Swift_Mime_SimpleMessage extends Swift_Mime_MimePart implements Swift_Mime
     /**
      * Get the addresses to which a read-receipt will be sent.
      *
-     * @return string
+     * @return string|null
      */
     public function getReadReceiptTo()
     {

--- a/lib/classes/Swift/Mime/SimpleMimeEntity.php
+++ b/lib/classes/Swift/Mime/SimpleMimeEntity.php
@@ -149,7 +149,7 @@ class Swift_Mime_SimpleMimeEntity implements Swift_Mime_MimeEntity
     /**
      * Get the Content-type of this entity.
      *
-     * @return string
+     * @return string|null
      */
     public function getContentType()
     {
@@ -182,9 +182,12 @@ class Swift_Mime_SimpleMimeEntity implements Swift_Mime_MimeEntity
      */
     public function getId()
     {
-        $tmp = (array) $this->_getHeaderFieldModel($this->_getIdField());
-
-        return $this->_headers->has($this->_getIdField()) ? current($tmp) : $this->_id;
+        $id = $this->_id;
+        if (!is_null($this->_getHeaderFieldModel($this->_getIdField()))) {
+            $tmp = (array) $this->_getHeaderFieldModel($this->_getIdField());
+            $id = current($tmp);
+        };
+        return $id;
     }
 
     /**
@@ -209,7 +212,7 @@ class Swift_Mime_SimpleMimeEntity implements Swift_Mime_MimeEntity
      *
      * This value comes from the Content-Description header if set.
      *
-     * @return string
+     * @return string|null
      */
     public function getDescription()
     {

--- a/lib/classes/Swift/Mime/SimpleMimeEntity.php
+++ b/lib/classes/Swift/Mime/SimpleMimeEntity.php
@@ -187,6 +187,7 @@ class Swift_Mime_SimpleMimeEntity implements Swift_Mime_MimeEntity
             $tmp = (array) $this->_getHeaderFieldModel($this->_getIdField());
             $id = current($tmp);
         };
+        
         return $id;
     }
 


### PR DESCRIPTION
Currently both the methods SimpleMimeEntity::_getHeaderParameter and SimpleMimeEntity::_getHeaderFieldModel will return null if the headers does not include the field parameter. The resulting methods that use these have no checks for null return types.

The methods that use these and return arrays can be defaulted to instead return empty arrays, where the methods that return strings and integers should have the possible return type of |null documented.