### PR TITLE
Adding the tests folder in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,5 +5,6 @@
 *.priv -crlf
 *.txt -crlf
 
-# ignore /notes in the git-generated distributed .zip archive
+# ignore /notes & /tests in the git-generated distributed .zip archive
 /notes export-ignore
+/tests export-ignore


### PR DESCRIPTION
This is not only for the distributed .zip archive but also to ignore the unwanted folders/files when we pull it with composer.

Usefull for clean/slim vendor folder (production env).
