### PR TITLE
Add constants for setting message priority

### DIFF
--- a/lib/classes/Swift/Mime/SimpleMessage.php
+++ b/lib/classes/Swift/Mime/SimpleMessage.php
@@ -15,6 +15,12 @@
  */
 class Swift_Mime_SimpleMessage extends Swift_Mime_MimePart implements Swift_Mime_Message
 {
+    const PRIORITY_HIGHEST = 1;
+    const PRIORITY_HIGH = 2;
+    const PRIORITY_NORMAL = 3;
+    const PRIORITY_LOW = 4;
+    const PRIORITY_LOWEST = 5;
+
     /**
      * Create a new SimpleMessage with $headers, $encoder and $cache.
      *
@@ -452,11 +458,11 @@ class Swift_Mime_SimpleMessage extends Swift_Mime_MimePart implements Swift_Mime
     public function setPriority($priority)
     {
         $priorityMap = array(
-            1 => 'Highest',
-            2 => 'High',
-            3 => 'Normal',
-            4 => 'Low',
-            5 => 'Lowest',
+            self::PRIORITY_HIGHEST => 'Highest',
+            self::PRIORITY_HIGH => 'High',
+            self::PRIORITY_NORMAL => 'Normal',
+            self::PRIORITY_LOW => 'Low',
+            self::PRIORITY_LOWEST => 'Lowest',
             );
         $pMapKeys = array_keys($priorityMap);
         if ($priority > max($pMapKeys)) {

--- a/tests/unit/Swift/Mime/SimpleMessageTest.php
+++ b/tests/unit/Swift/Mime/SimpleMessageTest.php
@@ -652,7 +652,7 @@ class Swift_Mime_SimpleMessageTest extends Swift_Mime_MimePartTest
             $this->_createHeaderSet(array('X-Priority' => $prio)),
             $this->_createEncoder(), $this->_createCache()
             );
-        $message->setPriority(5);
+        $message->setPriority($message::PRIORITY_LOWEST);
     }
 
     public function testPriorityHeaderIsAddedIfNoneSet()
@@ -667,7 +667,7 @@ class Swift_Mime_SimpleMessageTest extends Swift_Mime_MimePartTest
         $message = $this->_createMessage($headers, $this->_createEncoder(),
             $this->_createCache()
             );
-        $message->setPriority(4);
+        $message->setPriority($message::PRIORITY_LOW);
     }
 
     public function testReadReceiptAddressReadFromHeader()
@@ -802,7 +802,7 @@ class Swift_Mime_SimpleMessageTest extends Swift_Mime_MimePartTest
             ->setTo(array('chris@site.tld', 'mark@site.tld'))
             ->setCc('john@somewhere.tld')
             ->setBcc(array('one@site', 'two@site' => 'Two'))
-            ->setPriority(4)
+            ->setPriority($message::PRIORITY_LOW)
             ->setReadReceiptTo('a@b')
             ->attach($child)
             ->detach($child)


### PR DESCRIPTION
As per https://github.com/swiftmailer/swiftmailer/issues/806, this PR replaces integer with class constants. 

It's tested and it's backward compatible, i.e. you can keep using integers in your code if you prefer.