### PR TITLE
Use validator which supports RFC 6531

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3"
+        "php": ">=5.3.3",
+        "egulias/email-validator": "~1"
     },
     "require-dev": {
         "mockery/mockery": "~0.9.1"

--- a/lib/classes/Swift/Mime/Headers/MailboxHeader.php
+++ b/lib/classes/Swift/Mime/Headers/MailboxHeader.php
@@ -342,11 +342,11 @@ class Swift_Mime_Headers_MailboxHeader extends Swift_Mime_Headers_AbstractHeader
      */
     private function _assertValidAddress($address)
     {
-        if (!preg_match('/^'.$this->getGrammar()->getDefinition('addr-spec').'$/D',
-            $address)) {
+        $emailValidator = new \Egulias\EmailValidator\EmailValidator;
+        if (!$emailValidator->isValid($address)) {
             throw new Swift_RfcComplianceException(
                 'Address in mailbox given ['.$address.
-                '] does not comply with RFC 2822, 3.6.2.'
+                '] does not comply with RFC 2822, 3.6.2 and RFC 6531.'
                 );
         }
     }

--- a/lib/classes/Swift/Mime/Headers/MailboxHeader.php
+++ b/lib/classes/Swift/Mime/Headers/MailboxHeader.php
@@ -342,7 +342,7 @@ class Swift_Mime_Headers_MailboxHeader extends Swift_Mime_Headers_AbstractHeader
      */
     private function _assertValidAddress($address)
     {
-        $emailValidator = new \Egulias\EmailValidator\EmailValidator;
+        $emailValidator = new \Egulias\EmailValidator\EmailValidator();
         if (!$emailValidator->isValid($address)) {
             throw new Swift_RfcComplianceException(
                 'Address in mailbox given ['.$address.

--- a/tests/bug/Swift/Bug419Test.php
+++ b/tests/bug/Swift/Bug419Test.php
@@ -1,0 +1,32 @@
+<?php
+
+use Mockery as m;
+
+class Swift_Bug419Test extends \PHPUnit_Framework_TestCase
+{
+    public function emailProvider()
+    {
+        return array(
+            array('ек@example.com', true),
+            array('example@и.foo', true),
+            array('müller@gmail.com', true),
+            array('example@.@gmail.com', false),
+        );
+    }
+
+    /**
+     * @dataProvider emailProvider
+     */
+    public function testUnicodeEmailPartsAreValid($email, $expected)
+    {
+        try {
+            $message = new Swift_Message();
+            $message->setTo($email);
+            $actual = true;
+        } catch (\Swift_RfcComplianceException $e) {
+            $actual = false;
+        }
+
+        $this->assertEquals($expected, $actual);
+    }
+}


### PR DESCRIPTION
Addresses the following #419, #748, #810, #717 for 5.x. I know this has been addressed in master but I'm after PHP 5.3 support. 

I had an alternative approach in https://github.com/adeslade/swiftmailer/commit/01cb0870d3514e83327f6a8936cc97cbe03abb4f. I wasn't happy with this though as the `Swift_Mime_Headers_MailboxHeader` if manually instantiated would not have been backwards compatible.
