### PR TITLE
Inconsequent clone method

### DIFF
--- a/lib/classes/Swift/Message.php
+++ b/lib/classes/Swift/Message.php
@@ -281,11 +281,11 @@ class Swift_Message extends Swift_Mime_SimpleMessage
     {
         parent::__clone();
         foreach ($this->bodySigners as $key => $bodySigner) {
-            $this->bodySigners[$key] = clone($bodySigner);
+            $this->bodySigners[$key] = clone $bodySigner;
         }
 
         foreach ($this->headerSigners as $key => $headerSigner) {
-            $this->headerSigners[$key] = clone($headerSigner);
+            $this->headerSigners[$key] = clone $headerSigner;
         }
     }
 }


### PR DESCRIPTION
removing brackets for clone method in Swift_Message::__clone()

At all other places are clone without brackets according with PHP standards

Example:
https://github.com/swiftmailer/swiftmailer/blob/master/lib/classes/Swift/Mime/SimpleMimeEntity.php#L804

Related to https://github.com/wimg/PHPCompatibility/issues/284

