### PR TITLE
reverted escaping command-line args to mail

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,7 +4,7 @@ Changelog
 5.4.4 (2016-XX-XX)
 ------------------
 
- * n/a
+ * reverted escaping command-line args to mail (PHP mail() function already does it)
 
 5.4.3 (2016-07-08)
 ------------------
@@ -28,7 +28,7 @@ Changelog
  * added return-path header to the ignoredHeaders list of DKIMSigner
  * fixed crlf for subject using mail
  * fixed add soft line break only when necessary
- * fixed escaping command-line args to Sendmail
+ * fixed escaping command-line args to mail
 
 5.4.1 (2015-06-06)
 ------------------

--- a/lib/classes/Swift/Transport/MailTransport.php
+++ b/lib/classes/Swift/Transport/MailTransport.php
@@ -249,7 +249,8 @@ class Swift_Transport_MailTransport implements Swift_Transport
     private function _formatExtraParams($extraParams, $reversePath)
     {
         if (false !== strpos($extraParams, '-f%s')) {
-            $extraParams = empty($reversePath) ? str_replace('-f%s', '', $extraParams) : sprintf($extraParams, escapeshellarg($reversePath));
+            // no need to escape $reversePath) as mail() already does it
+            $extraParams = empty($reversePath) ? str_replace('-f%s', '', $extraParams) : sprintf($extraParams, $reversePath);
         }
 
         return !empty($extraParams) ? $extraParams : null;

--- a/tests/unit/Swift/Transport/MailTransportTest.php
+++ b/tests/unit/Swift/Transport/MailTransportTest.php
@@ -100,7 +100,7 @@ class Swift_Transport_MailTransportTest extends \SwiftMailerTestCase
              );
         $invoker->shouldReceive('mail')
                 ->once()
-                ->with(\Mockery::any(), \Mockery::any(), \Mockery::any(), \Mockery::any(), '-f\'foo@bar\'');
+                ->with(\Mockery::any(), \Mockery::any(), \Mockery::any(), \Mockery::any(), '-ffoo@bar');
 
         $transport->send($message);
     }
@@ -153,7 +153,7 @@ class Swift_Transport_MailTransportTest extends \SwiftMailerTestCase
             ->andReturn(null);
         $invoker->shouldReceive('mail')
             ->once()
-            ->with(\Mockery::any(), \Mockery::any(), \Mockery::any(), \Mockery::any(), '-x\'foo\' -f\'foo@bar\'');
+            ->with(\Mockery::any(), \Mockery::any(), \Mockery::any(), \Mockery::any(), '-x\'foo\' -ffoo@bar');
 
         $transport->send($message);
     }


### PR DESCRIPTION
This reverts 3d374ac (PR #626) as mail is already escaping this argument
(see https://github.com/php/php-src/blob/master/ext/standard/mail.c#L369)

fixes #824