### PR TITLE
[Security] Use _isShellSafe in Sendmail transport also

### DIFF
--- a/lib/classes/Swift/Transport/AbstractSmtpTransport.php
+++ b/lib/classes/Swift/Transport/AbstractSmtpTransport.php
@@ -13,7 +13,7 @@
  *
  * @author Chris Corbyn
  */
-abstract class Swift_Transport_AbstractSmtpTransport implements Swift_Transport
+abstract class Swift_Transport_AbstractSmtpTransport extends Swift_Transport_AbstractTransport implements Swift_Transport
 {
     /** Input-Output buffer for sending/receiving SMTP commands and responses */
     protected $_buffer;
@@ -331,27 +331,6 @@ abstract class Swift_Transport_AbstractSmtpTransport implements Swift_Transport
         }
         $this->_buffer->setWriteTranslations(array());
         $this->executeCommand("\r\n.\r\n", array(250));
-    }
-
-    /** Determine the best-use reverse path for this message */
-    protected function _getReversePath(Swift_Mime_Message $message)
-    {
-        $return = $message->getReturnPath();
-        $sender = $message->getSender();
-        $from = $message->getFrom();
-        $path = null;
-        if (!empty($return)) {
-            $path = $return;
-        } elseif (!empty($sender)) {
-            // Don't use array_keys
-            reset($sender); // Reset Pointer to first pos
-            $path = key($sender); // Get key
-        } elseif (!empty($from)) {
-            reset($from); // Reset Pointer to first pos
-            $path = key($from); // Get key
-        }
-
-        return $path;
     }
 
     /** Throw a TransportException, first sending it to any listeners */

--- a/lib/classes/Swift/Transport/AbstractTransport.php
+++ b/lib/classes/Swift/Transport/AbstractTransport.php
@@ -54,9 +54,18 @@ abstract class Swift_Transport_AbstractTransport
         $length = strlen($string);
         for ($i = 0; $i < $length; ++$i) {
             $c = $string[$i];
-            // All other characters have a special meaning in at least one common shell, including = and +.
-            // Full stop (.) has a special meaning in cmd.exe, but its impact should be negligible here.
-            // Note that this does permit non-Latin alphanumeric characters based on the current locale.
+
+            /*
+             * All other ASCII symbols have a special meaning in at least one common
+             * shell.  Notably, argument delimiters in cmd.exe include not only
+             * whitespace, but also comma, equals, and semicolon.  Plus also needs
+             * to be escaped in cmd.exe.
+             *
+             * ctype_alnum may allow non-Latin characters in some locales.  This
+             * should not present a problem on a properly configured system, or even
+             * most improperly configured systems.  If you need to enforce 7-bit
+             * ASCII, set the current language to "C".
+             */
             if (!ctype_alnum($c) && strpos('@_-.', $c) === false) {
                 return false;
             }

--- a/lib/classes/Swift/Transport/AbstractTransport.php
+++ b/lib/classes/Swift/Transport/AbstractTransport.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of SwiftMailer.
+ * (c) 2004-2009 Chris Corbyn
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * Abstract Tranport class.
+ *
+ */
+abstract class Swift_Transport_AbstractTransport
+{
+    /** Determine the best-use reverse path for this message */
+    protected function _getReversePath(Swift_Mime_Message $message)
+    {
+        $return = $message->getReturnPath();
+        $sender = $message->getSender();
+        $from = $message->getFrom();
+        $path = null;
+        if (!empty($return)) {
+            $path = $return;
+        } elseif (!empty($sender)) {
+            // Don't use array_keys
+            reset($sender); // Reset Pointer to first pos
+            $path = key($sender); // Get key
+        } elseif (!empty($from)) {
+            reset($from); // Reset Pointer to first pos
+            $path = key($from); // Get key
+        }
+
+        return $path;
+    }
+
+    /**
+     * Fix CVE-2016-10074 by disallowing potentially unsafe shell characters.
+     *
+     * Note that escapeshellarg and escapeshellcmd are inadequate for our purposes, especially on Windows.
+     *
+     * @param string $string The string to be validated
+     *
+     * @return bool
+     */
+    protected function _isShellSafe($string)
+    {
+        // Future-proof
+        if (escapeshellcmd($string) !== $string || !in_array(escapeshellarg($string), array("'$string'", "\"$string\""))) {
+            return false;
+        }
+
+        $length = strlen($string);
+        for ($i = 0; $i < $length; ++$i) {
+            $c = $string[$i];
+            // All other characters have a special meaning in at least one common shell, including = and +.
+            // Full stop (.) has a special meaning in cmd.exe, but its impact should be negligible here.
+            // Note that this does permit non-Latin alphanumeric characters based on the current locale.
+            if (!ctype_alnum($c) && strpos('@_-.', $c) === false) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/lib/classes/Swift/Transport/MailTransport.php
+++ b/lib/classes/Swift/Transport/MailTransport.php
@@ -23,7 +23,7 @@
  *
  * @deprecated since 5.4.5 (to be removed in 6.0)
  */
-class Swift_Transport_MailTransport implements Swift_Transport
+class Swift_Transport_MailTransport extends Swift_Transport_AbstractTransport implements Swift_Transport
 {
     /** Additional parameters to pass to mail() */
     private $_extraParams = '-f%s';
@@ -220,56 +220,6 @@ class Swift_Transport_MailTransport implements Swift_Transport
         } else {
             throw $e;
         }
-    }
-
-    /** Determine the best-use reverse path for this message */
-    private function _getReversePath(Swift_Mime_Message $message)
-    {
-        $return = $message->getReturnPath();
-        $sender = $message->getSender();
-        $from = $message->getFrom();
-        $path = null;
-        if (!empty($return)) {
-            $path = $return;
-        } elseif (!empty($sender)) {
-            $keys = array_keys($sender);
-            $path = array_shift($keys);
-        } elseif (!empty($from)) {
-            $keys = array_keys($from);
-            $path = array_shift($keys);
-        }
-
-        return $path;
-    }
-
-    /**
-     * Fix CVE-2016-10074 by disallowing potentially unsafe shell characters.
-     *
-     * Note that escapeshellarg and escapeshellcmd are inadequate for our purposes, especially on Windows.
-     *
-     * @param string $string The string to be validated
-     *
-     * @return bool
-     */
-    private function _isShellSafe($string)
-    {
-        // Future-proof
-        if (escapeshellcmd($string) !== $string || !in_array(escapeshellarg($string), array("'$string'", "\"$string\""))) {
-            return false;
-        }
-
-        $length = strlen($string);
-        for ($i = 0; $i < $length; ++$i) {
-            $c = $string[$i];
-            // All other characters have a special meaning in at least one common shell, including = and +.
-            // Full stop (.) has a special meaning in cmd.exe, but its impact should be negligible here.
-            // Note that this does permit non-Latin alphanumeric characters based on the current locale.
-            if (!ctype_alnum($c) && strpos('@_-.', $c) === false) {
-                return false;
-            }
-        }
-
-        return true;
     }
 
     /**

--- a/lib/classes/Swift/Transport/SendmailTransport.php
+++ b/lib/classes/Swift/Transport/SendmailTransport.php
@@ -112,8 +112,9 @@ class Swift_Transport_SendmailTransport extends Swift_Transport_AbstractSmtpTran
                 }
             }
 
-            if (false === strpos($command, ' -f')) {
-                $command .= ' -f'.escapeshellarg($this->_getReversePath($message));
+            $reversePath = $this->_getReversePath($message);
+            if (false === strpos($command, ' -f') && !empty($reversePath) && $this->_isShellSafe($reversePath)) {
+                $command .= ' -f'.escapeshellarg($reversePath);
             }
 
             $buffer->initialize(array_merge($this->_params, array('command' => $command)));


### PR DESCRIPTION
See #848
According to @Zenexer the `escapeshellarg` is not sufficient in this case. I'm not sure what payload would exactly cause this and on what systems, so following @zenexer here.

 - Created abstract Transport class to combine the reverse path + safe check
 - Make Mail transport + abstract SMTP transport extend the base abstract transport
 - Use safe check in Sendmail transport