### PR TITLE
No exception from Swift_Transport_AbstractSmtpTransport::__destruct

### DIFF
--- a/lib/classes/Swift/Transport/AbstractSmtpTransport.php
+++ b/lib/classes/Swift/Transport/AbstractSmtpTransport.php
@@ -396,7 +396,7 @@ abstract class Swift_Transport_AbstractSmtpTransport implements Swift_Transport
             do {
                 $line = $this->_buffer->readLine($seq);
                 $response .= $line;
-            } while (null !== $line && false !== $line && ' ' != $line{3});
+            } while (null !== $line && false !== $line && ' ' != $line[3]);
         } catch (Swift_TransportException $e) {
             $this->_throwException($e);
         } catch (Swift_IoException $e) {

--- a/lib/classes/Swift/Transport/AbstractSmtpTransport.php
+++ b/lib/classes/Swift/Transport/AbstractSmtpTransport.php
@@ -491,6 +491,9 @@ abstract class Swift_Transport_AbstractSmtpTransport implements Swift_Transport
      */
     public function __destruct()
     {
-        $this->stop();
+        try {
+            $this->stop();
+        } catch (Exception $e) {
+        }
     }
 }


### PR DESCRIPTION
Destructor should not throw any error because it leads to fatal error which cannot be handled.

When stream became invalid (broken pipe etc.), I was unable to terminate application without error.
And as it is stated here little bit down: http://au2.php.net/__construct
> Attempting to throw an exception from a destructor (called in the time of script termination) causes a fatal error.
