### PR TITLE
Fixes an 'Undefined variable: pipes' notice.

### DIFF
--- a/lib/classes/Swift/Transport/StreamBuffer.php
+++ b/lib/classes/Swift/Transport/StreamBuffer.php
@@ -292,6 +292,7 @@ class Swift_Transport_StreamBuffer extends Swift_ByteStream_AbstractFilterableIn
             1 => array('pipe', 'w'),
             2 => array('pipe', 'w'),
             );
+        $pipes = array();
         $this->_stream = proc_open($command, $descriptorSpec, $pipes);
         stream_set_blocking($pipes[2], 0);
         if ($err = stream_get_contents($pipes[2])) {


### PR DESCRIPTION
This is not a significant issue by any stretch of the imagination, but it's a quick fix and there's no reason for this notice to be there.