### PR TITLE
Update dkim

### DIFF
--- a/lib/classes/Swift/Signers/DKIMSigner.php
+++ b/lib/classes/Swift/Signers/DKIMSigner.php
@@ -38,6 +38,7 @@ class Swift_Signers_DKIMSigner implements Swift_Signers_HeaderSigner
 
     /**
      * Hash algorithm used.
+     *
      * @see RFC6376 3.3: Signers MUST implement and SHOULD sign using rsa-sha256.
      *
      * @var string
@@ -175,7 +176,7 @@ class Swift_Signers_DKIMSigner implements Swift_Signers_HeaderSigner
         $this->_domainName = $domainName;
         $this->_signerIdentity = '@'.$domainName;
         $this->_selector = $selector;
-        
+
         // keep fallback hash algorithm sha1, if php version is lower than 5.4.8
         if (version_compare(phpversion(), '5.4.8', '<')) {
             $this->_hashAlgorithm = 'rsa-sha1';
@@ -293,26 +294,27 @@ class Swift_Signers_DKIMSigner implements Swift_Signers_HeaderSigner
     {
         $this->reset();
     }
-    
+
     /**
      * Set hash_algorithm, must be one of rsa-sha256 | rsa-sha1.
      *
      * @param string $hash 'rsa-sha1' or 'rsa-sha256'
      *
      * @throws Swift_SwiftException
-     * 
+     *
      * @return Swift_Signers_DKIMSigner
      */
     public function setHashAlgorithm($hash)
     {
-        switch ($hash){
+        switch ($hash) {
             case 'rsa-sha1':
                 $this->_hashAlgorithm = 'rsa-sha1';
                 break;
             case 'rsa-sha256':
                 $this->_hashAlgorithm = 'rsa-sha256';
-                if (!defined('OPENSSL_ALGO_SHA256'))
+                if (!defined('OPENSSL_ALGO_SHA256')) {
                     throw new Swift_SwiftException('Unable to set sha256, not offered by openssl');
+                }
                 break;
             default:
                 throw new Swift_SwiftException('Unable to set hash algorithm');
@@ -689,7 +691,7 @@ class Swift_Signers_DKIMSigner implements Swift_Signers_HeaderSigner
     private function _getEncryptedHash()
     {
         $signature = '';
-        
+
         switch ($this->_hashAlgorithm) {
             case 'rsa-sha1':
                 $algorithm = OPENSSL_ALGO_SHA1;

--- a/lib/classes/Swift/Signers/DKIMSigner.php
+++ b/lib/classes/Swift/Signers/DKIMSigner.php
@@ -38,10 +38,11 @@ class Swift_Signers_DKIMSigner implements Swift_Signers_HeaderSigner
 
     /**
      * Hash algorithm used.
+     * @see RFC6376 3.3: Signers MUST implement and SHOULD sign using rsa-sha256.
      *
      * @var string
      */
-    protected $_hashAlgorithm = 'rsa-sha1';
+    protected $_hashAlgorithm = 'rsa-sha256';
 
     /**
      * Body canon method.
@@ -174,6 +175,11 @@ class Swift_Signers_DKIMSigner implements Swift_Signers_HeaderSigner
         $this->_domainName = $domainName;
         $this->_signerIdentity = '@'.$domainName;
         $this->_selector = $selector;
+        
+        // keep fallback hash algorithm sha1, if php version is lower than 5.4.8
+        if (version_compare(phpversion(), '5.4.8', '<')) {
+            $this->_hashAlgorithm = 'rsa-sha1';
+        }
     }
 
     /**
@@ -223,6 +229,7 @@ class Swift_Signers_DKIMSigner implements Swift_Signers_HeaderSigner
      *
      * @return int
      */
+    // TODO fix return
     public function write($bytes)
     {
         $this->_canonicalizeBody($bytes);
@@ -234,8 +241,6 @@ class Swift_Signers_DKIMSigner implements Swift_Signers_HeaderSigner
     /**
      * For any bytes that are currently buffered inside the stream, force them
      * off the buffer.
-     *
-     * @throws Swift_IoException
      */
     public function commit()
     {
@@ -276,8 +281,6 @@ class Swift_Signers_DKIMSigner implements Swift_Signers_HeaderSigner
                 return;
             }
         }
-
-        return;
     }
 
     /**
@@ -290,21 +293,29 @@ class Swift_Signers_DKIMSigner implements Swift_Signers_HeaderSigner
     {
         $this->reset();
     }
-
+    
     /**
-     * Set hash_algorithm, must be one of rsa-sha256 | rsa-sha1 defaults to rsa-sha256.
+     * Set hash_algorithm, must be one of rsa-sha256 | rsa-sha1.
      *
-     * @param string $hash
+     * @param string $hash 'rsa-sha1' or 'rsa-sha256'
      *
+     * @throws Swift_SwiftException
+     * 
      * @return Swift_Signers_DKIMSigner
      */
     public function setHashAlgorithm($hash)
     {
-        // Unable to sign with rsa-sha256
-        if ($hash == 'rsa-sha1') {
-            $this->_hashAlgorithm = 'rsa-sha1';
-        } else {
-            $this->_hashAlgorithm = 'rsa-sha256';
+        switch ($hash){
+            case 'rsa-sha1':
+                $this->_hashAlgorithm = 'rsa-sha1';
+                break;
+            case 'rsa-sha256':
+                $this->_hashAlgorithm = 'rsa-sha256';
+                if (!defined('OPENSSL_ALGO_SHA256'))
+                    throw new Swift_SwiftException('Unable to set sha256, not offered by openssl');
+                break;
+            default:
+                throw new Swift_SwiftException('Unable to set hash algorithm');
         }
 
         return $this;
@@ -432,11 +443,11 @@ class Swift_Signers_DKIMSigner implements Swift_Signers_HeaderSigner
     {
         // Init
         switch ($this->_hashAlgorithm) {
-            case 'rsa-sha256':
-                $this->_bodyHashHandler = hash_init('sha256');
-                break;
             case 'rsa-sha1':
                 $this->_bodyHashHandler = hash_init('sha1');
+                break;
+            case 'rsa-sha256':
+                $this->_bodyHashHandler = hash_init('sha256');
                 break;
         }
         $this->_bodyCanonLine = '';
@@ -678,6 +689,7 @@ class Swift_Signers_DKIMSigner implements Swift_Signers_HeaderSigner
     private function _getEncryptedHash()
     {
         $signature = '';
+        
         switch ($this->_hashAlgorithm) {
             case 'rsa-sha1':
                 $algorithm = OPENSSL_ALGO_SHA1;
@@ -685,6 +697,8 @@ class Swift_Signers_DKIMSigner implements Swift_Signers_HeaderSigner
             case 'rsa-sha256':
                 $algorithm = OPENSSL_ALGO_SHA256;
                 break;
+            default:
+                throw new Swift_SwiftException('Unable to set hash algorithm');
         }
         $pkeyId = openssl_get_privatekey($this->_privateKey);
         if (!$pkeyId) {

--- a/tests/unit/Swift/Signers/DKIMSignerTest.php
+++ b/tests/unit/Swift/Signers/DKIMSignerTest.php
@@ -29,12 +29,13 @@ class Swift_Signers_DKIMSignerTest extends \SwiftMailerTestCase
         $signer->addSignature($headers);
     }
 
-    // Default Signing
-    public function testSigningDefaults()
+    // SHA1 Signing
+    public function testSigningSHA1()
     {
         $headerSet = $this->_createHeaderSet();
         $messageContent = 'Hello World';
         $signer = new Swift_Signers_DKIMSigner(file_get_contents(dirname(dirname(dirname(__DIR__))).'/_samples/dkim/dkim.test.priv'), 'dummy.nxdomain.be', 'dummySelector');
+        $signer->setHashAlgorithm('rsa-sha1');
         $signer->setSignatureTimestamp('1299879181');
         $altered = $signer->getAlteredHeaders();
         $this->assertEquals(array('DKIM-Signature'), $altered);


### PR DESCRIPTION
As suggested in #870.

Changes:
 - use sha256 as default
 - old php 5.3 use sha1 still as default, because sha256 is missing
 - test adjusted
