### PR TITLE
fixed a PHP warning when sending a message that has a length of a multiple of 8192

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,8 +4,7 @@ Changelog
 5.4.6 (2017-XX-XX)
 ------------------
 
- * n/a
-
+ * fixed a PHP warning when sending a message that has a length of a multiple of 8192
 
 5.4.5 (2016-12-29)
 ------------------

--- a/lib/classes/Swift/StreamFilters/StringReplacementFilter.php
+++ b/lib/classes/Swift/StreamFilters/StringReplacementFilter.php
@@ -42,6 +42,10 @@ class Swift_StreamFilters_StringReplacementFilter implements Swift_StreamFilter
      */
     public function shouldBuffer($buffer)
     {
+        if ('' === $buffer) {
+            return false;
+        }
+
         $endOfBuffer = substr($buffer, -1);
         foreach ((array) $this->_search as $needle) {
             if (false !== strpos($needle, $endOfBuffer)) {

--- a/tests/acceptance/Swift/ByteStream/FileByteStreamAcceptanceTest.php
+++ b/tests/acceptance/Swift/ByteStream/FileByteStreamAcceptanceTest.php
@@ -50,18 +50,14 @@ class Swift_ByteStream_FileByteStreamAcceptanceTest extends \PHPUnit_Framework_T
 
     public function testFileCanBeWrittenTo()
     {
-        $file = $this->_createFileStream(
-            $this->_testFile, true
-            );
+        $file = $this->_createFileStream($this->_testFile, true);
         $file->write('foobar');
         $this->assertEquals('foobar', $file->read(8192));
     }
 
     public function testReadingFromThenWritingToFile()
     {
-        $file = $this->_createFileStream(
-            $this->_testFile, true
-            );
+        $file = $this->_createFileStream($this->_testFile, true);
         $file->write('foobar');
         $this->assertEquals('foobar', $file->read(8192));
         $file->write('zipbutton');
@@ -70,9 +66,7 @@ class Swift_ByteStream_FileByteStreamAcceptanceTest extends \PHPUnit_Framework_T
 
     public function testWritingToFileWithCanonicalization()
     {
-        $file = $this->_createFileStream(
-            $this->_testFile, true
-            );
+        $file = $this->_createFileStream($this->_testFile, true);
         $file->addFilter($this->_createFilter(array("\r\n", "\r"), "\n"), 'allToLF');
         $file->write("foo\r\nbar\r");
         $file->write("\nzip\r\ntest\r");
@@ -82,9 +76,7 @@ class Swift_ByteStream_FileByteStreamAcceptanceTest extends \PHPUnit_Framework_T
 
     public function testBindingOtherStreamsMirrorsWriteOperations()
     {
-        $file = $this->_createFileStream(
-            $this->_testFile, true
-            );
+        $file = $this->_createFileStream($this->_testFile, true);
         $is1 = $this->_createMockInputStream();
         $is2 = $this->_createMockInputStream();
 
@@ -129,9 +121,7 @@ class Swift_ByteStream_FileByteStreamAcceptanceTest extends \PHPUnit_Framework_T
 
     public function testUnbindingStreamPreventsFurtherWrites()
     {
-        $file = $this->_createFileStream(
-            $this->_testFile, true
-            );
+        $file = $this->_createFileStream($this->_testFile, true);
         $is1 = $this->_createMockInputStream();
         $is2 = $this->_createMockInputStream();
 
@@ -154,8 +144,6 @@ class Swift_ByteStream_FileByteStreamAcceptanceTest extends \PHPUnit_Framework_T
 
         $file->write('y');
     }
-
-    // -- Creation methods
 
     private function _createFilter($search, $replace)
     {

--- a/tests/acceptance/Swift/ByteStream/FileByteStreamAcceptanceTest.php
+++ b/tests/acceptance/Swift/ByteStream/FileByteStreamAcceptanceTest.php
@@ -74,6 +74,15 @@ class Swift_ByteStream_FileByteStreamAcceptanceTest extends \PHPUnit_Framework_T
         $this->assertEquals("foo\nbar\nzip\ntest\n", file_get_contents($this->_testFile));
     }
 
+    public function testWritingWithFulleMessageLengthOfAMultipleOf8192()
+    {
+        $file = $this->_createFileStream($this->_testFile, true);
+        $file->addFilter($this->_createFilter(array("\r\n", "\r"), "\n"), 'allToLF');
+        $file->write('');
+        $file->flushBuffers();
+        $this->assertEquals('', file_get_contents($this->_testFile));
+    }
+
     public function testBindingOtherStreamsMirrorsWriteOperations()
     {
         $file = $this->_createFileStream($this->_testFile, true);

--- a/tests/unit/Swift/StreamFilters/StringReplacementFilterTest.php
+++ b/tests/unit/Swift/StreamFilters/StringReplacementFilterTest.php
@@ -46,7 +46,11 @@ class Swift_StreamFilters_StringReplacementFilterTest extends \PHPUnit_Framework
             );
     }
 
-    // -- Creation methods
+    public function testShouldBufferReturnsFalseOnEmptyBuffer()
+    {
+        $filter = $this->_createFilter("\r\n", "\n");
+        $this->assertFalse($filter->shouldBuffer(''));
+    }
 
     private function _createFilter($search, $replace)
     {


### PR DESCRIPTION
fixes #762, replaces #871