### PR TITLE
[master] update to PHPUnit 6 and php7 only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,6 @@ script: ./vendor/bin/simple-phpunit
 
 matrix:
     include:
-        - php: 5.5
-        - php: 5.6
         - php: 7.0
         - php: 7.1
         - php: hhvm

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_script:
     - gem install mailcatcher
     - mailcatcher --smtp-port 4456
 
-script: ./vendor/bin/simple-phpunit
+script: SYMFONY_PHPUNIT_VERSION=6.1 ./vendor/bin/simple-phpunit
 
 matrix:
     include:

--- a/CHANGES
+++ b/CHANGES
@@ -13,7 +13,7 @@ Changelog
  * removed newInstance() methods everywhere
  * methods operating on Date header now use DateTimeImmutable object instead of Unix timestamp;
    Swift_Mime_Headers_DateHeader::getTimestamp()/setTimestamp() renamed to getDateTime()/setDateTime()
- * bumped minimum version to PHP 5.5
+ * bumped minimum version to PHP 7.0
 
 5.4.8 (2017-XX-XX)
 ------------------

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": ">=5.5.0",
+        "php": ">=7.0.0",
         "egulias/email-validator": "~2.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -16,10 +16,11 @@
     ],
     "require": {
         "php": ">=7.0.0",
-        "egulias/email-validator": "~2.0"
+        "egulias/email-validator": "~2.0",
+        "dkarlovi/symfony-flex-docker": "^0.1"
     },
     "require-dev": {
-        "mockery/mockery": "~0.9.1",
+        "mockery/mockery": "~1.0@dev",
         "symfony/phpunit-bridge": "~3.3@dev"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "dkarlovi/symfony-flex-docker": "^0.1"
     },
     "require-dev": {
-        "mockery/mockery": "~1.0@dev",
+        "mockery/mockery": "~0.9.1",
         "symfony/phpunit-bridge": "~3.3@dev"
     },
     "autoload": {

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -18,18 +18,7 @@ the long run if you at least read between the lines here.
 System Requirements
 -------------------
 
-The basic requirements to operate Swift Mailer are extremely minimal and
-easily achieved. Historically, Swift Mailer has supported both PHP 4 and PHP 5
-by following a parallel development workflow. Now in it's fourth major
-version, and Swift Mailer operates on servers running PHP 5.5 or higher.
-
-The library aims to work with as many PHP 5 projects as possible:
-
-* PHP 5.5 or higher, with the SPL extension (standard)
-
-* Limited network access to connect to remote SMTP servers
-
-* 8 MB or more memory limit (Swift Mailer uses around 2 MB)
+Swift Mailer operates on servers running PHP 7.0 or higher.
 
 Component Breakdown
 -------------------

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -33,9 +33,6 @@
     </testsuites>
 
     <listeners>
-        <!--
         <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
-        <listener class="Mockery\Adapter\Phpunit\TestListener" />
-        -->
     </listeners>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -33,7 +33,9 @@
     </testsuites>
 
     <listeners>
+        <!--
         <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
         <listener class="Mockery\Adapter\Phpunit\TestListener" />
+        -->
     </listeners>
 </phpunit>

--- a/tests/IdenticalBinaryConstraint.php
+++ b/tests/IdenticalBinaryConstraint.php
@@ -5,7 +5,7 @@
  *
  * @author Chris Corbyn
  */
-class IdenticalBinaryConstraint extends \PHPUnit_Framework_Constraint
+class IdenticalBinaryConstraint extends \PHPUnit\Framework\Constraint\Constraint
 {
     protected $value;
 
@@ -37,7 +37,7 @@ class IdenticalBinaryConstraint extends \PHPUnit_Framework_Constraint
      */
     public function toString()
     {
-        return 'indentical binary';
+        return 'identical binary';
     }
 
     /**

--- a/tests/SwiftMailerTestCase.php
+++ b/tests/SwiftMailerTestCase.php
@@ -1,5 +1,7 @@
 <?php
 
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+
 /**
  * A base test case with some custom expectations.
  *
@@ -7,6 +9,8 @@
  */
 class SwiftMailerTestCase extends \PHPUnit\Framework\TestCase
 {
+    use MockeryPHPUnitIntegration;
+
     public static function regExp($pattern)
     {
         if (!is_string($pattern)) {

--- a/tests/SwiftMailerTestCase.php
+++ b/tests/SwiftMailerTestCase.php
@@ -5,7 +5,7 @@
  *
  * @author Rouven Weßling
  */
-class SwiftMailerTestCase extends \PHPUnit_Framework_TestCase
+class SwiftMailerTestCase extends \PHPUnit\Framework\TestCase
 {
     public static function regExp($pattern)
     {
@@ -13,7 +13,7 @@ class SwiftMailerTestCase extends \PHPUnit_Framework_TestCase
             throw PHPUnit_Util_InvalidArgumentHelper::factory(1, 'string');
         }
 
-        return new PHPUnit_Framework_Constraint_PCREMatch($pattern);
+        return new \PHPUnit\Framework\Constraint\RegularExpression($pattern);
     }
 
     public function assertIdenticalBinary($expected, $actual, $message = '')

--- a/tests/acceptance/Swift/ByteStream/FileByteStreamAcceptanceTest.php
+++ b/tests/acceptance/Swift/ByteStream/FileByteStreamAcceptanceTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class Swift_ByteStream_FileByteStreamAcceptanceTest extends \PHPUnit_Framework_TestCase
+class Swift_ByteStream_FileByteStreamAcceptanceTest extends \PHPUnit\Framework\TestCase
 {
     private $_testFile;
 

--- a/tests/acceptance/Swift/CharacterReaderFactory/SimpleCharacterReaderFactoryAcceptanceTest.php
+++ b/tests/acceptance/Swift/CharacterReaderFactory/SimpleCharacterReaderFactoryAcceptanceTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class Swift_CharacterReaderFactory_SimpleCharacterReaderFactoryAcceptanceTest extends \PHPUnit_Framework_TestCase
+class Swift_CharacterReaderFactory_SimpleCharacterReaderFactoryAcceptanceTest extends \PHPUnit\Framework\TestCase
 {
     private $factory;
     private $prefix = 'Swift_CharacterReader_';

--- a/tests/acceptance/Swift/DependencyContainerAcceptanceTest.php
+++ b/tests/acceptance/Swift/DependencyContainerAcceptanceTest.php
@@ -4,7 +4,7 @@ require_once 'swift_required.php';
 
 //This is more of a "cross your fingers and hope it works" test!
 
-class Swift_DependencyContainerAcceptanceTest extends \PHPUnit_Framework_TestCase
+class Swift_DependencyContainerAcceptanceTest extends PHPUnit\Framework\TestCase
 {
     public function testNoLookupsFail()
     {

--- a/tests/acceptance/Swift/DependencyContainerAcceptanceTest.php
+++ b/tests/acceptance/Swift/DependencyContainerAcceptanceTest.php
@@ -16,5 +16,7 @@ class Swift_DependencyContainerAcceptanceTest extends PHPUnit\Framework\TestCase
                 $this->fail($e->getMessage());
             }
         }
+        // previous loop would fail if there is an issue
+        $this->addToAssertionCount(1);
     }
 }

--- a/tests/acceptance/Swift/Encoder/Base64EncoderAcceptanceTest.php
+++ b/tests/acceptance/Swift/Encoder/Base64EncoderAcceptanceTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class Swift_Encoder_Base64EncoderAcceptanceTest extends \PHPUnit_Framework_TestCase
+class Swift_Encoder_Base64EncoderAcceptanceTest extends \PHPUnit\Framework\TestCase
 {
     private $samplesDir;
     private $encoder;

--- a/tests/acceptance/Swift/Encoder/QpEncoderAcceptanceTest.php
+++ b/tests/acceptance/Swift/Encoder/QpEncoderAcceptanceTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class Swift_Encoder_QpEncoderAcceptanceTest extends \PHPUnit_Framework_TestCase
+class Swift_Encoder_QpEncoderAcceptanceTest extends \PHPUnit\Framework\TestCase
 {
     private $samplesDir;
     private $factory;

--- a/tests/acceptance/Swift/Encoder/Rfc2231EncoderAcceptanceTest.php
+++ b/tests/acceptance/Swift/Encoder/Rfc2231EncoderAcceptanceTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class Swift_Encoder_Rfc2231EncoderAcceptanceTest extends \PHPUnit_Framework_TestCase
+class Swift_Encoder_Rfc2231EncoderAcceptanceTest extends \PHPUnit\Framework\TestCase
 {
     private $samplesDir;
     private $factory;

--- a/tests/acceptance/Swift/KeyCache/ArrayKeyCacheAcceptanceTest.php
+++ b/tests/acceptance/Swift/KeyCache/ArrayKeyCacheAcceptanceTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class Swift_KeyCache_ArrayKeyCacheAcceptanceTest extends \PHPUnit_Framework_TestCase
+class Swift_KeyCache_ArrayKeyCacheAcceptanceTest extends \PHPUnit\Framework\TestCase
 {
     private $cache;
     private $key1 = 'key1';

--- a/tests/acceptance/Swift/KeyCache/DiskKeyCacheAcceptanceTest.php
+++ b/tests/acceptance/Swift/KeyCache/DiskKeyCacheAcceptanceTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class Swift_KeyCache_DiskKeyCacheAcceptanceTest extends \PHPUnit_Framework_TestCase
+class Swift_KeyCache_DiskKeyCacheAcceptanceTest extends \PHPUnit\Framework\TestCase
 {
     private $cache;
     private $key1;

--- a/tests/acceptance/Swift/Mime/AttachmentAcceptanceTest.php
+++ b/tests/acceptance/Swift/Mime/AttachmentAcceptanceTest.php
@@ -2,7 +2,7 @@
 
 use Egulias\EmailValidator\EmailValidator;
 
-class Swift_Mime_AttachmentAcceptanceTest extends \PHPUnit_Framework_TestCase
+class Swift_Mime_AttachmentAcceptanceTest extends \PHPUnit\Framework\TestCase
 {
     private $contentEncoder;
     private $cache;

--- a/tests/acceptance/Swift/Mime/ContentEncoder/Base64ContentEncoderAcceptanceTest.php
+++ b/tests/acceptance/Swift/Mime/ContentEncoder/Base64ContentEncoderAcceptanceTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class Swift_Mime_ContentEncoder_Base64ContentEncoderAcceptanceTest extends \PHPUnit_Framework_TestCase
+class Swift_Mime_ContentEncoder_Base64ContentEncoderAcceptanceTest extends \PHPUnit\Framework\TestCase
 {
     private $samplesDir;
     private $encoder;

--- a/tests/acceptance/Swift/Mime/ContentEncoder/NativeQpContentEncoderAcceptanceTest.php
+++ b/tests/acceptance/Swift/Mime/ContentEncoder/NativeQpContentEncoderAcceptanceTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class Swift_Mime_ContentEncoder_NativeQpContentEncoderAcceptanceTest extends \PHPUnit_Framework_TestCase
+class Swift_Mime_ContentEncoder_NativeQpContentEncoderAcceptanceTest extends \PHPUnit\Framework\TestCase
 {
     protected $_samplesDir;
 

--- a/tests/acceptance/Swift/Mime/ContentEncoder/PlainContentEncoderAcceptanceTest.php
+++ b/tests/acceptance/Swift/Mime/ContentEncoder/PlainContentEncoderAcceptanceTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class Swift_Mime_ContentEncoder_PlainContentEncoderAcceptanceTest extends \PHPUnit_Framework_TestCase
+class Swift_Mime_ContentEncoder_PlainContentEncoderAcceptanceTest extends \PHPUnit\Framework\TestCase
 {
     private $samplesDir;
     private $encoder;

--- a/tests/acceptance/Swift/Mime/ContentEncoder/QpContentEncoderAcceptanceTest.php
+++ b/tests/acceptance/Swift/Mime/ContentEncoder/QpContentEncoderAcceptanceTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class Swift_Mime_ContentEncoder_QpContentEncoderAcceptanceTest extends \PHPUnit_Framework_TestCase
+class Swift_Mime_ContentEncoder_QpContentEncoderAcceptanceTest extends \PHPUnit\Framework\TestCase
 {
     private $samplesDir;
     private $factory;

--- a/tests/acceptance/Swift/Mime/EmbeddedFileAcceptanceTest.php
+++ b/tests/acceptance/Swift/Mime/EmbeddedFileAcceptanceTest.php
@@ -2,7 +2,7 @@
 
 use Egulias\EmailValidator\EmailValidator;
 
-class Swift_Mime_EmbeddedFileAcceptanceTest extends \PHPUnit_Framework_TestCase
+class Swift_Mime_EmbeddedFileAcceptanceTest extends \PHPUnit\Framework\TestCase
 {
     private $contentEncoder;
     private $cache;

--- a/tests/acceptance/Swift/Mime/HeaderEncoder/Base64HeaderEncoderAcceptanceTest.php
+++ b/tests/acceptance/Swift/Mime/HeaderEncoder/Base64HeaderEncoderAcceptanceTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class Swift_Mime_HeaderEncoder_Base64HeaderEncoderAcceptanceTest extends \PHPUnit_Framework_TestCase
+class Swift_Mime_HeaderEncoder_Base64HeaderEncoderAcceptanceTest extends \PHPUnit\Framework\TestCase
 {
     private $encoder;
 

--- a/tests/acceptance/Swift/Mime/MimePartAcceptanceTest.php
+++ b/tests/acceptance/Swift/Mime/MimePartAcceptanceTest.php
@@ -2,7 +2,7 @@
 
 use Egulias\EmailValidator\EmailValidator;
 
-class Swift_Mime_MimePartAcceptanceTest extends \PHPUnit_Framework_TestCase
+class Swift_Mime_MimePartAcceptanceTest extends \PHPUnit\Framework\TestCase
 {
     private $contentEncoder;
     private $cache;

--- a/tests/acceptance/Swift/Mime/SimpleMessageAcceptanceTest.php
+++ b/tests/acceptance/Swift/Mime/SimpleMessageAcceptanceTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class Swift_Mime_SimpleMessageAcceptanceTest extends \PHPUnit_Framework_TestCase
+class Swift_Mime_SimpleMessageAcceptanceTest extends \PHPUnit\Framework\TestCase
 {
     protected function setUp()
     {

--- a/tests/acceptance/Swift/Transport/StreamBuffer/AbstractStreamBufferAcceptanceTest.php
+++ b/tests/acceptance/Swift/Transport/StreamBuffer/AbstractStreamBufferAcceptanceTest.php
@@ -1,6 +1,6 @@
 <?php
 
-abstract class Swift_Transport_StreamBuffer_AbstractStreamBufferAcceptanceTest extends \PHPUnit_Framework_TestCase
+abstract class Swift_Transport_StreamBuffer_AbstractStreamBufferAcceptanceTest extends \PHPUnit\Framework\TestCase
 {
     protected $buffer;
 

--- a/tests/acceptance/Swift/Transport/StreamBuffer/SocketTimeoutTest.php
+++ b/tests/acceptance/Swift/Transport/StreamBuffer/SocketTimeoutTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class Swift_Transport_StreamBuffer_SocketTimeoutTest extends \PHPUnit_Framework_TestCase
+class Swift_Transport_StreamBuffer_SocketTimeoutTest extends \PHPUnit\Framework\TestCase
 {
     protected $buffer;
     protected $server;

--- a/tests/bug/Swift/Bug111Test.php
+++ b/tests/bug/Swift/Bug111Test.php
@@ -1,6 +1,6 @@
 <?php
 
-class Swift_Bug111Test extends \PHPUnit_Framework_TestCase
+class Swift_Bug111Test extends \PHPUnit\Framework\TestCase
 {
     public function testUnstructuredHeaderSlashesShouldNotBeEscaped()
     {

--- a/tests/bug/Swift/Bug118Test.php
+++ b/tests/bug/Swift/Bug118Test.php
@@ -1,6 +1,6 @@
 <?php
 
-class Swift_Bug118Test extends \PHPUnit_Framework_TestCase
+class Swift_Bug118Test extends \PHPUnit\Framework\TestCase
 {
     private $message;
 

--- a/tests/bug/Swift/Bug206Test.php
+++ b/tests/bug/Swift/Bug206Test.php
@@ -2,7 +2,7 @@
 
 use Egulias\EmailValidator\EmailValidator;
 
-class Swift_Bug206Test extends \PHPUnit_Framework_TestCase
+class Swift_Bug206Test extends \PHPUnit\Framework\TestCase
 {
     private $factory;
 

--- a/tests/bug/Swift/Bug274Test.php
+++ b/tests/bug/Swift/Bug274Test.php
@@ -1,12 +1,21 @@
 <?php
 
-class Swift_Bug274Test extends \PHPUnit_Framework_TestCase
+// TODO update test
+
+class Swift_Bug274Test extends \PHPUnit\Framework\TestCase
 {
     public function testEmptyFileNameAsAttachment()
     {
         $message = new Swift_Message();
-        $this->setExpectedException('Swift_IoException', 'The path cannot be empty');
-        $message->attach(Swift_Attachment::fromPath(''));
+        // TODO no longer supported by phpunit test must be modified
+        // $this->setExpectedException('Swift_IoException', 'The path cannot be empty');
+        try {
+            $message->attach(Swift_Attachment::fromPath(''));
+        } catch (Exception $e) {
+            if (!is_a($e, 'Swift_IoException')) {
+                $this->fail('Expected Swift_IoException - The path cannot be empty');
+            }
+        }
     }
 
     public function testNonEmptyFileNameAsAttachment()

--- a/tests/bug/Swift/Bug274Test.php
+++ b/tests/bug/Swift/Bug274Test.php
@@ -1,21 +1,15 @@
 <?php
 
-// TODO update test
-
 class Swift_Bug274Test extends \PHPUnit\Framework\TestCase
 {
+    /**
+     * @expectedException \Swift_IoException
+     * @expectedMessageException The path cannot be empty
+     */
     public function testEmptyFileNameAsAttachment()
     {
         $message = new Swift_Message();
-        // TODO no longer supported by phpunit test must be modified
-        // $this->setExpectedException('Swift_IoException', 'The path cannot be empty');
-        try {
-            $message->attach(Swift_Attachment::fromPath(''));
-        } catch (Exception $e) {
-            if (!is_a($e, 'Swift_IoException')) {
-                $this->fail('Expected Swift_IoException - The path cannot be empty');
-            }
-        }
+        $message->attach(Swift_Attachment::fromPath(''));
     }
 
     public function testNonEmptyFileNameAsAttachment()
@@ -26,5 +20,6 @@ class Swift_Bug274Test extends \PHPUnit\Framework\TestCase
         } catch (Exception $e) {
             $this->fail('Path should not be empty');
         }
+        $this->addToAssertionCount(1);
     }
 }

--- a/tests/bug/Swift/Bug34Test.php
+++ b/tests/bug/Swift/Bug34Test.php
@@ -1,6 +1,6 @@
 <?php
 
-class Swift_Bug34Test extends \PHPUnit_Framework_TestCase
+class Swift_Bug34Test extends \PHPUnit\Framework\TestCase
 {
     protected function setUp()
     {

--- a/tests/bug/Swift/Bug35Test.php
+++ b/tests/bug/Swift/Bug35Test.php
@@ -1,6 +1,6 @@
 <?php
 
-class Swift_Bug35Test extends \PHPUnit_Framework_TestCase
+class Swift_Bug35Test extends \PHPUnit\Framework\TestCase
 {
     protected function setUp()
     {

--- a/tests/bug/Swift/Bug38Test.php
+++ b/tests/bug/Swift/Bug38Test.php
@@ -1,6 +1,6 @@
 <?php
 
-class Swift_Bug38Test extends \PHPUnit_Framework_TestCase
+class Swift_Bug38Test extends \PHPUnit\Framework\TestCase
 {
     private $attFile;
     private $attFileName;

--- a/tests/bug/Swift/Bug650Test.php
+++ b/tests/bug/Swift/Bug650Test.php
@@ -2,7 +2,7 @@
 
 use Egulias\EmailValidator\EmailValidator;
 
-class Swift_Bug650Test extends \PHPUnit_Framework_TestCase
+class Swift_Bug650Test extends \PHPUnit\Framework\TestCase
 {
     /**
      * @dataProvider encodingDataProvider

--- a/tests/bug/Swift/Bug71Test.php
+++ b/tests/bug/Swift/Bug71Test.php
@@ -1,6 +1,6 @@
 <?php
 
-class Swift_Bug71Test extends \PHPUnit_Framework_TestCase
+class Swift_Bug71Test extends \PHPUnit\Framework\TestCase
 {
     private $message;
 

--- a/tests/bug/Swift/Bug76Test.php
+++ b/tests/bug/Swift/Bug76Test.php
@@ -1,6 +1,6 @@
 <?php
 
-class Swift_Bug76Test extends \PHPUnit_Framework_TestCase
+class Swift_Bug76Test extends \PHPUnit\Framework\TestCase
 {
     private $inputFile;
     private $outputFile;

--- a/tests/bug/Swift/BugFileByteStreamConsecutiveReadCallsTest.php
+++ b/tests/bug/Swift/BugFileByteStreamConsecutiveReadCallsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class Swift_FileByteStreamConsecutiveReadCalls extends \PHPUnit_Framework_TestCase
+class Swift_FileByteStreamConsecutiveReadCalls extends \PHPUnit\Framework\TestCase
 {
     /**
      * @test

--- a/tests/unit/Swift/ByteStream/ArrayByteStreamTest.php
+++ b/tests/unit/Swift/ByteStream/ArrayByteStreamTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class Swift_ByteStream_ArrayByteStreamTest extends \PHPUnit_Framework_TestCase
+class Swift_ByteStream_ArrayByteStreamTest extends \PHPUnit\Framework\TestCase
 {
     public function testReadingSingleBytesFromBaseInput()
     {

--- a/tests/unit/Swift/CharacterReader/GenericFixedWidthReaderTest.php
+++ b/tests/unit/Swift/CharacterReader/GenericFixedWidthReaderTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class Swift_CharacterReader_GenericFixedWidthReaderTest extends \PHPUnit_Framework_TestCase
+class Swift_CharacterReader_GenericFixedWidthReaderTest extends \PHPUnit\Framework\TestCase
 {
     public function testInitialByteSizeMatchesWidth()
     {

--- a/tests/unit/Swift/CharacterReader/UsAsciiReaderTest.php
+++ b/tests/unit/Swift/CharacterReader/UsAsciiReaderTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class Swift_CharacterReader_UsAsciiReaderTest extends \PHPUnit_Framework_TestCase
+class Swift_CharacterReader_UsAsciiReaderTest extends \PHPUnit\Framework\TestCase
 {
     /*
 

--- a/tests/unit/Swift/CharacterReader/Utf8ReaderTest.php
+++ b/tests/unit/Swift/CharacterReader/Utf8ReaderTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class Swift_CharacterReader_Utf8ReaderTest extends \PHPUnit_Framework_TestCase
+class Swift_CharacterReader_Utf8ReaderTest extends \PHPUnit\Framework\TestCase
 {
     private $reader;
 

--- a/tests/unit/Swift/DependencyContainerTest.php
+++ b/tests/unit/Swift/DependencyContainerTest.php
@@ -12,7 +12,7 @@ class One
     }
 }
 
-class Swift_DependencyContainerTest extends \PHPUnit_Framework_TestCase
+class Swift_DependencyContainerTest extends \PHPUnit\Framework\TestCase
 {
     private $container;
 

--- a/tests/unit/Swift/Encoder/Base64EncoderTest.php
+++ b/tests/unit/Swift/Encoder/Base64EncoderTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class Swift_Encoder_Base64EncoderTest extends \PHPUnit_Framework_TestCase
+class Swift_Encoder_Base64EncoderTest extends \PHPUnit\Framework\TestCase
 {
     private $encoder;
 

--- a/tests/unit/Swift/Events/CommandEventTest.php
+++ b/tests/unit/Swift/Events/CommandEventTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class Swift_Events_CommandEventTest extends \PHPUnit_Framework_TestCase
+class Swift_Events_CommandEventTest extends \PHPUnit\Framework\TestCase
 {
     public function testCommandCanBeFetchedByGetter()
     {

--- a/tests/unit/Swift/Events/EventObjectTest.php
+++ b/tests/unit/Swift/Events/EventObjectTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class Swift_Events_EventObjectTest extends \PHPUnit_Framework_TestCase
+class Swift_Events_EventObjectTest extends \PHPUnit\Framework\TestCase
 {
     public function testEventSourceCanBeReturnedViaGetter()
     {

--- a/tests/unit/Swift/Events/ResponseEventTest.php
+++ b/tests/unit/Swift/Events/ResponseEventTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class Swift_Events_ResponseEventTest extends \PHPUnit_Framework_TestCase
+class Swift_Events_ResponseEventTest extends \PHPUnit\Framework\TestCase
 {
     public function testResponseCanBeFetchViaGetter()
     {

--- a/tests/unit/Swift/Events/SendEventTest.php
+++ b/tests/unit/Swift/Events/SendEventTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class Swift_Events_SendEventTest extends \PHPUnit_Framework_TestCase
+class Swift_Events_SendEventTest extends \PHPUnit\Framework\TestCase
 {
     public function testMessageCanBeFetchedViaGetter()
     {

--- a/tests/unit/Swift/Events/SimpleEventDispatcherTest.php
+++ b/tests/unit/Swift/Events/SimpleEventDispatcherTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class Swift_Events_SimpleEventDispatcherTest extends \PHPUnit_Framework_TestCase
+class Swift_Events_SimpleEventDispatcherTest extends \PHPUnit\Framework\TestCase
 {
     private $dispatcher;
 

--- a/tests/unit/Swift/Events/TransportChangeEventTest.php
+++ b/tests/unit/Swift/Events/TransportChangeEventTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class Swift_Events_TransportChangeEventTest extends \PHPUnit_Framework_TestCase
+class Swift_Events_TransportChangeEventTest extends \PHPUnit\Framework\TestCase
 {
     public function testGetTransportReturnsTransport()
     {

--- a/tests/unit/Swift/Events/TransportExceptionEventTest.php
+++ b/tests/unit/Swift/Events/TransportExceptionEventTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class Swift_Events_TransportExceptionEventTest extends \PHPUnit_Framework_TestCase
+class Swift_Events_TransportExceptionEventTest extends \PHPUnit\Framework\TestCase
 {
     public function testExceptionCanBeFetchViaGetter()
     {

--- a/tests/unit/Swift/KeyCache/ArrayKeyCacheTest.php
+++ b/tests/unit/Swift/KeyCache/ArrayKeyCacheTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class Swift_KeyCache_ArrayKeyCacheTest extends \PHPUnit_Framework_TestCase
+class Swift_KeyCache_ArrayKeyCacheTest extends \PHPUnit\Framework\TestCase
 {
     private $key1 = 'key1';
     private $key2 = 'key2';

--- a/tests/unit/Swift/KeyCache/SimpleKeyCacheInputStreamTest.php
+++ b/tests/unit/Swift/KeyCache/SimpleKeyCacheInputStreamTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class Swift_KeyCache_SimpleKeyCacheInputStreamTest extends \PHPUnit_Framework_TestCase
+class Swift_KeyCache_SimpleKeyCacheInputStreamTest extends \PHPUnit\Framework\TestCase
 {
     private $nsKey = 'ns1';
 

--- a/tests/unit/Swift/Mailer/ArrayRecipientIteratorTest.php
+++ b/tests/unit/Swift/Mailer/ArrayRecipientIteratorTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class Swift_Mailer_ArrayRecipientIteratorTest extends \PHPUnit_Framework_TestCase
+class Swift_Mailer_ArrayRecipientIteratorTest extends \PHPUnit\Framework\TestCase
 {
     public function testHasNextReturnsFalseForEmptyArray()
     {

--- a/tests/unit/Swift/MessageTest.php
+++ b/tests/unit/Swift/MessageTest.php
@@ -9,6 +9,8 @@ class Swift_MessageTest extends \PHPUnit\Framework\TestCase
         $message1_clone = clone $message1;
 
         $this->recursiveObjectCloningCheck($message1, $message2, $message1_clone);
+        // the test above will fail if the two messages are not identical
+        $this->addToAssertionCount(1);
     }
 
     public function testCloningWithSigners()
@@ -22,6 +24,8 @@ class Swift_MessageTest extends \PHPUnit\Framework\TestCase
         $message1_clone = clone $message1;
 
         $this->recursiveObjectCloningCheck($message1, $message2, $message1_clone);
+        // the test above will fail if the two messages are not identical
+        $this->addToAssertionCount(1);
     }
 
     public function testBodySwap()

--- a/tests/unit/Swift/MessageTest.php
+++ b/tests/unit/Swift/MessageTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class Swift_MessageTest extends \PHPUnit_Framework_TestCase
+class Swift_MessageTest extends \PHPUnit\Framework\TestCase
 {
     public function testCloning()
     {

--- a/tests/unit/Swift/Mime/EmbeddedFileTest.php
+++ b/tests/unit/Swift/Mime/EmbeddedFileTest.php
@@ -5,7 +5,8 @@ class Swift_Mime_EmbeddedFileTest extends Swift_Mime_AttachmentTest
 {
     public function testNestingLevelIsAttachment()
     {
-        //Overridden
+        // previous loop would fail if there is an issue
+        $this->addToAssertionCount(1);
     }
 
     public function testNestingLevelIsEmbedded()

--- a/tests/unit/Swift/Mime/HeaderEncoder/Base64HeaderEncoderTest.php
+++ b/tests/unit/Swift/Mime/HeaderEncoder/Base64HeaderEncoderTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class Swift_Mime_HeaderEncoder_Base64HeaderEncoderTest extends \PHPUnit_Framework_TestCase
+class Swift_Mime_HeaderEncoder_Base64HeaderEncoderTest extends \PHPUnit\Framework\TestCase
 {
     //Most tests are already covered in Base64EncoderTest since this subclass only
     // adds a getName() method

--- a/tests/unit/Swift/Mime/Headers/DateHeaderTest.php
+++ b/tests/unit/Swift/Mime/Headers/DateHeaderTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class Swift_Mime_Headers_DateHeaderTest extends \PHPUnit_Framework_TestCase
+class Swift_Mime_Headers_DateHeaderTest extends \PHPUnit\Framework\TestCase
 {
     /* --
     The following tests refer to RFC 2822, section 3.6.1 and 3.3.

--- a/tests/unit/Swift/Mime/Headers/IdentificationHeaderTest.php
+++ b/tests/unit/Swift/Mime/Headers/IdentificationHeaderTest.php
@@ -2,7 +2,7 @@
 
 use Egulias\EmailValidator\EmailValidator;
 
-class Swift_Mime_Headers_IdentificationHeaderTest extends \PHPUnit_Framework_TestCase
+class Swift_Mime_Headers_IdentificationHeaderTest extends \PHPUnit\Framework\TestCase
 {
     public function testTypeIsIdHeader()
     {

--- a/tests/unit/Swift/Mime/Headers/IdentificationHeaderTest.php
+++ b/tests/unit/Swift/Mime/Headers/IdentificationHeaderTest.php
@@ -99,16 +99,14 @@ class Swift_Mime_Headers_IdentificationHeaderTest extends \PHPUnit\Framework\Tes
         $this->assertEquals('<a.b+&%$.c@d>', $header->getFieldBody());
     }
 
+    /**
+     * @expectedException \Exception
+     * @expectedMessageException "a b c" is not valid id-left
+     */
     public function testInvalidIdLeftThrowsException()
     {
-        try {
-            $header = $this->getHeader('References');
-            $header->setId('a b c@d');
-            $this->fail(
-                'Exception should be thrown since "a b c" is not valid id-left.'
-                );
-        } catch (Exception $e) {
-        }
+        $header = $this->getHeader('References');
+        $header->setId('a b c@d');
     }
 
     public function testIdRightCanBeDotAtom()
@@ -135,32 +133,27 @@ class Swift_Mime_Headers_IdentificationHeaderTest extends \PHPUnit\Framework\Tes
         $this->assertEquals('<a@[1.2.3.4]>', $header->getFieldBody());
     }
 
+    /**
+     * @expectedException \Exception
+     * @expectedMessageException "b c d" is not valid id-right
+     */
     public function testInvalidIdRightThrowsException()
     {
-        try {
-            $header = $this->getHeader('References');
-            $header->setId('a@b c d');
-            $this->fail(
-                'Exception should be thrown since "b c d" is not valid id-right.'
-                );
-        } catch (Exception $e) {
-        }
+        $header = $this->getHeader('References');
+        $header->setId('a@b c d');
     }
 
+    /**
+     * @expectedException \Exception
+     * @expectedMessageException "abc" is does not contain @
+     */
     public function testMissingAtSignThrowsException()
     {
         /* -- RFC 2822, 3.6.4.
      msg-id          =       [CFWS] "<" id-left "@" id-right ">" [CFWS]
      */
-
-        try {
-            $header = $this->getHeader('References');
-            $header->setId('abc');
-            $this->fail(
-                'Exception should be thrown since "abc" is does not contain @.'
-                );
-        } catch (Exception $e) {
-        }
+        $header = $this->getHeader('References');
+        $header->setId('abc');
     }
 
     public function testSetBodyModel()

--- a/tests/unit/Swift/Mime/Headers/PathHeaderTest.php
+++ b/tests/unit/Swift/Mime/Headers/PathHeaderTest.php
@@ -2,7 +2,7 @@
 
 use Egulias\EmailValidator\EmailValidator;
 
-class Swift_Mime_Headers_PathHeaderTest extends \PHPUnit_Framework_TestCase
+class Swift_Mime_Headers_PathHeaderTest extends \PHPUnit\Framework\TestCase
 {
     public function testTypeIsPathHeader()
     {

--- a/tests/unit/Swift/Mime/Headers/PathHeaderTest.php
+++ b/tests/unit/Swift/Mime/Headers/PathHeaderTest.php
@@ -17,14 +17,13 @@ class Swift_Mime_Headers_PathHeaderTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('chris@swiftmailer.org', $header->getAddress());
     }
 
+    /**
+     * @expectedException \Exception
+     */
     public function testAddressMustComplyWithRfc2822()
     {
-        try {
-            $header = $this->getHeader('Return-Path');
-            $header->setAddress('chr is@swiftmailer.org');
-            $this->fail('Addresses not valid according to RFC 2822 addr-spec grammar must be rejected.');
-        } catch (Exception $e) {
-        }
+        $header = $this->getHeader('Return-Path');
+        $header->setAddress('chr is@swiftmailer.org');
     }
 
     public function testValueIsAngleAddrWithValidAddress()

--- a/tests/unit/Swift/Mime/IdGeneratorTest.php
+++ b/tests/unit/Swift/Mime/IdGeneratorTest.php
@@ -3,7 +3,7 @@
 use Egulias\EmailValidator\EmailValidator;
 use Egulias\EmailValidator\Validation\RFCValidation;
 
-class Swift_Mime_IdGeneratorTest extends \PHPUnit_Framework_TestCase
+class Swift_Mime_IdGeneratorTest extends \PHPUnit\Framework\TestCase
 {
     protected $emailValidator;
     protected $originalServerName;

--- a/tests/unit/Swift/Mime/SimpleHeaderFactoryTest.php
+++ b/tests/unit/Swift/Mime/SimpleHeaderFactoryTest.php
@@ -2,7 +2,7 @@
 
 use Egulias\EmailValidator\EmailValidator;
 
-class Swift_Mime_SimpleHeaderFactoryTest extends \PHPUnit_Framework_TestCase
+class Swift_Mime_SimpleHeaderFactoryTest extends \PHPUnit\Framework\TestCase
 {
     private $factory;
 

--- a/tests/unit/Swift/Mime/SimpleHeaderSetTest.php
+++ b/tests/unit/Swift/Mime/SimpleHeaderSetTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class Swift_Mime_SimpleHeaderSetTest extends \PHPUnit_Framework_TestCase
+class Swift_Mime_SimpleHeaderSetTest extends \PHPUnit\Framework\TestCase
 {
     public function testAddMailboxHeaderDelegatesToFactory()
     {

--- a/tests/unit/Swift/Mime/SimpleMessageTest.php
+++ b/tests/unit/Swift/Mime/SimpleMessageTest.php
@@ -5,7 +5,8 @@ class Swift_Mime_SimpleMessageTest extends Swift_Mime_MimePartTest
 {
     public function testNestingLevelIsSubpart()
     {
-        //Overridden
+        // not relevant
+        $this->addToAssertionCount(1);
     }
 
     public function testNestingLevelIsTop()

--- a/tests/unit/Swift/Plugins/AntiFloodPluginTest.php
+++ b/tests/unit/Swift/Plugins/AntiFloodPluginTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class Swift_Plugins_AntiFloodPluginTest extends \PHPUnit_Framework_TestCase
+class Swift_Plugins_AntiFloodPluginTest extends \PHPUnit\Framework\TestCase
 {
     public function testThresholdCanBeSetAndFetched()
     {

--- a/tests/unit/Swift/Plugins/BandwidthMonitorPluginTest.php
+++ b/tests/unit/Swift/Plugins/BandwidthMonitorPluginTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class Swift_Plugins_BandwidthMonitorPluginTest extends \PHPUnit_Framework_TestCase
+class Swift_Plugins_BandwidthMonitorPluginTest extends \PHPUnit\Framework\TestCase
 {
     private $_monitor;
 

--- a/tests/unit/Swift/Plugins/Loggers/ArrayLoggerTest.php
+++ b/tests/unit/Swift/Plugins/Loggers/ArrayLoggerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class Swift_Plugins_Loggers_ArrayLoggerTest extends \PHPUnit_Framework_TestCase
+class Swift_Plugins_Loggers_ArrayLoggerTest extends \PHPUnit\Framework\TestCase
 {
     public function testAddingSingleEntryDumpsSingleLine()
     {

--- a/tests/unit/Swift/Plugins/Loggers/EchoLoggerTest.php
+++ b/tests/unit/Swift/Plugins/Loggers/EchoLoggerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class Swift_Plugins_Loggers_EchoLoggerTest extends \PHPUnit_Framework_TestCase
+class Swift_Plugins_Loggers_EchoLoggerTest extends \PHPUnit\Framework\TestCase
 {
     public function testAddingEntryDumpsSingleLineWithoutHtml()
     {

--- a/tests/unit/Swift/Plugins/PopBeforeSmtpPluginTest.php
+++ b/tests/unit/Swift/Plugins/PopBeforeSmtpPluginTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class Swift_Plugins_PopBeforeSmtpPluginTest extends \PHPUnit_Framework_TestCase
+class Swift_Plugins_PopBeforeSmtpPluginTest extends \PHPUnit\Framework\TestCase
 {
     public function testPluginConnectsToPop3HostBeforeTransportStarts()
     {

--- a/tests/unit/Swift/Plugins/RedirectingPluginTest.php
+++ b/tests/unit/Swift/Plugins/RedirectingPluginTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class Swift_Plugins_RedirectingPluginTest extends \PHPUnit_Framework_TestCase
+class Swift_Plugins_RedirectingPluginTest extends \PHPUnit\Framework\TestCase
 {
     public function testRecipientCanBeSetAndFetched()
     {

--- a/tests/unit/Swift/Plugins/Reporters/HitReporterTest.php
+++ b/tests/unit/Swift/Plugins/Reporters/HitReporterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class Swift_Plugins_Reporters_HitReporterTest extends \PHPUnit_Framework_TestCase
+class Swift_Plugins_Reporters_HitReporterTest extends \PHPUnit\Framework\TestCase
 {
     private $hitReporter;
     private $message;

--- a/tests/unit/Swift/Plugins/Reporters/HtmlReporterTest.php
+++ b/tests/unit/Swift/Plugins/Reporters/HtmlReporterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class Swift_Plugins_Reporters_HtmlReporterTest extends \PHPUnit_Framework_TestCase
+class Swift_Plugins_Reporters_HtmlReporterTest extends \PHPUnit\Framework\TestCase
 {
     private $html;
     private $message;

--- a/tests/unit/Swift/Signers/SMimeSignerTest.php
+++ b/tests/unit/Swift/Signers/SMimeSignerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class Swift_Signers_SMimeSignerTest extends \PHPUnit_Framework_TestCase
+class Swift_Signers_SMimeSignerTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var Swift_StreamFilters_StringReplacementFilterFactory

--- a/tests/unit/Swift/StreamFilters/ByteArrayReplacementFilterTest.php
+++ b/tests/unit/Swift/StreamFilters/ByteArrayReplacementFilterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class Swift_StreamFilters_ByteArrayReplacementFilterTest extends \PHPUnit_Framework_TestCase
+class Swift_StreamFilters_ByteArrayReplacementFilterTest extends \PHPUnit\Framework\TestCase
 {
     public function testBasicReplacementsAreMade()
     {

--- a/tests/unit/Swift/StreamFilters/StringReplacementFilterFactoryTest.php
+++ b/tests/unit/Swift/StreamFilters/StringReplacementFilterFactoryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class Swift_StreamFilters_StringReplacementFilterFactoryTest extends \PHPUnit_Framework_TestCase
+class Swift_StreamFilters_StringReplacementFilterFactoryTest extends \PHPUnit\Framework\TestCase
 {
     public function testInstancesOfStringReplacementFilterAreCreated()
     {

--- a/tests/unit/Swift/StreamFilters/StringReplacementFilterTest.php
+++ b/tests/unit/Swift/StreamFilters/StringReplacementFilterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class Swift_StreamFilters_StringReplacementFilterTest extends \PHPUnit_Framework_TestCase
+class Swift_StreamFilters_StringReplacementFilterTest extends \PHPUnit\Framework\TestCase
 {
     public function testBasicReplacementsAreMade()
     {

--- a/tests/unit/Swift/Transport/AbstractSmtpTest.php
+++ b/tests/unit/Swift/Transport/AbstractSmtpTest.php
@@ -2,7 +2,6 @@
 
 abstract class Swift_Transport_AbstractSmtpTest extends \SwiftMailerTestCase
 {
-    /** Abstract test method */
     abstract protected function getTransport($buf);
 
     public function testStartAccepts220ServiceGreeting()

--- a/tests/unit/Swift/Transport/EsmtpTransportTest.php
+++ b/tests/unit/Swift/Transport/EsmtpTransportTest.php
@@ -49,7 +49,8 @@ class Swift_Transport_EsmtpTransportTest extends Swift_Transport_AbstractSmtpEve
 
     public function testStartSendsHeloToInitiate()
     {
-        //Overridden for EHLO instead
+        // previous loop would fail if there is an issue
+        $this->addToAssertionCount(1);
     }
 
     public function testStartSendsEhloToInitiate()

--- a/tests/unit/Swift/Transport/EsmtpTransportTest.php
+++ b/tests/unit/Swift/Transport/EsmtpTransportTest.php
@@ -111,7 +111,7 @@ class Swift_Transport_EsmtpTransportTest extends Swift_Transport_AbstractSmtpEve
         try {
             $smtp->start();
         } catch (Exception $e) {
-            $this->fail('Starting Esmtp should send EHLO and accept 250 response');
+            $this->fail('Starting Esmtp should send EHLO and accept 250 response: '.$e->getMessage());
         }
     }
 

--- a/tests/unit/Swift/Transport/StreamBufferTest.php
+++ b/tests/unit/Swift/Transport/StreamBufferTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class Swift_Transport_StreamBufferTest extends \PHPUnit_Framework_TestCase
+class Swift_Transport_StreamBufferTest extends \PHPUnit\Framework\TestCase
 {
     public function testSettingWriteTranslationsCreatesFilters()
     {


### PR DESCRIPTION
### Changes
Update phpunit class names.
Update test for phpunit 6.
Update travis.

### Why?
Swiftmailer do not released a new major since 2013 and it do not seem that there are plans to do so #894.

I think the plan was to refactor and release it as v6. Now php 7 is released which has lot of changes which make it difficult to handle both versions php v5.6 and v7.x.

My suggestion is to drop php 5.x in master completely to avoid this complexity and use the new advantages of php 7.

### Incompatible
Both listeners seems to be not compatible to phpunit 6 yet.
```xml     
<listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
<listener class="Mockery\Adapter\Phpunit\TestListener" />
```