### PR TITLE
Fix sorting MIME children when their types are equal

### DIFF
--- a/lib/classes/Swift/Mime/SimpleMimeEntity.php
+++ b/lib/classes/Swift/Mime/SimpleMimeEntity.php
@@ -787,13 +787,13 @@ class Swift_Mime_SimpleMimeEntity implements Swift_Mime_MimeEntity
         // Sort in order of preference, if there is one
         if ($shouldSort) {
             // Group the messages by order of preference
-            $sorted = [];
+            $sorted = array();
             foreach ($this->_immediateChildren as $child) {
                 $type = $child->getContentType();
                 $level = array_key_exists($type, $this->_alternativePartOrder) ? $this->_alternativePartOrder[$type] : max($this->_alternativePartOrder) + 1;
 
                 if (empty($sorted[$level])) {
-                    $sorted[$level] = [];
+                    $sorted[$level] = array();
                 }
 
                 $sorted[$level][] = $child;
@@ -801,7 +801,7 @@ class Swift_Mime_SimpleMimeEntity implements Swift_Mime_MimeEntity
 
             ksort($sorted);
 
-            $this->_immediateChildren = array_reduce($sorted, 'array_merge', []);
+            $this->_immediateChildren = array_reduce($sorted, 'array_merge', array());
         }
     }
 

--- a/lib/classes/Swift/Mime/SimpleMimeEntity.php
+++ b/lib/classes/Swift/Mime/SimpleMimeEntity.php
@@ -799,7 +799,7 @@ class Swift_Mime_SimpleMimeEntity implements Swift_Mime_MimeEntity
             $typePrefs[] = array_key_exists($type, $this->_alternativePartOrder) ? $this->_alternativePartOrder[$type] : max($this->_alternativePartOrder) + 1;
         }
 
-        return $typePrefs[0] >= $typePrefs[1] ? 1 : -1;
+        return $typePrefs[0] > $typePrefs[1] ? 1 : -1;
     }
 
     /**

--- a/lib/classes/Swift/Mime/SimpleMimeEntity.php
+++ b/lib/classes/Swift/Mime/SimpleMimeEntity.php
@@ -786,20 +786,23 @@ class Swift_Mime_SimpleMimeEntity implements Swift_Mime_MimeEntity
 
         // Sort in order of preference, if there is one
         if ($shouldSort) {
-            usort($this->_immediateChildren, array($this, '_childSortAlgorithm'));
+            // Group the messages by order of preference
+            $sorted = [];
+            foreach ($this->_immediateChildren as $child) {
+                $type = $child->getContentType();
+                $level = array_key_exists($type, $this->_alternativePartOrder) ? $this->_alternativePartOrder[$type] : max($this->_alternativePartOrder) + 1;
+
+                if (empty($sorted[$level])) {
+                    $sorted[$level] = [];
+                }
+
+                $sorted[$level][] = $child;
+            }
+
+            ksort($sorted);
+
+            $this->_immediateChildren = array_reduce($sorted, 'array_merge', []);
         }
-    }
-
-    private function _childSortAlgorithm($a, $b)
-    {
-        $typePrefs = array();
-        $types = array(strtolower($a->getContentType()), strtolower($b->getContentType()));
-
-        foreach ($types as $type) {
-            $typePrefs[] = array_key_exists($type, $this->_alternativePartOrder) ? $this->_alternativePartOrder[$type] : max($this->_alternativePartOrder) + 1;
-        }
-
-        return $typePrefs[0] > $typePrefs[1] ? 1 : -1;
     }
 
     /**


### PR DESCRIPTION
Currently, if a message has two MIME children with the same content type, they will be added in their inverted order. In most cases, this won't matter, but for some e-mails (like X-ARF, which has two text/plain parts, one with human readable and one with YAML content), this is problematic.

This small fix ensures the original ordering is preserved when the typePrefs are identical.