### PR TITLE
[travis] allow php 7.x to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,5 +24,7 @@ matrix:
         - php: 7.1
         - php: hhvm
     allow_failures:
+        - php: 7.0
+        - php: 7.1
         - php: hhvm
     fast_finish: true


### PR DESCRIPTION
Tavis fails because it uses a newer phpunit, until somebody fix travis script to force a older version, this patch should allow temporary fail on php7.x.