### PR TITLE
migrate to php7 Swift_IdGenerator

### DIFF
--- a/lib/classes/Swift/IdGenerator.php
+++ b/lib/classes/Swift/IdGenerator.php
@@ -18,5 +18,5 @@ interface Swift_IdGenerator
      *
      * @return string
      */
-    public function generateId();
+    public function generateId(): string;
 }

--- a/lib/classes/Swift/Mime/IdGenerator.php
+++ b/lib/classes/Swift/Mime/IdGenerator.php
@@ -13,10 +13,12 @@
  */
 class Swift_Mime_IdGenerator implements Swift_IdGenerator
 {
+    private $idRight;
+
     /**
      * @param string $idRight
      */
-    public function __construct($idRight)
+    public function __construct(String $idRight)
     {
         $this->idRight = $idRight;
     }
@@ -26,7 +28,7 @@ class Swift_Mime_IdGenerator implements Swift_IdGenerator
      *
      * @return string
      */
-    public function getIdRight()
+    public function getIdRight(): string
     {
         return $this->idRight;
     }
@@ -36,15 +38,15 @@ class Swift_Mime_IdGenerator implements Swift_IdGenerator
      *
      * @param string $idRight
      */
-    public function setIdRight($idRight)
+    public function setIdRight(String $idRight)
     {
         $this->idRight = $idRight;
     }
 
     /**
-     * @return string
+     * {@inheritdoc}
      */
-    public function generateId()
+    public function generateId(): string
     {
         $idLeft = md5(getmypid().'.'.time().'.'.uniqid(mt_rand(), true));
 


### PR DESCRIPTION
### Changed
- refactor Swift_Mime_IdGenerator, Swift_IdGenerator with return types
- replaced redundant documentation