### PR TITLE
 migrate to php7 Swift_Spool

### DIFF
--- a/lib/classes/Swift/FileSpool.php
+++ b/lib/classes/Swift/FileSpool.php
@@ -45,24 +45,22 @@ class Swift_FileSpool extends Swift_ConfigurableSpool
     }
 
     /**
-     * Tests if this Spool mechanism has started.
-     *
-     * @return bool
+     * {@inheritdoc}
      */
-    public function isStarted()
+    public function isStarted(): bool
     {
         return true;
     }
 
     /**
-     * Starts this Spool mechanism.
+     * {@inheritdoc}
      */
     public function start()
     {
     }
 
     /**
-     * Stops this Spool mechanism.
+     * {@inheritdoc}
      */
     public function stop()
     {
@@ -89,7 +87,7 @@ class Swift_FileSpool extends Swift_ConfigurableSpool
      *
      * @return bool
      */
-    public function queueMessage(Swift_Mime_SimpleMessage $message)
+    public function queueMessage(Swift_Mime_SimpleMessage $message): bool
     {
         $ser = serialize($message);
         $fileName = $this->path.'/'.$this->getRandomString(10);
@@ -138,7 +136,7 @@ class Swift_FileSpool extends Swift_ConfigurableSpool
      *
      * @return int The number of sent e-mail's
      */
-    public function flushQueue(Swift_Transport $transport, &$failedRecipients = null)
+    public function flushQueue(Swift_Transport $transport, &$failedRecipients = null): int
     {
         $directoryIterator = new DirectoryIterator($this->path);
 
@@ -193,7 +191,7 @@ class Swift_FileSpool extends Swift_ConfigurableSpool
      *
      * @return string
      */
-    protected function getRandomString($count)
+    protected function getRandomString($count): string
     {
         // This string MUST stay FS safe, avoid special chars
         $base = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-';

--- a/lib/classes/Swift/MemorySpool.php
+++ b/lib/classes/Swift/MemorySpool.php
@@ -19,24 +19,22 @@ class Swift_MemorySpool implements Swift_Spool
     private $flushRetries = 3;
 
     /**
-     * Tests if this Transport mechanism has started.
-     *
-     * @return bool
+     * {@inheritdoc}
      */
-    public function isStarted()
+    public function isStarted(): bool
     {
         return true;
     }
 
     /**
-     * Starts this Transport mechanism.
+     * {@inheritdoc}
      */
     public function start()
     {
     }
 
     /**
-     * Stops this Transport mechanism.
+     * {@inheritdoc}
      */
     public function stop()
     {
@@ -57,7 +55,7 @@ class Swift_MemorySpool implements Swift_Spool
      *
      * @return bool Whether the operation has succeeded
      */
-    public function queueMessage(Swift_Mime_SimpleMessage $message)
+    public function queueMessage(Swift_Mime_SimpleMessage $message): bool
     {
         //clone the message to make sure it is not changed while in the queue
         $this->messages[] = clone $message;
@@ -66,14 +64,9 @@ class Swift_MemorySpool implements Swift_Spool
     }
 
     /**
-     * Sends messages using the given transport instance.
-     *
-     * @param Swift_Transport $transport        A transport instance
-     * @param string[]        $failedRecipients An array of failures by-reference
-     *
-     * @return int The number of sent emails
+     * {@inheritdoc}
      */
-    public function flushQueue(Swift_Transport $transport, &$failedRecipients = null)
+    public function flushQueue(Swift_Transport $transport, &$failedRecipients = null): int
     {
         if (!$this->messages) {
             return 0;

--- a/lib/classes/Swift/Spool.php
+++ b/lib/classes/Swift/Spool.php
@@ -30,7 +30,7 @@ interface Swift_Spool
      *
      * @return bool
      */
-    public function isStarted();
+    public function isStarted(): bool;
 
     /**
      * Queues a message.
@@ -39,7 +39,7 @@ interface Swift_Spool
      *
      * @return bool Whether the operation has succeeded
      */
-    public function queueMessage(Swift_Mime_SimpleMessage $message);
+    public function queueMessage(Swift_Mime_SimpleMessage $message): bool;
 
     /**
      * Sends messages using the given transport instance.
@@ -49,5 +49,5 @@ interface Swift_Spool
      *
      * @return int The number of sent emails
      */
-    public function flushQueue(Swift_Transport $transport, &$failedRecipients = null);
+    public function flushQueue(Swift_Transport $transport, &$failedRecipients = null): int;
 }


### PR DESCRIPTION
### Changed
- refactor Swift_Spool with return types
- replaced redundant documentation