### PR TITLE
migrate to php7 Swift_Transport

### DIFF
--- a/lib/classes/Swift/Transport.php
+++ b/lib/classes/Swift/Transport.php
@@ -20,7 +20,7 @@ interface Swift_Transport
      *
      * @return bool
      */
-    public function isStarted();
+    public function isStarted(): bool;
 
     /**
      * Start this Transport mechanism.
@@ -53,7 +53,7 @@ interface Swift_Transport
      *
      * @return bool TRUE if the transport is alive
      */
-    public function ping();
+    public function ping(): bool;
 
     /**
      * Send the given Message.
@@ -66,7 +66,7 @@ interface Swift_Transport
      *
      * @return int
      */
-    public function send(Swift_Mime_SimpleMessage $message, &$failedRecipients = null);
+    public function send(Swift_Mime_SimpleMessage $message, &$failedRecipients = null): int;
 
     /**
      * Register a plugin in the Transport.

--- a/lib/classes/Swift/Transport/AbstractSmtpTransport.php
+++ b/lib/classes/Swift/Transport/AbstractSmtpTransport.php
@@ -143,23 +143,15 @@ abstract class Swift_Transport_AbstractSmtpTransport implements Swift_Transport
      *
      * @return bool
      */
-    public function isStarted()
+    public function isStarted(): bool
     {
         return $this->started;
     }
 
     /**
-     * Send the given Message.
-     *
-     * Recipient/sender data will be retrieved from the Message API.
-     * The return value is the number of recipients who were accepted for delivery.
-     *
-     * @param Swift_Mime_SimpleMessage $message
-     * @param string[]           $failedRecipients An array of failures by-reference
-     *
-     * @return int
+     * {@inheritdoc}
      */
-    public function send(Swift_Mime_SimpleMessage $message, &$failedRecipients = null)
+    public function send(Swift_Mime_SimpleMessage $message, &$failedRecipients = null): int
     {
         $sent = 0;
         $failedRecipients = (array) $failedRecipients;
@@ -246,7 +238,7 @@ abstract class Swift_Transport_AbstractSmtpTransport implements Swift_Transport
     /**
      * {@inheritdoc}
      */
-    public function ping()
+    public function ping(): bool 
     {
         try {
             if (!$this->isStarted()) {

--- a/lib/classes/Swift/Transport/FailoverTransport.php
+++ b/lib/classes/Swift/Transport/FailoverTransport.php
@@ -31,7 +31,7 @@ class Swift_Transport_FailoverTransport extends Swift_Transport_LoadBalancedTran
     /**
      * {@inheritdoc}
      */
-    public function ping()
+    public function ping(): bool
     {
         $maxTransports = count($this->transports);
         for ($i = 0; $i < $maxTransports
@@ -47,17 +47,9 @@ class Swift_Transport_FailoverTransport extends Swift_Transport_LoadBalancedTran
     }
 
     /**
-     * Send the given Message.
-     *
-     * Recipient/sender data will be retrieved from the Message API.
-     * The return value is the number of recipients who were accepted for delivery.
-     *
-     * @param Swift_Mime_SimpleMessage $message
-     * @param string[]           $failedRecipients An array of failures by-reference
-     *
-     * @return int
+     * {@inheritdoc}
      */
-    public function send(Swift_Mime_SimpleMessage $message, &$failedRecipients = null)
+    public function send(Swift_Mime_SimpleMessage $message, &$failedRecipients = null): int
     {
         $maxTransports = count($this->transports);
         $sent = 0;

--- a/lib/classes/Swift/Transport/LoadBalancedTransport.php
+++ b/lib/classes/Swift/Transport/LoadBalancedTransport.php
@@ -73,11 +73,9 @@ class Swift_Transport_LoadBalancedTransport implements Swift_Transport
     }
 
     /**
-     * Test if this Transport mechanism has started.
-     *
-     * @return bool
+     * {@inheritdoc}
      */
-    public function isStarted()
+    public function isStarted(): bool
     {
         return count($this->transports) > 0;
     }
@@ -103,7 +101,7 @@ class Swift_Transport_LoadBalancedTransport implements Swift_Transport
     /**
      * {@inheritdoc}
      */
-    public function ping()
+    public function ping(): bool
     {
         foreach ($this->transports as $transport) {
             if (!$transport->ping()) {
@@ -115,17 +113,9 @@ class Swift_Transport_LoadBalancedTransport implements Swift_Transport
     }
 
     /**
-     * Send the given Message.
-     *
-     * Recipient/sender data will be retrieved from the Message API.
-     * The return value is the number of recipients who were accepted for delivery.
-     *
-     * @param Swift_Mime_SimpleMessage $message
-     * @param string[]           $failedRecipients An array of failures by-reference
-     *
-     * @return int
+     * {@inheritdoc}
      */
-    public function send(Swift_Mime_SimpleMessage $message, &$failedRecipients = null)
+    public function send(Swift_Mime_SimpleMessage $message, &$failedRecipients = null): int
     {
         $maxTransports = count($this->transports);
         $sent = 0;

--- a/lib/classes/Swift/Transport/NullTransport.php
+++ b/lib/classes/Swift/Transport/NullTransport.php
@@ -27,24 +27,22 @@ class Swift_Transport_NullTransport implements Swift_Transport
     }
 
     /**
-     * Tests if this Transport mechanism has started.
-     *
-     * @return bool
+     * {@inheritdoc}
      */
-    public function isStarted()
+    public function isStarted(): bool
     {
         return true;
     }
 
     /**
-     * Starts this Transport mechanism.
+     * {@inheritdoc}
      */
     public function start()
     {
     }
 
     /**
-     * Stops this Transport mechanism.
+     * {@inheritdoc}
      */
     public function stop()
     {
@@ -53,7 +51,7 @@ class Swift_Transport_NullTransport implements Swift_Transport
     /**
      * {@inheritdoc}
      */
-    public function ping()
+    public function ping(): bool
     {
         return true;
     }
@@ -66,7 +64,7 @@ class Swift_Transport_NullTransport implements Swift_Transport
      *
      * @return int The number of sent emails
      */
-    public function send(Swift_Mime_SimpleMessage $message, &$failedRecipients = null)
+    public function send(Swift_Mime_SimpleMessage $message, &$failedRecipients = null): int
     {
         if ($evt = $this->eventDispatcher->createSendEvent($this, $message)) {
             $this->eventDispatcher->dispatchEvent($evt, 'beforeSendPerformed');

--- a/lib/classes/Swift/Transport/SendmailTransport.php
+++ b/lib/classes/Swift/Transport/SendmailTransport.php
@@ -98,7 +98,7 @@ class Swift_Transport_SendmailTransport extends Swift_Transport_AbstractSmtpTran
      *
      * @return int
      */
-    public function send(Swift_Mime_SimpleMessage $message, &$failedRecipients = null)
+    public function send(Swift_Mime_SimpleMessage $message, &$failedRecipients = null): int
     {
         $failedRecipients = (array) $failedRecipients;
         $command = $this->getCommand();

--- a/lib/classes/Swift/Transport/SpoolTransport.php
+++ b/lib/classes/Swift/Transport/SpoolTransport.php
@@ -55,24 +55,22 @@ class Swift_Transport_SpoolTransport implements Swift_Transport
     }
 
     /**
-     * Tests if this Transport mechanism has started.
-     *
-     * @return bool
+     * {@inheritdoc}
      */
-    public function isStarted()
+    public function isStarted(): bool
     {
         return true;
     }
 
     /**
-     * Starts this Transport mechanism.
+     * {@inheritdoc}
      */
     public function start()
     {
     }
 
     /**
-     * Stops this Transport mechanism.
+     * {@inheritdoc}
      */
     public function stop()
     {
@@ -81,7 +79,7 @@ class Swift_Transport_SpoolTransport implements Swift_Transport
     /**
      * {@inheritdoc}
      */
-    public function ping()
+    public function ping(): bool
     {
         return true;
     }
@@ -94,7 +92,7 @@ class Swift_Transport_SpoolTransport implements Swift_Transport
      *
      * @return int The number of sent e-mail's
      */
-    public function send(Swift_Mime_SimpleMessage $message, &$failedRecipients = null)
+    public function send(Swift_Mime_SimpleMessage $message, &$failedRecipients = null): int
     {
         if ($evt = $this->eventDispatcher->createSendEvent($this, $message)) {
             $this->eventDispatcher->dispatchEvent($evt, 'beforeSendPerformed');

--- a/tests/unit/Swift/MailerTest.php
+++ b/tests/unit/Swift/MailerTest.php
@@ -130,7 +130,7 @@ class Swift_MailerTest extends \SwiftMailerTestCase
 
     private function createTransport()
     {
-        return $this->getMockery('Swift_Transport')->shouldIgnoreMissing();
+        return $this->getMockery('Swift_Transport')->shouldIgnoreMissing(0);
     }
 
     private function createMessage()

--- a/tests/unit/Swift/Transport/FailoverTransportTest.php
+++ b/tests/unit/Swift/Transport/FailoverTransportTest.php
@@ -479,6 +479,7 @@ class Swift_Transport_FailoverTransportTest extends \SwiftMailerTestCase
                if ($connectionState) {
                    return 1;
                }
+               return 0;
            });
 
         $transport = $this->getTransport(array($t1));

--- a/tests/unit/Swift/Transport/FailoverTransportTest.php
+++ b/tests/unit/Swift/Transport/FailoverTransportTest.php
@@ -479,6 +479,7 @@ class Swift_Transport_FailoverTransportTest extends \SwiftMailerTestCase
                if ($connectionState) {
                    return 1;
                }
+
                return 0;
            });
 


### PR DESCRIPTION
- add return types
- replace redundant documentation

Reference to #956