### PR TITLE
Ignore tests suite on git export

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,3 +7,4 @@
 
 # ignore /notes in the git-generated distributed .zip archive
 /doc/notes export-ignore
+/tests export-ignore


### PR DESCRIPTION
This prevents composer downloading the lib's tests suite on dependent projects.