### PR TITLE
Queue spool.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,13 +21,15 @@
     "require-dev": {
         "mockery/mockery": "~0.9.1",
         "queue-interop/queue-interop": "^0.5|^0.6",
+        "queue-interop/amqp-interop": "^0.7",
         "symfony/phpunit-bridge": "~3.3@dev"
     },
     "autoload": {
         "files": ["lib/swift_required.php"]
     },
     "suggest": {
-        "queue-interop/queue-interop": "^0.5|^0.6. If you want to spool emails to a message queue."
+        "queue-interop/queue-interop": "^0.5|^0.6. If you want to spool emails to a message queue.",
+        "queue-interop/amqp-interop": "^0.7. If you want to spool emails to a AMQP message queue."
     },
     "autoload-dev": {
         "psr-0": { "Swift_": "tests/unit" }

--- a/composer.json
+++ b/composer.json
@@ -20,14 +20,14 @@
     },
     "require-dev": {
         "mockery/mockery": "~0.9.1",
-        "queue-interop/queue-interop": "^0.5",
+        "queue-interop/queue-interop": "^0.5|^0.6",
         "symfony/phpunit-bridge": "~3.3@dev"
     },
     "autoload": {
         "files": ["lib/swift_required.php"]
     },
     "suggest": {
-        "queue-interop/queue-interop": "^0.5. If you want to spool emails to a message queue."
+        "queue-interop/queue-interop": "^0.5|^0.6. If you want to spool emails to a message queue."
     },
     "autoload-dev": {
         "psr-0": { "Swift_": "tests/unit" }

--- a/composer.json
+++ b/composer.json
@@ -20,10 +20,14 @@
     },
     "require-dev": {
         "mockery/mockery": "~0.9.1",
+        "queue-interop/queue-interop": "^0.5",
         "symfony/phpunit-bridge": "~3.3@dev"
     },
     "autoload": {
         "files": ["lib/swift_required.php"]
+    },
+    "suggest": {
+        "queue-interop/queue-interop": "^0.5. If you want to spool emails to a message queue."
     },
     "autoload-dev": {
         "psr-0": { "Swift_": "tests/unit" }

--- a/lib/classes/Swift/AmqpSpool.php
+++ b/lib/classes/Swift/AmqpSpool.php
@@ -1,0 +1,118 @@
+<?php
+
+use Interop\Amqp\AmqpConsumer;
+use Interop\Amqp\AmqpContext;
+use Interop\Amqp\AmqpMessage;
+use Interop\Amqp\AmqpQueue;
+use Interop\Queue\ExceptionInterface as PsrException;
+
+/**
+ * The class spools emails to the message queue via queue interop compatible transport.
+ *
+ * @author Max Kotliar
+ */
+class Swift_AmqpSpool extends \Swift_ConfigurableSpool
+{
+    /**
+     * @var AmqpContext
+     */
+    private $context;
+
+    /**
+     * @var AmqpQueue
+     */
+    private $queue;
+
+    /**
+     * @param AmqpContext      $context
+     * @param AmqpQueue|string $queue
+     */
+    public function __construct(AmqpContext $context, $queue = 'swiftmailer_spool')
+    {
+        if (false === $queue instanceof AmqpQueue) {
+            $queue = $this->context->createQueue($queue);
+        }
+
+        $this->context = $context;
+        $this->queue = $queue;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function queueMessage(Swift_Mime_SimpleMessage $message)
+    {
+        try {
+            $message = $this->context->createMessage(serialize($message));
+
+            $this->context->createProducer()->send($this->queue, $message);
+        } catch (PsrException $e) {
+            throw new \Swift_IoException(sprintf('Unable to send message to message queue.'), null, $e);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function flushQueue(Swift_Transport $transport, &$failedRecipients = null)
+    {
+        $consumer = $this->context->createConsumer($this->queue);
+
+        $isTransportStarted = false;
+
+        $failedRecipients = (array) $failedRecipients;
+        $count = 0;
+        $time = time();
+
+        $this->context->subscribe($consumer, function(AmqpMessage $psrMessage, AmqpConsumer $consumer) use ($transport, &$count) {
+            $message = unserialize($psrMessage->getBody());
+
+            $count += $transport->send($message, $failedRecipients);
+
+            $consumer->acknowledge($psrMessage);
+
+            return true;
+        });
+
+        while (true) {
+            if (false == $isTransportStarted) {
+                $transport->start();
+                $isTransportStarted = true;
+            }
+
+            $this->context->consume(1000);
+
+            if ($this->getMessageLimit() && $count >= $this->getMessageLimit()) {
+                break;
+            }
+
+            if ($this->getTimeLimit() && (time() - $time) >= $this->getTimeLimit()) {
+                break;
+            }
+        }
+
+        return $count;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function start()
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function stop()
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isStarted()
+    {
+        return true;
+    }
+}

--- a/lib/classes/Swift/QueueSpool.php
+++ b/lib/classes/Swift/QueueSpool.php
@@ -1,0 +1,108 @@
+<?php
+use Interop\Queue\ExceptionInterface as PsrException;
+use Interop\Queue\PsrContext;
+use Interop\Queue\PsrQueue;
+
+class Swift_QueueSpool extends \Swift_ConfigurableSpool
+{
+    /**
+     * @var PsrContext
+     */
+    private $context;
+
+    /**
+     * @var PsrQueue
+     */
+    private $queue;
+
+    /**
+     * @param PsrContext $context
+     * @param PsrQueue|string $queue
+     */
+    public function __construct(PsrContext $context, $queue = 'swiftmailer_spool')
+    {
+        $this->context = $context;
+
+        if (false == $queue instanceof PsrQueue) {
+            $queue = $this->context->createQueue($queue);
+        }
+
+        $this->queue = $queue;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function queueMessage(Swift_Mime_SimpleMessage $message)
+    {
+        try {
+            $message = $this->context->createMessage(serialize($message));
+
+            $this->context->createProducer()->send($this->queue, $message);
+        } catch (PsrException $e) {
+            throw new \Swift_IoException(sprintf('Unable to send message to message queue.'), null, $e);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function flushQueue(Swift_Transport $transport, &$failedRecipients = null)
+    {
+        $consumer = $this->context->createConsumer($this->queue);
+
+        $isTransportStarted = false;
+
+        $failedRecipients = (array) $failedRecipients;
+        $count = 0;
+        $time = time();
+
+        while (true) {
+            if ($psrMessage = $consumer->receive(1000)) {
+                if (false == $isTransportStarted) {
+                    $transport->start();
+                    $isTransportStarted = true;
+                }
+
+
+                $message = unserialize($psrMessage->getBody());
+
+                $count += $transport->send($message, $failedRecipients);
+
+                $consumer->acknowledge($psrMessage);
+            }
+
+            if ($this->getMessageLimit() && $count >= $this->getMessageLimit()) {
+                break;
+            }
+
+            if ($this->getTimeLimit() && (time() - $time) >= $this->getTimeLimit()) {
+                break;
+            }
+        }
+
+        return $count;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function start()
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function stop()
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isStarted()
+    {
+        return true;
+    }
+}

--- a/lib/classes/Swift/QueueSpool.php
+++ b/lib/classes/Swift/QueueSpool.php
@@ -4,6 +4,11 @@ use Interop\Queue\ExceptionInterface as PsrException;
 use Interop\Queue\PsrContext;
 use Interop\Queue\PsrQueue;
 
+/**
+ * The class spools emails to the message queue via queue interop compatible transport.
+ *
+ * @author Max Kotliar
+ */
 class Swift_QueueSpool extends \Swift_ConfigurableSpool
 {
     /**
@@ -22,12 +27,11 @@ class Swift_QueueSpool extends \Swift_ConfigurableSpool
      */
     public function __construct(PsrContext $context, $queue = 'swiftmailer_spool')
     {
-        $this->context = $context;
-
-        if (false == $queue instanceof PsrQueue) {
+        if (false === $queue instanceof PsrQueue) {
             $queue = $this->context->createQueue($queue);
         }
 
+        $this->context = $context;
         $this->queue = $queue;
     }
 

--- a/lib/classes/Swift/QueueSpool.php
+++ b/lib/classes/Swift/QueueSpool.php
@@ -1,4 +1,5 @@
 <?php
+
 use Interop\Queue\ExceptionInterface as PsrException;
 use Interop\Queue\PsrContext;
 use Interop\Queue\PsrQueue;
@@ -16,7 +17,7 @@ class Swift_QueueSpool extends \Swift_ConfigurableSpool
     private $queue;
 
     /**
-     * @param PsrContext $context
+     * @param PsrContext      $context
      * @param PsrQueue|string $queue
      */
     public function __construct(PsrContext $context, $queue = 'swiftmailer_spool')
@@ -63,7 +64,6 @@ class Swift_QueueSpool extends \Swift_ConfigurableSpool
                     $transport->start();
                     $isTransportStarted = true;
                 }
-
 
                 $message = unserialize($psrMessage->getBody());
 


### PR DESCRIPTION
PR adds an ability to use any queue-interop compatible MQ transport as an email spool. 

Here's use case example, the source code is [here](https://github.com/php-enqueue/enqueue-sandbox/tree/master/swiftmailer):

```php
<?php

// send.php
// could be run as GUSER=yourAccountName@gmail.com GPASS="yourGmailPassword" php send.php

require_once __DIR__.'/vendor/autoload.php';

$transport = new Swift_SpoolTransport(new \Swift_QueueSpool(
    (new \Enqueue\Fs\FsConnectionFactory('file://'.__DIR__.'/queue'))->createContext()
));

$mailer = new Swift_Mailer($transport);

$message = (new Swift_Message('Wonderful Subject'))
    ->setFrom(getenv('GUSER'))
    ->setTo(getenv('GUSER'))
    ->setBody('Here is the message itself. Sent at: '.date('Y-m-d H:i:s'))
;

$result = $mailer->send($message);
```

The message was queued, to send message for real we have to flush queue.

```php
<?php

// consume.php
// GUSER=yourAccountName@gmail.com GPASS="yourGmailPassword" php consume.php

require_once __DIR__.'/vendor/autoload.php';

$transport = new Swift_SpoolTransport(new \Swift_QueueSpool(
    (new \Enqueue\Fs\FsConnectionFactory('file://'.__DIR__.'/queue'))->createContext()
));

/** @var \Swift_QueueSpool $spool */
$spool = $transport->getSpool();
$spool->setTimeLimit(3);

$realTransport = (new Swift_SmtpTransport('smtp.gmail.com', 465, 'ssl'))
    ->setUsername(getenv('GUSER'))
    ->setPassword(getenv('GPASS'))
;

$spool->flushQueue($realTransport);
```

TODO:

* [ ] tests
* [ ] docs.
* [ ] TBD PsrProcessor 