### PR TITLE
remove outdated version in comment/code

### DIFF
--- a/lib/classes/Swift/Mime/SimpleMimeEntity.php
+++ b/lib/classes/Swift/Mime/SimpleMimeEntity.php
@@ -420,7 +420,7 @@ class Swift_Mime_SimpleMimeEntity implements Swift_Mime_CharsetObserver, Swift_M
     public function getBoundary()
     {
         if (!isset($this->boundary)) {
-            $this->boundary = '_=_swift_v4_'.time().'_'.md5(getmypid().mt_rand().uniqid('', true)).'_=_';
+            $this->boundary = '_=_swift_'.time().'_'.md5(getmypid().mt_rand().uniqid('', true)).'_=_';
         }
 
         return $this->boundary;

--- a/tests/smoke.conf.php.default
+++ b/tests/smoke.conf.php.default
@@ -1,7 +1,7 @@
 <?php
 
 /*
- Swift Mailer V4 smoke test configuration.
+ Swift Mailer smoke test configuration.
 
  YOU ONLY NEED TO EDIT THIS FILE IF YOU WISH TO RUN THE SMOKE TESTS.
 

--- a/tests/smoke/Swift/Smoke/AttachmentSmokeTest.php
+++ b/tests/smoke/Swift/Smoke/AttachmentSmokeTest.php
@@ -22,7 +22,7 @@ class Swift_Smoke_AttachmentSmokeTest extends SwiftMailerSmokeTestCase
             ->setTo(SWIFT_SMOKE_EMAIL_ADDRESS)
             ->setBody('This message should contain an attached ZIP file (named "textfile.zip").'.PHP_EOL.
                 'When unzipped, the archive should produce a text file which reads:'.PHP_EOL.
-                '"This is part of a Swift Mailer v4 smoke test."'
+                '"This is part of a Swift Mailer smoke test."'
                 )
             ->attach(Swift_Attachment::fromPath($this->attFile))
             ;

--- a/tests/smoke/Swift/Smoke/HtmlWithAttachmentSmokeTest.php
+++ b/tests/smoke/Swift/Smoke/HtmlWithAttachmentSmokeTest.php
@@ -21,7 +21,7 @@ class Swift_Smoke_HtmlWithAttachmentSmokeTest extends SwiftMailerSmokeTestCase
             ->attach(Swift_Attachment::fromPath($this->attFile))
             ->setBody('<p>This HTML-formatted message should contain an attached ZIP file (named "textfile.zip").'.PHP_EOL.
                 'When unzipped, the archive should produce a text file which reads:</p>'.PHP_EOL.
-                '<p><q>This is part of a Swift Mailer v4 smoke test.</q></p>', 'text/html'
+                '<p><q>This is part of a Swift Mailer smoke test.</q></p>', 'text/html'
             )
             ;
         $this->assertEquals(1, $mailer->send($message),

--- a/tests/smoke/Swift/Smoke/InternationalSmokeTest.php
+++ b/tests/smoke/Swift/Smoke/InternationalSmokeTest.php
@@ -23,7 +23,7 @@ class Swift_Smoke_InternationalSmokeTest extends SwiftMailerSmokeTestCase
             ->setTo(SWIFT_SMOKE_EMAIL_ADDRESS)
             ->setBody('This message should contain an attached ZIP file (named "κείμενο, εδάφιο, θέμα.zip").'.PHP_EOL.
                 'When unzipped, the archive should produce a text file which reads:'.PHP_EOL.
-                '"This is part of a Swift Mailer v4 smoke test."'.PHP_EOL.
+                '"This is part of a Swift Mailer smoke test."'.PHP_EOL.
                 PHP_EOL.
                 'Following is some arbitrary Greek text:'.PHP_EOL.
                 'Δεν βρέθηκαν λέξεις.'


### PR DESCRIPTION
Nothing important, only code clean up. `v4` is a little outdated.