### PR TITLE
[Docs] Converted mysql_* into PDO calls

### DIFF
--- a/doc/plugins.rst
+++ b/doc/plugins.rst
@@ -304,14 +304,14 @@ provide an implementation that does this. You need to create a small class::
 
     class DbReplacements implements Swift_Plugins_Decorator_Replacements {
       public function getReplacementsFor($address) {
-        $sql = sprintf(
-          "SELECT * FROM user WHERE email = '%s'",
-          mysql_real_escape_string($address)
+        global $db; // Your PDO instance with a connection to your database
+        $query = $db->prepare(
+          "SELECT * FROM `users` WHERE `email` = ?"
         );
 
-        $result = mysql_query($sql);
+        $query->execute([$address]);
 
-        if ($row = mysql_fetch_assoc($result)) {
+        if ($row = $query->fetch(PDO::FETCH_ASSOC)) {
           return [
             '{username}'=>$row['username'],
             '{resetcode}'=>$row['resetcode']


### PR DESCRIPTION
<!-- Please fill in this template according to the PR you're about to submit. -->

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc update?   | yes
| BC breaks?    | no
| Deprecations? | yes
| Fixed tickets | #994
| License       | MIT

In the docs for the Decorator plugin removed all `mysql_*` calls and replaced them with PDO calls, as indicated in #994.
