### PR TITLE
A possible fix for the issues #957 and #967

### DIFF
--- a/lib/classes/Swift/Plugins/DecoratorPlugin.php
+++ b/lib/classes/Swift/Plugins/DecoratorPlugin.php
@@ -111,7 +111,7 @@ class Swift_Plugins_DecoratorPlugin implements Swift_Events_SendListener, Swift_
                             $count = 1;
                         }
                     }
-                } else {
+                } elseif (is_string($body)) {
                     $bodyReplaced = str_replace($search, $replace, $body, $count);
                 }
 

--- a/tests/unit/Swift/Plugins/DecoratorPluginTest.php
+++ b/tests/unit/Swift/Plugins/DecoratorPluginTest.php
@@ -186,7 +186,7 @@ class Swift_Plugins_DecoratorPluginTest extends \SwiftMailerTestCase
 
         $evt = $this->createSendEvent($message);
 
-        $plugin = $this->createPlugin(['somebody@hostname.tld' => ['foo' => 'bar']]);
+        $plugin = $this->createPlugin(array('somebody@hostname.tld' => array('foo' => 'bar')));
 
         $plugin->beforeSendPerformed($evt);
 

--- a/tests/unit/Swift/Plugins/DecoratorPluginTest.php
+++ b/tests/unit/Swift/Plugins/DecoratorPluginTest.php
@@ -177,6 +177,23 @@ class Swift_Plugins_DecoratorPluginTest extends \SwiftMailerTestCase
         $plugin->sendPerformed($evt);
     }
 
+    public function testReplacementsWithAMessageWithImmutableDate()
+    {
+        $message = (new Swift_Message('subject foo'))
+            ->setBody('body foo')
+            ->addTo('somebody@hostname.tld')
+            ->addFrom('somebody@hostname.tld');
+
+        $evt = $this->createSendEvent($message);
+
+        $plugin = $this->createPlugin(['somebody@hostname.tld' => ['foo' => 'bar']]);
+
+        $plugin->beforeSendPerformed($evt);
+
+        $this->assertEquals('subject bar', $message->getSubject());
+        $this->assertEquals('body bar', $message->getBody());
+    }
+
     private function createMessage($headers, $to = array(), $from = null, $subject = null,
         $body = null)
     {


### PR DESCRIPTION
<!-- Please fill in this template according to the PR you're about to submit. -->

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc update?   | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #957 #967
| License       | MIT


<!-- Replace this comment by the description of your issue. -->
The proposed fix simply checks whether the header is of a string type, since otherwise it makes very little sense to run substitutions.