### PR TITLE
Refactored the SMime signer

### DIFF
--- a/lib/classes/Swift/Message.php
+++ b/lib/classes/Swift/Message.php
@@ -129,8 +129,8 @@ class Swift_Message extends Swift_Mime_SimpleMessage
      */
     public function clearSigners()
     {
-        $this->headerSigners = [];
-        $this->bodySigners = [];
+        $this->headerSigners = array();
+        $this->bodySigners = array();
 
         return $this;
     }
@@ -218,7 +218,7 @@ class Swift_Message extends Swift_Mime_SimpleMessage
         $this->savedMessage = array('headers' => array());
         $this->savedMessage['body'] = $this->getBody();
         $this->savedMessage['children'] = $this->getChildren();
-        if (count($this->savedMessage['children']) > 0 && $this->getBody() != '') {
+        if (count($this->savedMessage['children']) > 0 && '' != $this->getBody()) {
             $this->setChildren(array_merge(array($this->becomeMimePart()), $this->savedMessage['children']));
             $this->setBody('');
         }

--- a/lib/classes/Swift/Message.php
+++ b/lib/classes/Swift/Message.php
@@ -123,6 +123,19 @@ class Swift_Message extends Swift_Mime_SimpleMessage
     }
 
     /**
+     * Clear all signature handlers attached to the message.
+     *
+     * @return $this
+     */
+    public function clearSigners()
+    {
+        $this->headerSigners = [];
+        $this->bodySigners = [];
+
+        return $this;
+    }
+
+    /**
      * Get this message as a complete string.
      *
      * @return string

--- a/lib/classes/Swift/Mime/ContentEncoder/NullContentEncoder.php
+++ b/lib/classes/Swift/Mime/ContentEncoder/NullContentEncoder.php
@@ -1,0 +1,81 @@
+<?php
+
+/*
+ * This file is part of SwiftMailer.
+ * (c) 2004-2009 Chris Corbyn
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * Handles the case where the email body is already encoded and you just need specify the correct
+ * encoding without actually changing the encoding of the body.
+ *
+ * @author Jan Flora <jf@penneo.com>
+ */
+class Swift_Mime_ContentEncoder_NullContentEncoder implements Swift_Mime_ContentEncoder
+{
+    /**
+     * The name of this encoding scheme (probably 7bit or 8bit).
+     *
+     * @var string
+     */
+    private $_name;
+
+    /**
+     * Creates a new NullContentEncoder with $name (probably 7bit or 8bit).
+     *
+     * @param string $name
+     */
+    public function __construct($name)
+    {
+        $this->_name = $name;
+    }
+
+    /**
+     * Encode a given string to produce an encoded string.
+     *
+     * @param string $string
+     * @param int    $firstLineOffset ignored
+     * @param int    $maxLineLength   ignored
+     *
+     * @return string
+     */
+    public function encodeString($string, $firstLineOffset = 0, $maxLineLength = 0)
+    {
+        return $string;
+    }
+
+    /**
+     * Encode stream $in to stream $out.
+     *
+     * @param Swift_OutputByteStream $in
+     * @param Swift_InputByteStream  $out
+     * @param int                    $firstLineOffset ignored
+     * @param int                    $maxLineLength   ignored
+     */
+    public function encodeByteStream(Swift_OutputByteStream $os, Swift_InputByteStream $is, $firstLineOffset = 0, $maxLineLength = 0)
+    {
+        while (false !== ($bytes = $os->read(8192))) {
+            $is->write($bytes);
+        }
+    }
+
+    /**
+     * Get the name of this encoding scheme.
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->_name;
+    }
+
+    /**
+     * Not used.
+     */
+    public function charsetChanged($charset)
+    {
+    }
+}

--- a/lib/classes/Swift/Signers/SMimeSigner.php
+++ b/lib/classes/Swift/Signers/SMimeSigner.php
@@ -483,7 +483,7 @@ class Swift_Signers_SMimeSigner implements Swift_Signers_BodySigner
      * This message will parse the headers of a MIME email byte stream
      * and return an array that contains the headers as an associative
      * array and the email body as a string.
-     * 
+     *
      * @param Swift_OutputByteStream $emailStream
      * @param Swift_InputByteStream  $toStream
      *

--- a/tests/unit/Swift/Signers/SMimeSignerTest.php
+++ b/tests/unit/Swift/Signers/SMimeSignerTest.php
@@ -17,7 +17,7 @@ class Swift_Signers_SMimeSignerTest extends \PHPUnit\Framework\TestCase
         $this->samplesDir = str_replace('\\', '/', realpath(__DIR__.'/../../../_samples/')).'/';
     }
 
-    public function testUnSingedMessage()
+    public function testUnSignedMessage()
     {
         $message = (new Swift_Message('Wonderful Subject'))
           ->setFrom(array('john@doe.com' => 'John Doe'))
@@ -27,7 +27,7 @@ class Swift_Signers_SMimeSignerTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('Here is the message itself', $message->getBody());
     }
 
-    public function testSingedMessage()
+    public function testSignedMessage()
     {
         $message = (new Swift_Message('Wonderful Subject'))
           ->setFrom(array('john@doe.com' => 'John Doe'))
@@ -70,7 +70,62 @@ OEL;
         unset($messageStream);
     }
 
-    public function testSingedMessageExtraCerts()
+    public function testSignedMessageWithFullyWrappedMessage()
+    {
+        $message = (new Swift_Message('Middle-out compression secrets'))
+          ->setFrom(array('richard@piedpiper.com' => 'Richard Hendricks'))
+          ->setTo(array('jared@piedpiper.com' => 'Jared Dunn'))
+          ->setBody('Here goes the entire algorithm...');
+
+        $signer = new Swift_Signers_SMimeSigner();
+        $signer->setSignCertificate($this->samplesDir.'smime/sign.crt', $this->samplesDir.'smime/sign.key');
+
+        // Tell the signer to wrap the full MIME message
+        $signer->setWrapFullMessage(true);
+        $message->attachSigner($signer);
+
+        $messageStream = $this->newFilteredStream();
+        $message->toByteStream($messageStream);
+        $messageStream->commit();
+
+        $entityString = $messageStream->getContent();
+        $headers = self::getHeadersOfMessage($entityString);
+
+        if (!($boundary = $this->getBoundary($headers['content-type']))) {
+            return false;
+        }
+
+        $expectedBody = <<<OEL
+This is an S/MIME signed message
+
+--$boundary
+Content-Type: message/rfc822; charset=utf-8
+Content-Transfer-Encoding: 7bit
+
+Message-ID: <[a-f0-9]+@swift.generated>
+Date: .*
+Subject: Middle-out compression secrets
+From: Richard Hendricks <richard@piedpiper.com>
+To: Jared Dunn <jared@piedpiper.com>
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: quoted-printable
+
+Here goes the entire algorithm...
+--$boundary
+Content-Type: application/(x\-)?pkcs7-signature; name="smime\.p7s"
+Content-Transfer-Encoding: base64
+Content-Disposition: attachment; filename="smime\.p7s"
+
+(?:^[a-zA-Z0-9\/\\r\\n+]*={0,2})
+
+--$boundary--
+OEL;
+        $this->assertValidVerify($expectedBody, $messageStream);
+        unset($messageStream);
+    }
+
+    public function testSignedMessageExtraCerts()
     {
         $message = (new Swift_Message('Wonderful Subject'))
           ->setFrom(array('john@doe.com' => 'John Doe'))
@@ -113,7 +168,7 @@ OEL;
         unset($messageStream);
     }
 
-    public function testSingedMessageBinary()
+    public function testSignedMessageBinary()
     {
         $message = (new Swift_Message('Wonderful Subject'))
           ->setFrom(array('john@doe.com' => 'John Doe'))
@@ -148,7 +203,7 @@ OEL;
         unset($messageStreamClean, $messageStream);
     }
 
-    public function testSingedMessageWithAttachments()
+    public function testSignedMessageWithAttachments()
     {
         $message = (new Swift_Message('Wonderful Subject'))
           ->setFrom(array('john@doe.com' => 'John Doe'))
@@ -247,6 +302,51 @@ OEL;
         }
 
         $this->assertEquals($originalMessage, $decryptedMessageStream->getContent());
+        unset($decryptedMessageStream, $messageStream);
+    }
+
+    public function testEncryptedMessageWithFullyWrappedMessage()
+    {
+        $message = (new Swift_Message('Middle-out compression secrets'))
+          ->setFrom(array('richard@piedpiper.com' => 'Richard Hendricks'))
+          ->setTo(array('jared@piedpiper.com' => 'Jared Dunn'))
+          ->setBody('Here goes the entire algorithm...');
+
+        $originalMessage = $message->toString();
+
+        $signer = new Swift_Signers_SMimeSigner();
+        $signer->setEncryptCertificate($this->samplesDir.'smime/encrypt.crt');
+        $signer->setWrapFullMessage(true);
+        $message->attachSigner($signer);
+
+        $messageStream = new Swift_ByteStream_TemporaryFileByteStream();
+        $message->toByteStream($messageStream);
+        $messageStream->commit();
+
+        $entityString = $messageStream->getContent();
+        $headers = self::getHeadersOfMessage($entityString);
+
+        if (!preg_match('#^application/(x\-)?pkcs7-mime; smime-type=enveloped\-data;#', $headers['content-type'])) {
+            $this->fail('Content-type does not match.');
+
+            return false;
+        }
+
+        $expectedBody = '(?:^[a-zA-Z0-9\/\\r\\n+]*={0,2})';
+
+        $decryptedMessageStream = new Swift_ByteStream_TemporaryFileByteStream();
+
+        if (!openssl_pkcs7_decrypt($messageStream->getPath(), $decryptedMessageStream->getPath(), 'file://'.$this->samplesDir.'smime/encrypt.crt', array('file://'.$this->samplesDir.'smime/encrypt.key', 'swift'))) {
+            $this->fail(sprintf('Decrypt of the message failed. Internal error "%s".', openssl_error_string()));
+        }
+
+        $decryptedMessage = $decryptedMessageStream->getContent();
+        $decryptedHeaders = self::getHeadersOfMessage($decryptedMessage);
+        $this->assertEquals('message/rfc822; charset=utf-8', $decryptedHeaders['content-type']);
+        $this->assertEquals('7bit', $decryptedHeaders['content-transfer-encoding']);
+
+        $decryptedMessageBody = self::getBodyOfMessage($decryptedMessage);
+        $this->assertEquals($originalMessage, $decryptedMessageBody);
         unset($decryptedMessageStream, $messageStream);
     }
 
@@ -369,7 +469,7 @@ OEL;
           ->setTo(array('receiver@domain.org', 'other@domain.org' => 'A name'))
           ->setBody('Here is the message itself');
 
-        $originalMessage = $this->cleanMessage($message->toString());
+        $originalMessage = $message->toString();
 
         $signer = new Swift_Signers_SMimeSigner();
         $signer->setSignCertificate($this->samplesDir.'smime/sign.crt', $this->samplesDir.'smime/sign.key');
@@ -392,10 +492,10 @@ OEL;
 This is an S/MIME signed message
 
 --$boundary
-(?P<encrypted_message>MIME-Version: 1\.0
-Content-Disposition: attachment; filename="smime\.p7m"
-Content-Type: application/(x\-)?pkcs7-mime; smime-type=enveloped-data; name="smime\.p7m"
+(?P<encrypted_message>Content-Type: application/(x\-)?pkcs7-mime; smime-type=enveloped-data;
+ name="smime\.p7m"; charset=utf-8
 Content-Transfer-Encoding: base64
+Content-Disposition: attachment; filename="smime\.p7m"
 
 (?:^[a-zA-Z0-9\/\\r\\n+]*={0,2})
 
@@ -441,7 +541,7 @@ OEL;
         // File is UNIX encoded so convert them to correct line ending
         $expected = str_replace("\n", "\r\n", $expected);
 
-        $actual = trim(self::getBodyOfMessage($actual));
+        $actual = self::getBodyOfMessage($actual);
         if (!$this->assertRegExp('%^'.$expected.'$\s*%m', $actual)) {
             return false;
         }
@@ -484,7 +584,7 @@ OEL;
 
     protected static function getBodyOfMessage($message)
     {
-        return substr($message, strpos($message, "\r\n\r\n"));
+        return trim(substr($message, strpos($message, "\r\n\r\n")));
     }
 
     /**
@@ -511,7 +611,7 @@ OEL;
             $newContent .= "$headerName: $value\r\n";
         }
 
-        return $newContent."\r\n".ltrim(self::getBodyOfMessage($content));
+        return $newContent."\r\n".self::getBodyOfMessage($content);
     }
 
     /**
@@ -526,17 +626,19 @@ OEL;
     protected static function getHeadersOfMessage($message)
     {
         $headersPosEnd = strpos($message, "\r\n\r\n");
-        $headerData = substr($message, 0, $headersPosEnd);
+        $headerData = trim(substr($message, 0, $headersPosEnd));
         $headerLines = explode("\r\n", $headerData);
-
-        if (empty($headerLines)) {
-            return array();
-        }
-
         $headers = array();
 
+        if (false === $headerLines) {
+            return $headers;
+        }
+
+        // Transform header lines into an associative array
+        $currentHeaderName = '';
         foreach ($headerLines as $headerLine) {
-            if (ctype_space($headerLines[0]) || false === strpos($headerLine, ':')) {
+            // Handle headers that span multiple lines
+            if (false === strpos($headerLine, ':')) {
                 $headers[$currentHeaderName] .= ' '.trim($headerLine);
                 continue;
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| Doc update?   | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #834, #822
| License       | MIT

* Support for full MIME message wrapping (message/rfc822) for both signing and encryption was added. This has been described in RFC5751 section 3.1.
* The methods that carries out signing and encryption have been completely rewritten and a lot of comments were added to explain what's going on. This was not very clear before.
* The above mentioned rewrites fixed #834 and fixed #822.
* A public method was added to the Swift_Message class to clear all attached signers. This way it is possible to reuse the existing message object when signing and/or encrypting.
* A "Null" MIME content encoder was added to help recreating MIME parts from byte streams. OpenSSL is used carry out the actual encryption and signing. The resulting MIME part is returned as a byte stream (file) and needs to be parsed back into a Swift message. Since the content of the byte stream already has the correct encoding, the appropriate content encoder just needs to set the correct header and not touch the body content at all.
