### PR TITLE
fix ternary operator typo

### DIFF
--- a/lib/classes/Swift/Transport/EsmtpTransport.php
+++ b/lib/classes/Swift/Transport/EsmtpTransport.php
@@ -208,7 +208,7 @@ class Swift_Transport_EsmtpTransport extends Swift_Transport_AbstractSmtpTranspo
      */
     public function getSourceIp()
     {
-        return $this->params['sourceIp'] ?? null;
+        return $this->params['sourceIp'] ?: null;
     }
 
     /**


### PR DESCRIPTION
<!-- Please fill in this template according to the PR you're about to submit. -->

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Doc update?   | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | no
| License       | MIT

I've found a typo in a ternary operator in `lib/classes/Swift/Transport/EsmtpTransport.php`. There's a second `?` instead `:`.

<!-- Replace this comment by the description of your issue. -->

  
  