### PR TITLE
Basic IDN support

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,10 +1,10 @@
 Changelog
 =========
 
-6.0.3 (2017-XX-XX)
+6.1.0 (2017-XX-XX)
 ------------------
 
- * n/a
+ * added support for IDN domains in email addresses
 
 6.0.2 (2017-09-30)
 ------------------

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,10 @@
         "mockery/mockery": "~0.9.1",
         "symfony/phpunit-bridge": "~3.3@dev"
     },
+    "suggest": {
+        "ext-intl": "Needed to support internationalized email addresses",
+        "true/punycode": "Needed to support internationalized email addresses, if ext-intl is not installed"
+    },
     "autoload": {
         "files": ["lib/swift_required.php"]
     },

--- a/doc/headers.rst
+++ b/doc/headers.rst
@@ -383,6 +383,19 @@ following::
 
     */
 
+Internationalized domains are automatically converted to IDN encoding::
+
+    $to = $message->getHeaders()->get('To');
+    $to->setAddresses('joe@ëxämple.org');
+
+    echo $to->toString();
+
+    /*
+
+    To: joe@xn--xmple-gra1c.org
+
+    */
+
 ID Headers
 ~~~~~~~~~~
 

--- a/lib/classes/Swift/AddressEncoder.php
+++ b/lib/classes/Swift/AddressEncoder.php
@@ -25,6 +25,6 @@ interface Swift_AddressEncoder
      * @throws Swift_AddressEncoderException If the email cannot be represented in
      *                                       the encoding implemented by this class.
      */
-    public function encodeString($address);
+    public function encodeString(string $address): string;
 }
 

--- a/lib/classes/Swift/AddressEncoder.php
+++ b/lib/classes/Swift/AddressEncoder.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of SwiftMailer.
+ * (c) 2018 Christian Schmidt
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * Email address encoder.
+ *
+ * @author Chris Corbyn
+ */
+interface Swift_AddressEncoder
+{
+    /**
+     * Encodes an email address.
+     *
+     * @param string $address
+     *
+     * @return string
+     *
+     * @throws Swift_AddressEncoderException If the email cannot be represented in
+     *                                       the encoding implemented by this class.
+     */
+    public function encodeString($address);
+}
+

--- a/lib/classes/Swift/AddressEncoder.php
+++ b/lib/classes/Swift/AddressEncoder.php
@@ -11,20 +11,15 @@
 /**
  * Email address encoder.
  *
- * @author Chris Corbyn
+ * @author Christian Schmidt
  */
 interface Swift_AddressEncoder
 {
     /**
      * Encodes an email address.
      *
-     * @param string $address
-     *
-     * @return string
-     *
      * @throws Swift_AddressEncoderException If the email cannot be represented in
      *                                       the encoding implemented by this class.
      */
     public function encodeString(string $address): string;
 }
-

--- a/lib/classes/Swift/AddressEncoder/IdnAddressEncoder.php
+++ b/lib/classes/Swift/AddressEncoder/IdnAddressEncoder.php
@@ -50,7 +50,7 @@ class Swift_AddressEncoder_IdnAddressEncoder implements Swift_AddressEncoder
     protected function idnToAscii($string)
     {
         if (function_exists('idn_to_ascii')) {
-            return idn_to_ascii($string);
+            return idn_to_ascii($string, INTL_IDNA_VARIANT_UTS46);
         }
 
         if (class_exists('TrueBV\Punycode')) {

--- a/lib/classes/Swift/AddressEncoder/IdnAddressEncoder.php
+++ b/lib/classes/Swift/AddressEncoder/IdnAddressEncoder.php
@@ -18,10 +18,6 @@ class Swift_AddressEncoder_IdnAddressEncoder implements Swift_AddressEncoder
     /**
      * Encodes the domain part of an address using IDN.
      *
-     * @param string $address
-     *
-     * @return string
-     *
      * @throws Swift_AddressEncoderException If local-part contains non-ASCII characters
      */
     public function encodeString(string $address): string
@@ -62,4 +58,3 @@ class Swift_AddressEncoder_IdnAddressEncoder implements Swift_AddressEncoder
         throw new Swift_SwiftException('No IDN encoder found (install the intl extension or the true/punycode package');
     }
 }
-

--- a/lib/classes/Swift/AddressEncoder/IdnAddressEncoder.php
+++ b/lib/classes/Swift/AddressEncoder/IdnAddressEncoder.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of SwiftMailer.
+ * (c) 2018 Christian Schmidt
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * An IDN email address encoder.
+ *
+ * @author Christian Schmidt
+ */
+class Swift_AddressEncoder_IdnAddressEncoder implements Swift_AddressEncoder
+{
+    /**
+     * Encodes the domain part of an address using IDN.
+     *
+     * @param string $address
+     *
+     * @return string
+     *
+     * @throws Swift_AddressEncoderException If local-part contains non-ASCII characters
+     */
+    public function encodeString($address)
+    {
+        $i = strrpos($address, '@');
+        if (false !== $i) {
+            $local = substr($address, 0, $i);
+            $domain = substr($address, $i + 1);
+
+            if (preg_match('/[^\x00-\x7F]/', $local)) {
+                throw new Swift_AddressEncoderException('Non-ASCII characters not supported in local-part', $address);
+            }
+
+            $address = sprintf('%s@%s', $local, $this->idnToAscii($domain));
+        }
+
+        return $address;
+    }
+
+    /**
+     * IDN-encodes a UTF-8 string to ASCII.
+     *
+     * @param  string $string
+     * @return string
+     */
+    protected function idnToAscii($string)
+    {
+        if (function_exists('idn_to_ascii')) {
+            return idn_to_ascii($string);
+        }
+
+        if (class_exists('TrueBV\Punycode')) {
+            $punycode = new \TrueBV\Punycode();
+            return $punycode->encode($string);
+        }
+
+        throw new Swift_SwiftException('No IDN encoder found (install the intl extension or the true/punycode package');
+    }
+}
+

--- a/lib/classes/Swift/AddressEncoder/IdnAddressEncoder.php
+++ b/lib/classes/Swift/AddressEncoder/IdnAddressEncoder.php
@@ -24,7 +24,7 @@ class Swift_AddressEncoder_IdnAddressEncoder implements Swift_AddressEncoder
      *
      * @throws Swift_AddressEncoderException If local-part contains non-ASCII characters
      */
-    public function encodeString($address)
+    public function encodeString(string $address): string
     {
         $i = strrpos($address, '@');
         if (false !== $i) {
@@ -45,12 +45,13 @@ class Swift_AddressEncoder_IdnAddressEncoder implements Swift_AddressEncoder
      * IDN-encodes a UTF-8 string to ASCII.
      *
      * @param  string $string
+     *
      * @return string
      */
-    protected function idnToAscii($string)
+    protected function idnToAscii(string $string): string
     {
         if (function_exists('idn_to_ascii')) {
-            return idn_to_ascii($string, INTL_IDNA_VARIANT_UTS46);
+            return idn_to_ascii($string, 0, INTL_IDNA_VARIANT_UTS46);
         }
 
         if (class_exists('TrueBV\Punycode')) {

--- a/lib/classes/Swift/AddressEncoderException.php
+++ b/lib/classes/Swift/AddressEncoderException.php
@@ -24,7 +24,7 @@ class Swift_AddressEncoderException extends Swift_RfcComplianceException
      *
      * @param string $message
      */
-    public function __construct($address, $message)
+    public function __construct(string $address, string $message)
     {
         parent::__construct($message);
     }

--- a/lib/classes/Swift/AddressEncoderException.php
+++ b/lib/classes/Swift/AddressEncoderException.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of SwiftMailer.
+ * (c) 2018 Christian Schmidt
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * AddressEncoderException when the specified email address is in a format that
+ * cannot be encoded by a given address encoder.
+ *
+ * @author Christian Schmidt
+ */
+class Swift_AddressEncoderException extends Swift_RfcComplianceException
+{
+    /** The address that could not be encoded */
+    protected $address;
+
+    /**
+     * Create a new AddressEncoderException with $message.
+     *
+     * @param string $message
+     */
+    public function __construct($address, $message)
+    {
+        parent::__construct($message);
+    }
+}

--- a/lib/classes/Swift/AddressEncoderException.php
+++ b/lib/classes/Swift/AddressEncoderException.php
@@ -19,13 +19,17 @@ class Swift_AddressEncoderException extends Swift_RfcComplianceException
     /** The address that could not be encoded */
     protected $address;
 
-    /**
-     * Create a new AddressEncoderException with $message.
-     *
-     * @param string $message
-     */
-    public function __construct(string $address, string $message)
+    public function __construct(string $message, string $address)
     {
         parent::__construct($message);
+        $this->address = $address;
+    }
+
+    /**
+     * Returns the address that could not be encoded.
+     */
+    public function getAddress(): string
+    {
+        return $this->address;
     }
 }

--- a/lib/classes/Swift/Mime/Headers/IdentificationHeader.php
+++ b/lib/classes/Swift/Mime/Headers/IdentificationHeader.php
@@ -34,11 +34,6 @@ class Swift_Mime_Headers_IdentificationHeader extends Swift_Mime_Headers_Abstrac
      */
     private $emailValidator;
 
-    /**
-     * The address encoder.
-     *
-     * @var Swift_AddressEncoder
-     */
     private $addressEncoder;
 
     /**

--- a/lib/classes/Swift/Mime/Headers/IdentificationHeader.php
+++ b/lib/classes/Swift/Mime/Headers/IdentificationHeader.php
@@ -35,15 +35,23 @@ class Swift_Mime_Headers_IdentificationHeader extends Swift_Mime_Headers_Abstrac
     private $emailValidator;
 
     /**
+     * The address encoder.
+     *
+     * @var Swift_AddressEncoder
+     */
+    private $addressEncoder;
+
+    /**
      * Creates a new IdentificationHeader with the given $name and $id.
      *
      * @param string         $name
      * @param EmailValidator $emailValidator
      */
-    public function __construct($name, EmailValidator $emailValidator)
+    public function __construct($name, EmailValidator $emailValidator, Swift_AddressEncoder $addressEncoder = null)
     {
         $this->setFieldName($name);
         $this->emailValidator = $emailValidator;
+        $this->addressEncoder = $addressEncoder ?? new Swift_AddressEncoder_IdnAddressEncoder();
     }
 
     /**
@@ -159,7 +167,7 @@ class Swift_Mime_Headers_IdentificationHeader extends Swift_Mime_Headers_Abstrac
             $angleAddrs = array();
 
             foreach ($this->ids as $id) {
-                $angleAddrs[] = '<'.$id.'>';
+                $angleAddrs[] = '<'.$this->addressEncoder->encodeString($id).'>';
             }
 
             $this->setCachedValue(implode(' ', $angleAddrs));

--- a/lib/classes/Swift/Mime/Headers/IdentificationHeader.php
+++ b/lib/classes/Swift/Mime/Headers/IdentificationHeader.php
@@ -44,8 +44,9 @@ class Swift_Mime_Headers_IdentificationHeader extends Swift_Mime_Headers_Abstrac
     /**
      * Creates a new IdentificationHeader with the given $name and $id.
      *
-     * @param string         $name
-     * @param EmailValidator $emailValidator
+     * @param string               $name
+     * @param emailValidator       $emailValidator
+     * @param Swift_AddressEncoder $addressEncoder
      */
     public function __construct($name, EmailValidator $emailValidator, Swift_AddressEncoder $addressEncoder = null)
     {

--- a/lib/classes/Swift/Mime/Headers/MailboxHeader.php
+++ b/lib/classes/Swift/Mime/Headers/MailboxHeader.php
@@ -45,6 +45,7 @@ class Swift_Mime_Headers_MailboxHeader extends Swift_Mime_Headers_AbstractHeader
      * @param string                   $name           of Header
      * @param Swift_Mime_HeaderEncoder $encoder
      * @param EmailValidator           $emailValidator
+     * @param Swift_AddressEncoder     $addressEncoder
      */
     public function __construct($name, Swift_Mime_HeaderEncoder $encoder, EmailValidator $emailValidator, Swift_AddressEncoder $addressEncoder = null)
     {

--- a/lib/classes/Swift/Mime/Headers/MailboxHeader.php
+++ b/lib/classes/Swift/Mime/Headers/MailboxHeader.php
@@ -32,11 +32,6 @@ class Swift_Mime_Headers_MailboxHeader extends Swift_Mime_Headers_AbstractHeader
      */
     private $emailValidator;
 
-    /**
-     * The address encoder.
-     *
-     * @var Swift_AddressEncoder
-     */
     private $addressEncoder;
 
     /**

--- a/lib/classes/Swift/Mime/Headers/MailboxHeader.php
+++ b/lib/classes/Swift/Mime/Headers/MailboxHeader.php
@@ -33,17 +33,25 @@ class Swift_Mime_Headers_MailboxHeader extends Swift_Mime_Headers_AbstractHeader
     private $emailValidator;
 
     /**
+     * The address encoder.
+     *
+     * @var Swift_AddressEncoder
+     */
+    private $addressEncoder;
+
+    /**
      * Creates a new MailboxHeader with $name.
      *
      * @param string                   $name           of Header
      * @param Swift_Mime_HeaderEncoder $encoder
      * @param EmailValidator           $emailValidator
      */
-    public function __construct($name, Swift_Mime_HeaderEncoder $encoder, EmailValidator $emailValidator)
+    public function __construct($name, Swift_Mime_HeaderEncoder $encoder, EmailValidator $emailValidator, Swift_AddressEncoder $addressEncoder = null)
     {
         $this->setFieldName($name);
         $this->setEncoder($encoder);
         $this->emailValidator = $emailValidator;
+        $this->addressEncoder = $addressEncoder ?? new Swift_AddressEncoder_IdnAddressEncoder();
     }
 
     /**
@@ -330,7 +338,7 @@ class Swift_Mime_Headers_MailboxHeader extends Swift_Mime_Headers_AbstractHeader
         $strings = array();
 
         foreach ($mailboxes as $email => $name) {
-            $mailboxStr = $email;
+            $mailboxStr = $this->addressEncoder->encodeString($email);
             if (null !== $name) {
                 $nameStr = $this->createDisplayNameString($name, empty($strings));
                 $mailboxStr = $nameStr.' <'.$mailboxStr.'>';

--- a/lib/classes/Swift/Mime/Headers/PathHeader.php
+++ b/lib/classes/Swift/Mime/Headers/PathHeader.php
@@ -42,8 +42,9 @@ class Swift_Mime_Headers_PathHeader extends Swift_Mime_Headers_AbstractHeader
     /**
      * Creates a new PathHeader with the given $name.
      *
-     * @param string         $name
-     * @param EmailValidator $emailValidator
+     * @param string               $name
+     * @param EmailValidator       $emailValidator
+     * @param Swift_AddressEncoder $addressEncoder
      */
     public function __construct($name, EmailValidator $emailValidator, Swift_AddressEncoder $addressEncoder = null)
     {

--- a/lib/classes/Swift/Mime/Headers/PathHeader.php
+++ b/lib/classes/Swift/Mime/Headers/PathHeader.php
@@ -33,15 +33,23 @@ class Swift_Mime_Headers_PathHeader extends Swift_Mime_Headers_AbstractHeader
     private $emailValidator;
 
     /**
+     * The address encoder.
+     *
+     * @var Swift_AddressEncoder
+     */
+    private $addressEncoder;
+
+    /**
      * Creates a new PathHeader with the given $name.
      *
      * @param string         $name
      * @param EmailValidator $emailValidator
      */
-    public function __construct($name, EmailValidator $emailValidator)
+    public function __construct($name, EmailValidator $emailValidator, Swift_AddressEncoder $addressEncoder = null)
     {
         $this->setFieldName($name);
         $this->emailValidator = $emailValidator;
+        $this->addressEncoder = $addressEncoder ?? new Swift_AddressEncoder_IdnAddressEncoder();
     }
 
     /**
@@ -127,7 +135,8 @@ class Swift_Mime_Headers_PathHeader extends Swift_Mime_Headers_AbstractHeader
     {
         if (!$this->getCachedValue()) {
             if (isset($this->address)) {
-                $this->setCachedValue('<'.$this->address.'>');
+                $address = $this->addressEncoder->encodeString($this->address);
+                $this->setCachedValue('<'.$address.'>');
             }
         }
 

--- a/lib/classes/Swift/Mime/Headers/PathHeader.php
+++ b/lib/classes/Swift/Mime/Headers/PathHeader.php
@@ -32,11 +32,6 @@ class Swift_Mime_Headers_PathHeader extends Swift_Mime_Headers_AbstractHeader
      */
     private $emailValidator;
 
-    /**
-     * The address encoder.
-     *
-     * @var Swift_AddressEncoder
-     */
     private $addressEncoder;
 
     /**

--- a/lib/classes/Swift/Mime/SimpleHeaderFactory.php
+++ b/lib/classes/Swift/Mime/SimpleHeaderFactory.php
@@ -36,6 +36,7 @@ class Swift_Mime_SimpleHeaderFactory implements Swift_Mime_CharsetObserver
      * @param Swift_Encoder            $paramEncoder
      * @param EmailValidator           $emailValidator
      * @param string|null              $charset
+     * @param Swift_AddressEncoder     $addressEncoder
      */
     public function __construct(Swift_Mime_HeaderEncoder $encoder, Swift_Encoder $paramEncoder, EmailValidator $emailValidator, $charset = null, Swift_AddressEncoder $addressEncoder = null)
     {

--- a/lib/classes/Swift/Mime/SimpleHeaderFactory.php
+++ b/lib/classes/Swift/Mime/SimpleHeaderFactory.php
@@ -37,12 +37,13 @@ class Swift_Mime_SimpleHeaderFactory implements Swift_Mime_CharsetObserver
      * @param EmailValidator           $emailValidator
      * @param string|null              $charset
      */
-    public function __construct(Swift_Mime_HeaderEncoder $encoder, Swift_Encoder $paramEncoder, EmailValidator $emailValidator, $charset = null)
+    public function __construct(Swift_Mime_HeaderEncoder $encoder, Swift_Encoder $paramEncoder, EmailValidator $emailValidator, $charset = null, Swift_AddressEncoder $addressEncoder = null)
     {
         $this->encoder = $encoder;
         $this->paramEncoder = $paramEncoder;
         $this->emailValidator = $emailValidator;
         $this->charset = $charset;
+        $this->addressEncoder = $addressEncoder ?? new Swift_AddressEncoder_IdnAddressEncoder();
     }
 
     /**
@@ -55,7 +56,7 @@ class Swift_Mime_SimpleHeaderFactory implements Swift_Mime_CharsetObserver
      */
     public function createMailboxHeader($name, $addresses = null)
     {
-        $header = new Swift_Mime_Headers_MailboxHeader($name, $this->encoder, $this->emailValidator);
+        $header = new Swift_Mime_Headers_MailboxHeader($name, $this->encoder, $this->emailValidator, $this->addressEncoder);
         if (isset($addresses)) {
             $header->setFieldBodyModel($addresses);
         }

--- a/lib/classes/Swift/Transport/AbstractSmtpTransport.php
+++ b/lib/classes/Swift/Transport/AbstractSmtpTransport.php
@@ -27,7 +27,6 @@ abstract class Swift_Transport_AbstractSmtpTransport implements Swift_Transport
     /** The event dispatching layer */
     protected $eventDispatcher;
 
-    /** The address encoder */
     protected $addressEncoder;
 
     /** Source Ip */

--- a/lib/classes/Swift/Transport/AbstractSmtpTransport.php
+++ b/lib/classes/Swift/Transport/AbstractSmtpTransport.php
@@ -27,6 +27,9 @@ abstract class Swift_Transport_AbstractSmtpTransport implements Swift_Transport
     /** The event dispatching layer */
     protected $eventDispatcher;
 
+    /** The address encoder */
+    protected $addressEncoder;
+
     /** Source Ip */
     protected $sourceIp;
 
@@ -39,11 +42,13 @@ abstract class Swift_Transport_AbstractSmtpTransport implements Swift_Transport
      * @param Swift_Transport_IoBuffer     $buf
      * @param Swift_Events_EventDispatcher $dispatcher
      * @param string                       $localDomain
+     * @param Swift_AddressEncoder         $addressEncoder
      */
-    public function __construct(Swift_Transport_IoBuffer $buf, Swift_Events_EventDispatcher $dispatcher, $localDomain = '127.0.0.1')
+    public function __construct(Swift_Transport_IoBuffer $buf, Swift_Events_EventDispatcher $dispatcher, $localDomain = '127.0.0.1', Swift_AddressEncoder $addressEncoder = null)
     {
-        $this->eventDispatcher = $dispatcher;
         $this->buffer = $buf;
+        $this->eventDispatcher = $dispatcher;
+        $this->addressEncoder = $addressEncoder ?? new Swift_AddressEncoder_IdnAddressEncoder();
         $this->setLocalDomain($localDomain);
     }
 
@@ -336,6 +341,7 @@ abstract class Swift_Transport_AbstractSmtpTransport implements Swift_Transport
     /** Send the MAIL FROM command */
     protected function doMailFromCommand($address)
     {
+        $address = $this->addressEncoder->encodeString($address);
         $this->executeCommand(
             sprintf("MAIL FROM:<%s>\r\n", $address), array(250)
             );
@@ -344,6 +350,7 @@ abstract class Swift_Transport_AbstractSmtpTransport implements Swift_Transport
     /** Send the RCPT TO command */
     protected function doRcptToCommand($address)
     {
+        $address = $this->addressEncoder->encodeString($address);
         $this->executeCommand(
             sprintf("RCPT TO:<%s>\r\n", $address), array(250, 251, 252)
             );

--- a/lib/classes/Swift/Transport/EsmtpTransport.php
+++ b/lib/classes/Swift/Transport/EsmtpTransport.php
@@ -52,10 +52,11 @@ class Swift_Transport_EsmtpTransport extends Swift_Transport_AbstractSmtpTranspo
      * @param Swift_Transport_EsmtpHandler[] $extensionHandlers
      * @param Swift_Events_EventDispatcher   $dispatcher
      * @param string                         $localDomain
+     * @param Swift_AddressEncoder         $addressEncoder
      */
-    public function __construct(Swift_Transport_IoBuffer $buf, array $extensionHandlers, Swift_Events_EventDispatcher $dispatcher, $localDomain = '127.0.0.1')
+    public function __construct(Swift_Transport_IoBuffer $buf, array $extensionHandlers, Swift_Events_EventDispatcher $dispatcher, $localDomain = '127.0.0.1', Swift_AddressEncoder $addressEncoder = null)
     {
-        parent::__construct($buf, $dispatcher, $localDomain);
+        parent::__construct($buf, $dispatcher, $localDomain, $addressEncoder);
         $this->setExtensionHandlers($extensionHandlers);
     }
 
@@ -338,6 +339,7 @@ class Swift_Transport_EsmtpTransport extends Swift_Transport_AbstractSmtpTranspo
     /** Overridden to add Extension support */
     protected function doMailFromCommand($address)
     {
+        $address = $this->addressEncoder->encodeString($address);
         $handlers = $this->getActiveHandlers();
         $params = array();
         foreach ($handlers as $handler) {
@@ -352,6 +354,7 @@ class Swift_Transport_EsmtpTransport extends Swift_Transport_AbstractSmtpTranspo
     /** Overridden to add Extension support */
     protected function doRcptToCommand($address)
     {
+        $address = $this->addressEncoder->encodeString($address);
         $handlers = $this->getActiveHandlers();
         $params = array();
         foreach ($handlers as $handler) {

--- a/lib/classes/Swift/Transport/EsmtpTransport.php
+++ b/lib/classes/Swift/Transport/EsmtpTransport.php
@@ -52,7 +52,7 @@ class Swift_Transport_EsmtpTransport extends Swift_Transport_AbstractSmtpTranspo
      * @param Swift_Transport_EsmtpHandler[] $extensionHandlers
      * @param Swift_Events_EventDispatcher   $dispatcher
      * @param string                         $localDomain
-     * @param Swift_AddressEncoder         $addressEncoder
+     * @param Swift_AddressEncoder           $addressEncoder
      */
     public function __construct(Swift_Transport_IoBuffer $buf, array $extensionHandlers, Swift_Events_EventDispatcher $dispatcher, $localDomain = '127.0.0.1', Swift_AddressEncoder $addressEncoder = null)
     {

--- a/lib/dependency_maps/mime_deps.php
+++ b/lib/dependency_maps/mime_deps.php
@@ -68,6 +68,7 @@ Swift_DependencyContainer::getInstance()
             'mime.rfc2231encoder',
             'email.validator',
             'properties.charset',
+            'mime.addressencoder',
         ))
 
     ->register('mime.headerset')
@@ -125,6 +126,9 @@ Swift_DependencyContainer::getInstance()
     ->register('mime.rfc2231encoder')
     ->asNewInstanceOf('Swift_Encoder_Rfc2231Encoder')
     ->withDependencies(array('mime.charstream'))
+
+    ->register('mime.addressencoder')
+    ->asNewInstanceOf('Swift_AddressEncoder_IdnAddressEncoder')
 ;
 
 unset($swift_mime_types);

--- a/lib/dependency_maps/transport_deps.php
+++ b/lib/dependency_maps/transport_deps.php
@@ -14,6 +14,7 @@ Swift_DependencyContainer::getInstance()
         array('transport.authhandler'),
         'transport.eventdispatcher',
         'transport.localdomain',
+        'transport.addressencoder',
     ))
 
     ->register('transport.sendmail')
@@ -71,6 +72,9 @@ Swift_DependencyContainer::getInstance()
 
     ->register('transport.eventdispatcher')
     ->asNewInstanceOf('Swift_Events_SimpleEventDispatcher')
+
+    ->register('transport.addressencoder')
+    ->asNewInstanceOf('Swift_AddressEncoder_IdnAddressEncoder')
 
     ->register('transport.replacementfactory')
     ->asSharedInstanceOf('Swift_StreamFilters_StringReplacementFilterFactory')

--- a/tests/unit/Swift/Mime/Headers/IdentificationHeaderTest.php
+++ b/tests/unit/Swift/Mime/Headers/IdentificationHeaderTest.php
@@ -133,6 +133,14 @@ class Swift_Mime_Headers_IdentificationHeaderTest extends \PHPUnit\Framework\Tes
         $this->assertEquals('<a@[1.2.3.4]>', $header->getFieldBody());
     }
 
+    public function testIdRigthIsIdnEncoded()
+    {
+        $header = $this->getHeader('References');
+        $header->setId('a@ä');
+        $this->assertEquals('a@ä', $header->getId());
+        $this->assertEquals('<a@xn--4ca>', $header->getFieldBody());
+    }
+
     /**
      * @expectedException \Exception
      * @expectedMessageException "b c d" is not valid id-right
@@ -179,6 +187,6 @@ class Swift_Mime_Headers_IdentificationHeaderTest extends \PHPUnit\Framework\Tes
 
     private function getHeader($name)
     {
-        return new Swift_Mime_Headers_IdentificationHeader($name, new EmailValidator());
+        return new Swift_Mime_Headers_IdentificationHeader($name, new EmailValidator(), new Swift_AddressEncoder_IdnAddressEncoder());
     }
 }

--- a/tests/unit/Swift/Mime/Headers/MailboxHeaderTest.php
+++ b/tests/unit/Swift/Mime/Headers/MailboxHeaderTest.php
@@ -71,6 +71,30 @@ class Swift_Mime_Headers_MailboxHeaderTest extends \SwiftMailerTestCase
             );
     }
 
+    public function testUtf8CharsInDomainAreIdnEncoded()
+    {
+        $header = $this->getHeader('From', $this->getEncoder('Q', true));
+        $header->setNameAddresses(array(
+            'chris@swïftmailer.org' => 'Chris Corbyn',
+            ));
+        $this->assertEquals(
+            array('Chris Corbyn <chris@xn--swftmailer-78a.org>'),
+            $header->getNameAddressStrings()
+            );
+    }
+
+    /**
+     * @expectedException \Swift_AddressEncoderException
+     */
+    public function testUtf8CharsInLocalPartThrows()
+    {
+        $header = $this->getHeader('From', $this->getEncoder('Q', true));
+        $header->setNameAddresses(array(
+            'chrïs@swiftmailer.org' => 'Chris Corbyn',
+            ));
+        $header->getNameAddressStrings();
+    }
+
     public function testGetMailboxesReturnsNameValuePairs()
     {
         $header = $this->getHeader('From', $this->getEncoder('Q', true));
@@ -311,7 +335,7 @@ class Swift_Mime_Headers_MailboxHeaderTest extends \SwiftMailerTestCase
 
     private function getHeader($name, $encoder)
     {
-        $header = new Swift_Mime_Headers_MailboxHeader($name, $encoder, new EmailValidator());
+        $header = new Swift_Mime_Headers_MailboxHeader($name, $encoder, new EmailValidator(), new Swift_AddressEncoder_IdnAddressEncoder());
         $header->setCharset($this->charset);
 
         return $header;

--- a/tests/unit/Swift/Mime/Headers/PathHeaderTest.php
+++ b/tests/unit/Swift/Mime/Headers/PathHeaderTest.php
@@ -41,6 +41,23 @@ class Swift_Mime_Headers_PathHeaderTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('<chris@swiftmailer.org>', $header->getFieldBody());
     }
 
+    public function testAddressIsIdnEncoded()
+    {
+        $header = $this->getHeader('Return-Path');
+        $header->setAddress('chris@swïftmailer.org');
+        $this->assertEquals('<chris@xn--swftmailer-78a.org>', $header->getFieldBody());
+    }
+
+    /**
+     * @expectedException Swift_AddressEncoderException
+     */
+    public function testAddressMustBeEncodable()
+    {
+        $header = $this->getHeader('Return-Path');
+        $header->setAddress('chrïs@swiftmailer.org');
+        $header->getFieldBody();
+    }
+
     public function testValueIsEmptyAngleBracketsIfEmptyAddressSet()
     {
         $header = $this->getHeader('Return-Path');
@@ -73,6 +90,6 @@ class Swift_Mime_Headers_PathHeaderTest extends \PHPUnit\Framework\TestCase
 
     private function getHeader($name)
     {
-        return new Swift_Mime_Headers_PathHeader($name, new EmailValidator());
+        return new Swift_Mime_Headers_PathHeader($name, new EmailValidator(), new Swift_AddressEncoder_IdnAddressEncoder());
     }
 }

--- a/tests/unit/Swift/Transport/AbstractSmtpTest.php
+++ b/tests/unit/Swift/Transport/AbstractSmtpTest.php
@@ -427,6 +427,36 @@ abstract class Swift_Transport_AbstractSmtpTest extends \SwiftMailerTestCase
         }
     }
 
+    public function testUtf8Address()
+    {
+        $buf = $this->getBuffer();
+        $smtp = $this->getTransport($buf);
+        $message = $this->createMessage();
+
+        $message->shouldReceive('getFrom')
+                ->once()
+                ->andReturn(array('me@dömain.com' => 'Me'));
+        $message->shouldReceive('getTo')
+                ->once()
+                ->andReturn(array('foo@bär' => null));
+        $buf->shouldReceive('write')
+            ->once()
+            ->with("MAIL FROM:<me@xn--dmain-jua.com>\r\n")
+            ->andReturn(1);
+        $buf->shouldReceive('write')
+            ->once()
+            ->with("RCPT TO:<foo@xn--br-via>\r\n")
+            ->andReturn(1);
+        $buf->shouldReceive('readLine')
+            ->once()
+            ->with(1)
+            ->andReturn('250 OK'."\r\n");
+
+        $this->finishBuffer($buf);
+        $smtp->start();
+        $smtp->send($message);
+    }
+
     public function testMailFromCommandIsOnlySentOncePerMessage()
     {
         $buf = $this->getBuffer();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Doc update?   | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #63, #541
| License       | MIT

IDN domains have been around for more than a decade and are now widely used. Swiftmailer should support internationalised email addresses. Even if you don't use an IDN domain yourself, you may need to send email to people who do.

Calling `setTo()` with a non-ASCII email address does not throw an error (it does throw, if the email address is otherwise malformed). The [egulias/EmailValidator](https://github.com/egulias/EmailValidator) package accepts addresses containing non-ASCII characters both in the local-part (the part of the address left of @) and domain (after @). However, when you try to send the email, the SMTP server rejects the address for being syntactically invalid.

Handling non-ASCII characters in local-part and domain are two different issues. Non-ASCII characters in the domain is supported by all email servers, as long as the domain is IDN-encoded by the sender. Non-ASCII characters in local-part requires support for the `SMTPUTF8` SMTP extension (see [RFC 6531](https://tools.ietf.org/html/rfc6531)).

This PR adds basic support for email addresses using IDN domains. It does not add support for `SMTPUTF8` but simply IDN-encodes the domain, so mail can use the existing infrastructure. The implementation is backwards-compatible fashion.

Future work should add support for `SMTPUTF8` in order to support for email addresses with non-ASCII characters in local-part also. This would probably require BC-breaking changes, so it needs to go into a new major release of Swiftmailer.