### PR TITLE
Add Swift_DependencyContainer::asArray()

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,7 @@ Changelog
 ------------------
 
  * added support for IDN domains in email addresses
+ * introduced new dependencies: transport.smtphandlers and transport.authhandlers
 
 6.0.2 (2017-09-30)
 ------------------

--- a/lib/classes/Swift/DependencyContainer.php
+++ b/lib/classes/Swift/DependencyContainer.php
@@ -16,16 +16,19 @@
 class Swift_DependencyContainer
 {
     /** Constant for literal value types */
-    const TYPE_VALUE = 0x0001;
+    const TYPE_VALUE = 0x00001;
 
     /** Constant for new instance types */
-    const TYPE_INSTANCE = 0x0010;
+    const TYPE_INSTANCE = 0x00010;
 
     /** Constant for shared instance types */
-    const TYPE_SHARED = 0x0100;
+    const TYPE_SHARED = 0x00100;
 
     /** Constant for aliases */
-    const TYPE_ALIAS = 0x1000;
+    const TYPE_ALIAS = 0x01000;
+
+    /** Constant for arrays */
+    const TYPE_ARRAY = 0x10000;
 
     /** Singleton instance */
     private static $instance = null;
@@ -112,6 +115,8 @@ class Swift_DependencyContainer
                 return $this->createNewInstance($itemName);
             case self::TYPE_SHARED:
                 return $this->createSharedInstance($itemName);
+            case self::TYPE_ARRAY:
+                return $this->createDependenciesFor($itemName);
         }
     }
 
@@ -223,6 +228,21 @@ class Swift_DependencyContainer
         $endPoint = &$this->getEndPoint();
         $endPoint['lookupType'] = self::TYPE_SHARED;
         $endPoint['className'] = $className;
+
+        return $this;
+    }
+
+    /**
+     * Specify the previously registered item as array of dependencies.
+     *
+     * {@link register()} must be called before this will work.
+     *
+     * @return $this
+     */
+    public function asArray()
+    {
+        $endPoint = &$this->getEndPoint();
+        $endPoint['lookupType'] = self::TYPE_ARRAY;
 
         return $this;
     }

--- a/lib/dependency_maps/mime_deps.php
+++ b/lib/dependency_maps/mime_deps.php
@@ -64,12 +64,12 @@ Swift_DependencyContainer::getInstance()
     ->register('mime.headerfactory')
     ->asNewInstanceOf('Swift_Mime_SimpleHeaderFactory')
     ->withDependencies([
-            'mime.qpheaderencoder',
-            'mime.rfc2231encoder',
-            'email.validator',
-            'properties.charset',
-            'mime.addressencoder',
-        ])
+        'mime.qpheaderencoder',
+        'mime.rfc2231encoder',
+        'email.validator',
+        'properties.charset',
+        'mime.addressencoder',
+    ])
 
     ->register('mime.headerset')
     ->asNewInstanceOf('Swift_Mime_SimpleHeaderSet')

--- a/lib/dependency_maps/transport_deps.php
+++ b/lib/dependency_maps/transport_deps.php
@@ -11,7 +11,7 @@ Swift_DependencyContainer::getInstance()
     ->asNewInstanceOf('Swift_Transport_EsmtpTransport')
     ->withDependencies([
         'transport.buffer',
-        ['transport.authhandler'],
+        'transport.smtphandlers',
         'transport.eventdispatcher',
         'transport.localdomain',
         'transport.addressencoder',
@@ -43,16 +43,22 @@ Swift_DependencyContainer::getInstance()
     ->asNewInstanceOf('Swift_Transport_StreamBuffer')
     ->withDependencies(['transport.replacementfactory'])
 
+    ->register('transport.smtphandlers')
+    ->asArray()
+    ->withDependencies(['transport.authhandler'])
+
     ->register('transport.authhandler')
     ->asNewInstanceOf('Swift_Transport_Esmtp_AuthHandler')
+    ->withDependencies(['transport.authhandlers'])
+
+    ->register('transport.authhandlers')
+    ->asArray()
     ->withDependencies([
-        [
-            'transport.crammd5auth',
-            'transport.loginauth',
-            'transport.plainauth',
-            'transport.ntlmauth',
-            'transport.xoauth2auth',
-        ],
+        'transport.crammd5auth',
+        'transport.loginauth',
+        'transport.plainauth',
+        'transport.ntlmauth',
+        'transport.xoauth2auth',
     ])
 
     ->register('transport.crammd5auth')

--- a/tests/unit/Swift/DependencyContainerTest.php
+++ b/tests/unit/Swift/DependencyContainerTest.php
@@ -78,6 +78,12 @@ class Swift_DependencyContainerTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($a, $b);
     }
 
+    public function testRegisterAndLookupArray()
+    {
+        $this->container->register('One')->asArray();
+        $this->assertSame([], $this->container->lookup('One'));
+    }
+
     public function testNewInstanceWithDependencies()
     {
         $this->container->register('foo')->asValue('FOO');
@@ -154,6 +160,15 @@ class Swift_DependencyContainerTest extends \PHPUnit\Framework\TestCase
         $obj = $this->container->lookup('two');
         $this->assertEquals([$this->container->lookup('one'), 'FOO'], $obj->arg1);
         $this->assertSame('FOO', $obj->arg2);
+    }
+
+    public function testArrayWithDependencies()
+    {
+        $this->container->register('foo')->asValue('FOO');
+        $this->container->register('bar')->asValue(42);
+        $this->container->register('one')->asArray('One')
+            ->withDependencies(['foo', 'bar']);
+        $this->assertSame(['FOO', 42], $this->container->lookup('one'));
     }
 
     public function testAliasCanBeSet()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Doc update?   | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 
| License       | MIT

The constructor for `Swift_Transport_EsmtpTransport` accepts an array of `Swift_Transport_EsmtpHandler` instances. In order to add more handlers using `Swift_DependencyContainer` you have to specify all handlers in addition to the four other constructor arguments.

This PR makes it possible to extract the array of instances as a separate item in the dependency container.