### PR TITLE
Remove unused sourceIp

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+7.0.0 (2018-XX-XX)
+------------------
+
+ * removed Swift_Transport_AbstractSmtpTransport::getSourceIp() and setSourceIp()
+
 6.1.0 (2018-XX-XX)
 ------------------
 

--- a/lib/classes/Swift/Transport/AbstractSmtpTransport.php
+++ b/lib/classes/Swift/Transport/AbstractSmtpTransport.php
@@ -35,9 +35,6 @@ abstract class Swift_Transport_AbstractSmtpTransport implements Swift_Transport
     /** The pipelined commands waiting for response */
     protected $pipeline = [];
 
-    /** Source Ip */
-    protected $sourceIp;
-
     /** Return an array of params for the Buffer */
     abstract protected function getBufferParams();
 
@@ -94,26 +91,6 @@ abstract class Swift_Transport_AbstractSmtpTransport implements Swift_Transport
     public function getLocalDomain()
     {
         return $this->domain;
-    }
-
-    /**
-     * Sets the source IP.
-     *
-     * @param string $source
-     */
-    public function setSourceIp($source)
-    {
-        $this->sourceIp = $source;
-    }
-
-    /**
-     * Returns the IP used to connect to the destination.
-     *
-     * @return string
-     */
-    public function getSourceIp()
-    {
-        return $this->sourceIp;
     }
 
     public function setAddressEncoder(Swift_AddressEncoder $addressEncoder)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Doc update?   | no
| BC breaks?    | yes
| Deprecations? | no
| Fixed tickets | 
| License       | MIT

`Swift_Transport_AbstractSmtpTransport::getSourceIp()` and `setSourceIp()` are not used, so let's remove them.

This is a BC break, so this PR must wait until the next major version.