### PR TITLE
Remove getPriorityOver()

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+7.0.x (2018-XX-XX)
+------------------
+
+ * removed Swift_Transport_EsmtpHandler::getPriorityOver()
+
+
 6.1.0 (2018-XX-XX)
 ------------------
 

--- a/lib/classes/Swift/Transport/Esmtp/AuthHandler.php
+++ b/lib/classes/Swift/Transport/Esmtp/AuthHandler.php
@@ -209,20 +209,6 @@ class Swift_Transport_Esmtp_AuthHandler implements Swift_Transport_EsmtpHandler
     }
 
     /**
-     * Returns +1, -1 or 0 according to the rules for usort().
-     *
-     * This method is called to ensure extensions can be execute in an appropriate order.
-     *
-     * @param string $esmtpKeyword to compare with
-     *
-     * @return int
-     */
-    public function getPriorityOver($esmtpKeyword)
-    {
-        return 0;
-    }
-
-    /**
      * Returns an array of method names which are exposed to the Esmtp class.
      *
      * @return string[]

--- a/lib/classes/Swift/Transport/EsmtpHandler.php
+++ b/lib/classes/Swift/Transport/EsmtpHandler.php
@@ -62,17 +62,6 @@ interface Swift_Transport_EsmtpHandler
     public function onCommand(Swift_Transport_SmtpAgent $agent, $command, $codes = [], &$failedRecipients = null, &$stop = false);
 
     /**
-     * Returns +1, -1 or 0 according to the rules for usort().
-     *
-     * This method is called to ensure extensions can be execute in an appropriate order.
-     *
-     * @param string $esmtpKeyword to compare with
-     *
-     * @return int
-     */
-    public function getPriorityOver($esmtpKeyword);
-
-    /**
      * Returns an array of method names which are exposed to the Esmtp class.
      *
      * @return string[]

--- a/lib/classes/Swift/Transport/EsmtpTransport.php
+++ b/lib/classes/Swift/Transport/EsmtpTransport.php
@@ -212,6 +212,8 @@ class Swift_Transport_EsmtpTransport extends Swift_Transport_AbstractSmtpTranspo
     /**
      * Set ESMTP extension handlers.
      *
+     * The handlers will be invoked in the order they are provided.
+     *
      * @param Swift_Transport_EsmtpHandler[] $handlers
      *
      * @return $this
@@ -222,9 +224,6 @@ class Swift_Transport_EsmtpTransport extends Swift_Transport_AbstractSmtpTranspo
         foreach ($handlers as $handler) {
             $assoc[$handler->getHandledKeyword()] = $handler;
         }
-        uasort($assoc, function ($a, $b) {
-            return $a->getPriorityOver($b->getHandledKeyword());
-        });
         $this->handlers = $assoc;
         $this->setHandlerParams();
 

--- a/tests/unit/Swift/Transport/EsmtpTransport/ExtensionSupportTest.php
+++ b/tests/unit/Swift/Transport/EsmtpTransport/ExtensionSupportTest.php
@@ -11,33 +11,6 @@ interface Swift_Transport_EsmtpHandlerMixin extends Swift_Transport_EsmtpHandler
 
 class Swift_Transport_EsmtpTransport_ExtensionSupportTest extends Swift_Transport_EsmtpTransportTest
 {
-    public function testExtensionHandlersAreSortedAsNeeded()
-    {
-        $buf = $this->getBuffer();
-        $smtp = $this->getTransport($buf);
-        $ext1 = $this->getMockery('Swift_Transport_EsmtpHandler')->shouldIgnoreMissing();
-        $ext2 = $this->getMockery('Swift_Transport_EsmtpHandler')->shouldIgnoreMissing();
-
-        $ext1->shouldReceive('getHandledKeyword')
-             ->zeroOrMoreTimes()
-             ->andReturn('AUTH');
-        $ext1->shouldReceive('getPriorityOver')
-             ->zeroOrMoreTimes()
-             ->with('STARTTLS')
-             ->andReturn(1);
-        $ext2->shouldReceive('getHandledKeyword')
-             ->zeroOrMoreTimes()
-             ->andReturn('STARTTLS');
-        $ext2->shouldReceive('getPriorityOver')
-             ->zeroOrMoreTimes()
-             ->with('AUTH')
-             ->andReturn(-1);
-        $this->finishBuffer($buf);
-
-        $smtp->setExtensionHandlers([$ext1, $ext2]);
-        $this->assertEquals([$ext2, $ext1], $smtp->getExtensionHandlers());
-    }
-
     public function testHandlersAreNotifiedOfParams()
     {
         $buf = $this->getBuffer();


### PR DESCRIPTION
<!-- Please fill in this template according to the PR you're about to submit. -->

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc update?   | no
| BC breaks?    | yes
| Deprecations? | no
| Fixed tickets | 
| License       | MIT

The idea behind `Swift_Transport_EsmtpHandler::getPriorityOver()` is flawed.

`uasort()` requires that operators are symmetric, i.e. if `FooHandler::getPriorityOver("BAR")` returns 1, `BarHandler::getPriorityOver("FOO")` should return -1. A handler cannot simply return 0 to indicate that it does not care about ordering, like `Swift_Transport_Esmtp_AuthHandler` currently does. It is not practical for a handler to know about all other possible handlers and their priority requirements.

You usually only have a few extension handlers that are configured manually, so having an automated priority sort is not really required. I suggest that we just require users to manually sort the list of extension handlers before passing it to `Swift_Transport_EsmtpTransport::setExtensionHandlers()` or the `Swift_Transport_EsmtpTransport` constructor.