### PR TITLE
Handle address encoder exceptions during send

### DIFF
--- a/lib/classes/Swift/Transport/AbstractSmtpTransport.php
+++ b/lib/classes/Swift/Transport/AbstractSmtpTransport.php
@@ -456,6 +456,8 @@ abstract class Swift_Transport_AbstractSmtpTransport implements Swift_Transport
                 ++$sent;
             } catch (Swift_TransportException $e) {
                 $failedRecipients[] = $forwardPath;
+            } catch (Swift_AddressEncoderException $e) {
+                $failedRecipients[] = $forwardPath;
             }
         }
 

--- a/lib/classes/Swift/Transport/SendmailTransport.php
+++ b/lib/classes/Swift/Transport/SendmailTransport.php
@@ -36,9 +36,9 @@ class Swift_Transport_SendmailTransport extends Swift_Transport_AbstractSmtpTran
      *
      * @param string $localDomain
      */
-    public function __construct(Swift_Transport_IoBuffer $buf, Swift_Events_EventDispatcher $dispatcher, $localDomain = '127.0.0.1')
+    public function __construct(Swift_Transport_IoBuffer $buf, Swift_Events_EventDispatcher $dispatcher, $localDomain = '127.0.0.1', Swift_AddressEncoder $addressEncoder = null)
     {
-        parent::__construct($buf, $dispatcher, $localDomain);
+        parent::__construct($buf, $dispatcher, $localDomain, $addressEncoder);
     }
 
     /**

--- a/tests/unit/Swift/Transport/EsmtpTransportTest.php
+++ b/tests/unit/Swift/Transport/EsmtpTransportTest.php
@@ -2,13 +2,12 @@
 
 class Swift_Transport_EsmtpTransportTest extends Swift_Transport_AbstractSmtpEventSupportTest
 {
-    protected function getTransport($buf, $dispatcher = null)
+    protected function getTransport($buf, $dispatcher = null, $addressEncoder = null)
     {
-        if (!$dispatcher) {
-            $dispatcher = $this->createEventDispatcher();
-        }
+        $dispatcher = $dispatcher ?? $this->createEventDispatcher();
+        $addressEncoder = $addressEncoder ?? new Swift_AddressEncoder_IdnAddressEncoder();
 
-        return new Swift_Transport_EsmtpTransport($buf, [], $dispatcher, 'example.org');
+        return new Swift_Transport_EsmtpTransport($buf, [], $dispatcher, 'example.org', $addressEncoder);
     }
 
     public function testHostCanBeSetAndFetched()

--- a/tests/unit/Swift/Transport/SendmailTransportTest.php
+++ b/tests/unit/Swift/Transport/SendmailTransportTest.php
@@ -2,12 +2,12 @@
 
 class Swift_Transport_SendmailTransportTest extends Swift_Transport_AbstractSmtpEventSupportTest
 {
-    protected function getTransport($buf, $dispatcher = null, $command = '/usr/sbin/sendmail -bs')
+    protected function getTransport($buf, $dispatcher = null, $addressEncoder = null, $command = '/usr/sbin/sendmail -bs')
     {
         if (!$dispatcher) {
             $dispatcher = $this->createEventDispatcher();
         }
-        $transport = new Swift_Transport_SendmailTransport($buf, $dispatcher, 'example.org');
+        $transport = new Swift_Transport_SendmailTransport($buf, $dispatcher, 'example.org', $addressEncoder);
         $transport->setCommand($command);
 
         return $transport;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc update?   | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 
| License       | MIT

After working some more with #1044 I noticed some inconsistencies between `SendmailTransport` and `EsmtpTransport`. First of all, I failed to add the address encoder to the constructor of `SendmailTransport`. And secondly, a `Swift_AddressEncoderException` throw in `doRcptToCommand()` because of a bad _recipient_ address was not caught and added to `$failedRecipients`. If the exception is thrown because of a bad sender address, we still throw the exception – I assume this is the expected behaviour.

I modified the other tests in `AbstractSmtpTest` to catch a Swiftmailer-specific exception, so they wont accidentally catch an exception thrown by PHPUnit in the `fail()` method.  