### PR TITLE
Support SMTPUTF8 extension

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,7 +4,7 @@ Changelog
 6.1.0 (2018-XX-XX)
 ------------------
 
- * added support for IDN domains in email addresses
+ * added support for non-ASCII email addresses
 
 6.0.2 (2017-09-30)
 ------------------

--- a/doc/messages.rst
+++ b/doc/messages.rst
@@ -628,6 +628,26 @@ the address::
         $message->addBcc('person1@example.org');
         $message->addBcc('person2@example.org', 'Person 2 Name');
 
+.. sidebar:: Internationalized Email Addresses
+
+    Traditionally only ASCII characters have been allowed in email addresses.
+    With the introduction of internationalized domain names (IDNs), non-ASCII
+    characters may appear in the domain name. By default, Swiftmailer encodes
+    such domain names in Punycode (e.g. xn--xample-ova.invalid). This is
+    compatible with all mail servers.
+
+    RFC 6531 introduced an SMTP extension, SMTPUTF8, that allows non-ASCII
+    characters in email addresses on both sides of the @ sign. To send to such
+    addresses, your outbound SMTP server must support the SMTPUTF8 extension.
+    You should use the ``Swift_AddressEncoder_Utf8AddressEncoder`` address
+    encoder and enable the ``Swift_Transport_Esmtp_SmtpUtf8Handler`` SMTP
+    extension handler::
+
+        $smtpUtf8 = new Swift_Transport_Esmtp_SmtpUtf8Handler();
+        $transport->setExtensionHandlers([$smtpUtf8]);
+        $utf8Encoder = new Swift_AddressEncoder_Utf8AddressEncoder();
+        $transport->setAddressEncoder($utf8Encoder);
+
 Specifying Sender Details
 -------------------------
 

--- a/lib/classes/Swift/AddressEncoder/IdnAddressEncoder.php
+++ b/lib/classes/Swift/AddressEncoder/IdnAddressEncoder.php
@@ -11,6 +11,15 @@
 /**
  * An IDN email address encoder.
  *
+ * Encodes the domain part of an address using IDN. This is compatible will all
+ * SMTP servers.
+ *
+ * This encoder does not support email addresses with non-ASCII characters in
+ * local-part (the substring before @). To send to such addresses, use
+ * Swift_AddressEncoder_Utf8AddressEncoder together with
+ * Swift_Transport_Esmtp_SmtpUtf8Handler. Your outbound SMTP server must support
+ * the SMTPUTF8 extension.
+ *
  * @author Christian Schmidt
  */
 class Swift_AddressEncoder_IdnAddressEncoder implements Swift_AddressEncoder

--- a/lib/classes/Swift/AddressEncoder/Utf8AddressEncoder.php
+++ b/lib/classes/Swift/AddressEncoder/Utf8AddressEncoder.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of SwiftMailer.
+ * (c) 2018 Christian Schmidt
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * A UTF-8 email address encoder.
+ *
+ * Returns the email address verbatimly in UTF-8 as permitted by RFC 6531 and
+ * RFC 6532. It supports addresses containing non-ASCII characters in both
+ * local-part and domain (i.e. on both sides of @).
+ *
+ * This encoder must be used together with Swift_Transport_Esmtp_SmtpUtf8Handler
+ * and requires that the outbound SMTP server supports the SMTPUTF8 extension.
+ *
+ * If your outbound SMTP server does not support SMTPUTF8, use
+ * Swift_AddressEncoder_IdnAddressEncoder instead. This allows sending to email
+ * addresses with non-ASCII characters in the domain, but not in local-part.
+ *
+ * @author Christian Schmidt
+ */
+class Swift_AddressEncoder_Utf8AddressEncoder implements Swift_AddressEncoder
+{
+    /**
+     * Returns the address verbatimly.
+     */
+    public function encodeString(string $address): string
+    {
+        return $address;
+    }
+}

--- a/lib/classes/Swift/Transport/AbstractSmtpTransport.php
+++ b/lib/classes/Swift/Transport/AbstractSmtpTransport.php
@@ -110,6 +110,16 @@ abstract class Swift_Transport_AbstractSmtpTransport implements Swift_Transport
         return $this->sourceIp;
     }
 
+    public function setAddressEncoder(Swift_AddressEncoder $addressEncoder)
+    {
+        $this->addressEncoder = $addressEncoder;
+    }
+
+    public function getAddressEncoder()
+    {
+        return $this->addressEncoder;
+    }
+
     /**
      * Start the SMTP connection.
      */

--- a/lib/classes/Swift/Transport/Esmtp/AuthHandler.php
+++ b/lib/classes/Swift/Transport/Esmtp/AuthHandler.php
@@ -9,7 +9,7 @@
  */
 
 /**
- * An ESMTP handler for AUTH support.
+ * An ESMTP handler for AUTH support (RFC 5248).
  *
  * @author Chris Corbyn
  */
@@ -143,7 +143,7 @@ class Swift_Transport_Esmtp_AuthHandler implements Swift_Transport_EsmtpHandler
     /**
      * Get the name of the ESMTP extension this handles.
      *
-     * @return bool
+     * @return string
      */
     public function getHandledKeyword()
     {

--- a/lib/classes/Swift/Transport/Esmtp/SmtpUtf8Handler.php
+++ b/lib/classes/Swift/Transport/Esmtp/SmtpUtf8Handler.php
@@ -1,0 +1,107 @@
+<?php
+
+/*
+ * This file is part of SwiftMailer.
+ * (c) 2018 Christian Schmidt
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * An ESMTP handler for SMTPUTF8 support (RFC 6531).
+ *
+ * SMTPUTF8 is required when sending to email addresses containing non-ASCII
+ * characters in local-part (the substring before @). This handler should be
+ * used together with Swift_AddressEncoder_Utf8AddressEncoder.
+ *
+ * SMTPUTF8 mode is enabled unconditionally, even when sending to ASCII-only
+ * addresses, so it should only be used with an outbound SMTP server that will
+ * deliver ASCII-only messages even if the next hop does not support SMTPUTF8.
+ *
+ * @author Christian Schmidt
+ */
+class Swift_Transport_Esmtp_SmtpUtf8Handler implements Swift_Transport_EsmtpHandler
+{
+    public function __construct()
+    {
+    }
+
+    /**
+     * Get the name of the ESMTP extension this handles.
+     *
+     * @return string
+     */
+    public function getHandledKeyword()
+    {
+        return 'SMTPUTF8';
+    }
+
+    /**
+     * Not used.
+     */
+    public function setKeywordParams(array $parameters)
+    {
+    }
+
+    /**
+     * Not used.
+     */
+    public function afterEhlo(Swift_Transport_SmtpAgent $agent)
+    {
+    }
+
+    /**
+     * Get params which are appended to MAIL FROM:<>.
+     *
+     * @return string[]
+     */
+    public function getMailParams()
+    {
+        return ['SMTPUTF8'];
+    }
+
+    /**
+     * Not used.
+     */
+    public function getRcptParams()
+    {
+        return [];
+    }
+
+    /**
+     * Not used.
+     */
+    public function onCommand(Swift_Transport_SmtpAgent $agent, $command, $codes = array(), &$failedRecipients = null, &$stop = false)
+    {
+    }
+
+    /**
+     * Returns +1, -1 or 0 according to the rules for usort().
+     *
+     * This method is called to ensure extensions can be execute in an appropriate order.
+     *
+     * @param string $esmtpKeyword to compare with
+     *
+     * @return int
+     */
+    public function getPriorityOver($esmtpKeyword)
+    {
+        return 0;
+    }
+
+    /**
+     * Not used.
+     */
+    public function exposeMixinMethods()
+    {
+        return [];
+    }
+
+    /**
+     * Not used.
+     */
+    public function resetState()
+    {
+    }
+}

--- a/lib/classes/Swift/Transport/EsmtpHandler.php
+++ b/lib/classes/Swift/Transport/EsmtpHandler.php
@@ -18,7 +18,7 @@ interface Swift_Transport_EsmtpHandler
     /**
      * Get the name of the ESMTP extension this handles.
      *
-     * @return bool
+     * @return string
      */
     public function getHandledKeyword();
 

--- a/lib/dependency_maps/mime_deps.php
+++ b/lib/dependency_maps/mime_deps.php
@@ -68,7 +68,7 @@ Swift_DependencyContainer::getInstance()
             'mime.rfc2231encoder',
             'email.validator',
             'properties.charset',
-            'mime.addressencoder',
+            'address.idnaddressencoder',
         ])
 
     ->register('mime.headerset')
@@ -126,9 +126,6 @@ Swift_DependencyContainer::getInstance()
     ->register('mime.rfc2231encoder')
     ->asNewInstanceOf('Swift_Encoder_Rfc2231Encoder')
     ->withDependencies(['mime.charstream'])
-
-    ->register('mime.addressencoder')
-    ->asNewInstanceOf('Swift_AddressEncoder_IdnAddressEncoder')
 ;
 
 unset($swift_mime_types);

--- a/lib/dependency_maps/transport_deps.php
+++ b/lib/dependency_maps/transport_deps.php
@@ -11,10 +11,10 @@ Swift_DependencyContainer::getInstance()
     ->asNewInstanceOf('Swift_Transport_EsmtpTransport')
     ->withDependencies([
         'transport.buffer',
-        ['transport.authhandler'],
+        ['transport.authhandler', 'transport.smtputf8handler'],
         'transport.eventdispatcher',
         'transport.localdomain',
-        'transport.addressencoder',
+        'address.idnaddressencoder',
     ])
 
     ->register('transport.sendmail')
@@ -55,6 +55,9 @@ Swift_DependencyContainer::getInstance()
         ],
     ])
 
+    ->register('transport.smtputf8handler')
+    ->asNewInstanceOf('Swift_Transport_Esmtp_SmtpUtf8Handler')
+
     ->register('transport.crammd5auth')
     ->asNewInstanceOf('Swift_Transport_Esmtp_Auth_CramMd5Authenticator')
 
@@ -73,9 +76,12 @@ Swift_DependencyContainer::getInstance()
     ->register('transport.eventdispatcher')
     ->asNewInstanceOf('Swift_Events_SimpleEventDispatcher')
 
-    ->register('transport.addressencoder')
-    ->asNewInstanceOf('Swift_AddressEncoder_IdnAddressEncoder')
-
     ->register('transport.replacementfactory')
     ->asSharedInstanceOf('Swift_StreamFilters_StringReplacementFilterFactory')
+
+    ->register('address.idnaddressencoder')
+    ->asNewInstanceOf('Swift_AddressEncoder_IdnAddressEncoder')
+
+    ->register('address.utf8addressencoder')
+    ->asNewInstanceOf('Swift_AddressEncoder_Utf8AddressEncoder')
 ;

--- a/tests/unit/Swift/Mime/Headers/MailboxHeaderTest.php
+++ b/tests/unit/Swift/Mime/Headers/MailboxHeaderTest.php
@@ -11,13 +11,13 @@ class Swift_Mime_Headers_MailboxHeaderTest extends \SwiftMailerTestCase
 
     public function testTypeIsMailboxHeader()
     {
-        $header = $this->getHeader('To', $this->getEncoder('Q', true));
+        $header = $this->getHeader('To');
         $this->assertEquals(Swift_Mime_Header::TYPE_MAILBOX, $header->getFieldType());
     }
 
     public function testMailboxIsSetForAddress()
     {
-        $header = $this->getHeader('From', $this->getEncoder('Q', true));
+        $header = $this->getHeader('From');
         $header->setAddresses('chris@swiftmailer.org');
         $this->assertEquals(['chris@swiftmailer.org'],
             $header->getNameAddressStrings()
@@ -26,7 +26,7 @@ class Swift_Mime_Headers_MailboxHeaderTest extends \SwiftMailerTestCase
 
     public function testMailboxIsRenderedForNameAddress()
     {
-        $header = $this->getHeader('From', $this->getEncoder('Q', true));
+        $header = $this->getHeader('From');
         $header->setNameAddresses(['chris@swiftmailer.org' => 'Chris Corbyn']);
         $this->assertEquals(
             ['Chris Corbyn <chris@swiftmailer.org>'], $header->getNameAddressStrings()
@@ -35,21 +35,21 @@ class Swift_Mime_Headers_MailboxHeaderTest extends \SwiftMailerTestCase
 
     public function testAddressCanBeReturnedForAddress()
     {
-        $header = $this->getHeader('From', $this->getEncoder('Q', true));
+        $header = $this->getHeader('From');
         $header->setAddresses('chris@swiftmailer.org');
         $this->assertEquals(['chris@swiftmailer.org'], $header->getAddresses());
     }
 
     public function testAddressCanBeReturnedForNameAddress()
     {
-        $header = $this->getHeader('From', $this->getEncoder('Q', true));
+        $header = $this->getHeader('From');
         $header->setNameAddresses(['chris@swiftmailer.org' => 'Chris Corbyn']);
         $this->assertEquals(['chris@swiftmailer.org'], $header->getAddresses());
     }
 
     public function testQuotesInNameAreQuoted()
     {
-        $header = $this->getHeader('From', $this->getEncoder('Q', true));
+        $header = $this->getHeader('From');
         $header->setNameAddresses([
             'chris@swiftmailer.org' => 'Chris Corbyn, "DHE"',
             ]);
@@ -61,7 +61,7 @@ class Swift_Mime_Headers_MailboxHeaderTest extends \SwiftMailerTestCase
 
     public function testEscapeCharsInNameAreQuoted()
     {
-        $header = $this->getHeader('From', $this->getEncoder('Q', true));
+        $header = $this->getHeader('From');
         $header->setNameAddresses([
             'chris@swiftmailer.org' => 'Chris Corbyn, \\escaped\\',
             ]);
@@ -73,7 +73,7 @@ class Swift_Mime_Headers_MailboxHeaderTest extends \SwiftMailerTestCase
 
     public function testUtf8CharsInDomainAreIdnEncoded()
     {
-        $header = $this->getHeader('From', $this->getEncoder('Q', true));
+        $header = $this->getHeader('From');
         $header->setNameAddresses([
             'chris@swïftmailer.org' => 'Chris Corbyn',
             ]);
@@ -88,16 +88,28 @@ class Swift_Mime_Headers_MailboxHeaderTest extends \SwiftMailerTestCase
      */
     public function testUtf8CharsInLocalPartThrows()
     {
-        $header = $this->getHeader('From', $this->getEncoder('Q', true));
+        $header = $this->getHeader('From');
         $header->setNameAddresses([
             'chrïs@swiftmailer.org' => 'Chris Corbyn',
             ]);
         $header->getNameAddressStrings();
     }
 
+    public function testUtf8CharsInEmail()
+    {
+        $header = $this->getHeader('From', null, new Swift_AddressEncoder_Utf8AddressEncoder());
+        $header->setNameAddresses([
+            'chrïs@swïftmailer.org' => 'Chris Corbyn',
+            ]);
+        $this->assertEquals(
+            ['Chris Corbyn <chrïs@swïftmailer.org>'],
+            $header->getNameAddressStrings()
+            );
+    }
+
     public function testGetMailboxesReturnsNameValuePairs()
     {
-        $header = $this->getHeader('From', $this->getEncoder('Q', true));
+        $header = $this->getHeader('From');
         $header->setNameAddresses([
             'chris@swiftmailer.org' => 'Chris Corbyn, DHE',
             ]);
@@ -108,7 +120,7 @@ class Swift_Mime_Headers_MailboxHeaderTest extends \SwiftMailerTestCase
 
     public function testMultipleAddressesCanBeSetAndFetched()
     {
-        $header = $this->getHeader('From', $this->getEncoder('Q', true));
+        $header = $this->getHeader('From');
         $header->setAddresses([
             'chris@swiftmailer.org', 'mark@swiftmailer.org',
             ]);
@@ -120,7 +132,7 @@ class Swift_Mime_Headers_MailboxHeaderTest extends \SwiftMailerTestCase
 
     public function testMultipleAddressesAsMailboxes()
     {
-        $header = $this->getHeader('From', $this->getEncoder('Q', true));
+        $header = $this->getHeader('From');
         $header->setAddresses([
             'chris@swiftmailer.org', 'mark@swiftmailer.org',
             ]);
@@ -132,7 +144,7 @@ class Swift_Mime_Headers_MailboxHeaderTest extends \SwiftMailerTestCase
 
     public function testMultipleAddressesAsMailboxStrings()
     {
-        $header = $this->getHeader('From', $this->getEncoder('Q', true));
+        $header = $this->getHeader('From');
         $header->setAddresses([
             'chris@swiftmailer.org', 'mark@swiftmailer.org',
             ]);
@@ -144,7 +156,7 @@ class Swift_Mime_Headers_MailboxHeaderTest extends \SwiftMailerTestCase
 
     public function testMultipleNamedMailboxesReturnsMultipleAddresses()
     {
-        $header = $this->getHeader('From', $this->getEncoder('Q', true));
+        $header = $this->getHeader('From');
         $header->setNameAddresses([
             'chris@swiftmailer.org' => 'Chris Corbyn',
             'mark@swiftmailer.org' => 'Mark Corbyn',
@@ -157,7 +169,7 @@ class Swift_Mime_Headers_MailboxHeaderTest extends \SwiftMailerTestCase
 
     public function testMultipleNamedMailboxesReturnsMultipleMailboxes()
     {
-        $header = $this->getHeader('From', $this->getEncoder('Q', true));
+        $header = $this->getHeader('From');
         $header->setNameAddresses([
             'chris@swiftmailer.org' => 'Chris Corbyn',
             'mark@swiftmailer.org' => 'Mark Corbyn',
@@ -172,7 +184,7 @@ class Swift_Mime_Headers_MailboxHeaderTest extends \SwiftMailerTestCase
 
     public function testMultipleMailboxesProducesMultipleMailboxStrings()
     {
-        $header = $this->getHeader('From', $this->getEncoder('Q', true));
+        $header = $this->getHeader('From');
         $header->setNameAddresses([
             'chris@swiftmailer.org' => 'Chris Corbyn',
             'mark@swiftmailer.org' => 'Mark Corbyn',
@@ -187,7 +199,7 @@ class Swift_Mime_Headers_MailboxHeaderTest extends \SwiftMailerTestCase
 
     public function testSetAddressesOverwritesAnyMailboxes()
     {
-        $header = $this->getHeader('From', $this->getEncoder('Q', true));
+        $header = $this->getHeader('From');
         $header->setNameAddresses([
             'chris@swiftmailer.org' => 'Chris Corbyn',
             'mark@swiftmailer.org' => 'Mark Corbyn',
@@ -257,7 +269,7 @@ class Swift_Mime_Headers_MailboxHeaderTest extends \SwiftMailerTestCase
 
     public function testGetValueReturnsMailboxStringValue()
     {
-        $header = $this->getHeader('From', $this->getEncoder('Q', true));
+        $header = $this->getHeader('From');
         $header->setNameAddresses([
             'chris@swiftmailer.org' => 'Chris Corbyn',
             ]);
@@ -268,7 +280,7 @@ class Swift_Mime_Headers_MailboxHeaderTest extends \SwiftMailerTestCase
 
     public function testGetValueReturnsMailboxStringValueForMultipleMailboxes()
     {
-        $header = $this->getHeader('From', $this->getEncoder('Q', true));
+        $header = $this->getHeader('From');
         $header->setNameAddresses([
             'chris@swiftmailer.org' => 'Chris Corbyn',
             'mark@swiftmailer.org' => 'Mark Corbyn',
@@ -281,7 +293,7 @@ class Swift_Mime_Headers_MailboxHeaderTest extends \SwiftMailerTestCase
 
     public function testRemoveAddressesWithSingleValue()
     {
-        $header = $this->getHeader('From', $this->getEncoder('Q', true));
+        $header = $this->getHeader('From');
         $header->setNameAddresses([
             'chris@swiftmailer.org' => 'Chris Corbyn',
             'mark@swiftmailer.org' => 'Mark Corbyn',
@@ -294,7 +306,7 @@ class Swift_Mime_Headers_MailboxHeaderTest extends \SwiftMailerTestCase
 
     public function testRemoveAddressesWithList()
     {
-        $header = $this->getHeader('From', $this->getEncoder('Q', true));
+        $header = $this->getHeader('From');
         $header->setNameAddresses([
             'chris@swiftmailer.org' => 'Chris Corbyn',
             'mark@swiftmailer.org' => 'Mark Corbyn',
@@ -307,21 +319,21 @@ class Swift_Mime_Headers_MailboxHeaderTest extends \SwiftMailerTestCase
 
     public function testSetBodyModel()
     {
-        $header = $this->getHeader('From', $this->getEncoder('Q', true));
+        $header = $this->getHeader('From');
         $header->setFieldBodyModel('chris@swiftmailer.org');
         $this->assertEquals(['chris@swiftmailer.org' => null], $header->getNameAddresses());
     }
 
     public function testGetBodyModel()
     {
-        $header = $this->getHeader('From', $this->getEncoder('Q', true));
+        $header = $this->getHeader('From');
         $header->setAddresses(['chris@swiftmailer.org']);
         $this->assertEquals(['chris@swiftmailer.org' => null], $header->getFieldBodyModel());
     }
 
     public function testToString()
     {
-        $header = $this->getHeader('From', $this->getEncoder('Q', true));
+        $header = $this->getHeader('From');
         $header->setNameAddresses([
             'chris@swiftmailer.org' => 'Chris Corbyn',
             'mark@swiftmailer.org' => 'Mark Corbyn',
@@ -333,15 +345,17 @@ class Swift_Mime_Headers_MailboxHeaderTest extends \SwiftMailerTestCase
             );
     }
 
-    private function getHeader($name, $encoder)
+    private function getHeader($name, $encoder = null, $addressEncoder = null)
     {
-        $header = new Swift_Mime_Headers_MailboxHeader($name, $encoder, new EmailValidator(), new Swift_AddressEncoder_IdnAddressEncoder());
+        $encoder = $encoder ?? $this->getEncoder('Q', true);
+        $addressEncoder = $addressEncoder ?? new Swift_AddressEncoder_IdnAddressEncoder();
+        $header = new Swift_Mime_Headers_MailboxHeader($name, $encoder, new EmailValidator(), $addressEncoder);
         $header->setCharset($this->charset);
 
         return $header;
     }
 
-    private function getEncoder($type, $stub = false)
+    private function getEncoder($type)
     {
         $encoder = $this->getMockery('Swift_Mime_HeaderEncoder')->shouldIgnoreMissing();
         $encoder->shouldReceive('getName')


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Doc update?   | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets |
| License       | MIT

#1044 added support for non-ASCII characters in the email domain. This PR adds support for the SMTPUTF8 SMTP extension (see [RFC 6531](https://tools.ietf.org/html/rfc6531)) that allows UTF-8 characters in the local-part also.

This PR does _not_ implement an UTF-8 header encoder (e.g. `Swift_Mime_HeaderEncoder_Utf8HeaderEncoder`) as described in [RFC 6532](https://tools.ietf.org/html/rfc6532). For the purpose of sending to non-ASCII email addresses, the new `Swift_AddressEncoder_Utf8AddressEncoder` works fine with the existing header encoders – `Swift_Mime_Headers_MailboxHeader` does not encode the actual email address but simple passes through whatever is returned by the address encoder.

FWIW, SMTPUTF8 is supported by [Postfix](http://www.postfix.org/SMTPUTF8_README.html), [Gmail](https://googleblog.blogspot.dk/2014/08/a-first-step-toward-more-global-email.html), among others.