### PR TITLE
Direct SMTP Transport

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -38,6 +38,7 @@ Changelog
  * added support for SMTP pipelining
  * added Swift_Transport_Esmtp_EightBitMimeHandler
  * fixed startTLS only allowed tls1.0, now allowed: tls1.0, tls1.1, tls1.2
+ * added Swift_DirectSmtpTransport and Swift_Transport_DirectEsmtpTransport
 
 6.0.2 (2017-09-30)
 ------------------

--- a/doc/sending.rst
+++ b/doc/sending.rst
@@ -52,6 +52,10 @@ types of Transport in Swift Mailer, all of which implement the
   Supports Encryption. Very portable; Pleasingly predictable results; Provides
   good feedback;
 
+* ``Swift_DirectSmtpTransport``: Sends messages over SMTP directly to the
+  recipient's inbound mail server. No local mail server required; Instant
+  feedback on delivery errors; Fails if remote mail server is temporarily down.
+
 * ``Swift_SendmailTransport``: Communicates with a locally installed
   ``sendmail`` executable (Linux/UNIX). Quick time-to-run; Provides
   less-accurate feedback than SMTP; Requires ``sendmail`` installation;
@@ -179,6 +183,27 @@ be thrown.
     If you need to know early whether or not authentication has failed and an
     Exception is going to be thrown, call the ``start()`` method on the
     created Transport.
+
+The Direct SMTP Transport
+.........................
+
+Mail clients usually delivers all messages to an outbound mail server using the
+SMTP protocol. The outbound server spools the messages and, in turn, delivers
+them to the recipients' inbound mail servers, also using SMTP. If a remote mail
+server is temporarily down, the outbound server will spool the message and try
+again later, usually for several days.
+
+The Direct SMTP Transport, ``Swift_DirectSmtpTransport``, skips the outbound
+mail server and connects directly to the recipients' inbound mail servers. This
+approach is less resilient to remote servers being down or just slow, but it may
+be useful if you don't have access to an outbound SMTP server. It can also be
+used, if you need instant feedback on delivery problems.
+
+The Direct SMTP Transport looks up the recipients' inbound mail servers in DNS.
+The actual SMTP communication is delegated to a regular SMTP Transport instance.
+Some configuration of this instance, such as local domain and timeout may be
+adjusted, while other settings, e.g. port number, username and password, must
+use the default values when connecting to remote inbound servers.
 
 The Sendmail Transport
 ......................
@@ -319,6 +344,7 @@ recipients are delivered to successfully then the value 5 will be returned::
     }
 
     */
+
 
 Sending Emails in Batch
 .......................

--- a/doc/sending.rst
+++ b/doc/sending.rst
@@ -205,6 +205,11 @@ Some configuration of this instance, such as local domain and timeout may be
 adjusted, while other settings, e.g. port number, username and password, must
 use the default values when connecting to remote inbound servers.
 
+SMTP always uses port 25. Note that many ISPs and firewalls block port 25 as an
+anti-spam measure, so the Direct SMTP Transport may not work when running on a
+personal computer on a home or office network rather than on a server in a
+hosting facility.
+
 The Sendmail Transport
 ......................
 
@@ -344,7 +349,6 @@ recipients are delivered to successfully then the value 5 will be returned::
     }
 
     */
-
 
 Sending Emails in Batch
 .......................

--- a/lib/classes/Swift/Mime/SimpleMessage.php
+++ b/lib/classes/Swift/Mime/SimpleMessage.php
@@ -441,6 +441,35 @@ class Swift_Mime_SimpleMessage extends Swift_Mime_MimePart
     }
 
     /**
+     * Get the reverse path for this message.
+     *
+     * @return string
+     */
+    public function getReversePath()
+    {
+        $returnPath = $this->getReturnPath();
+        if ($returnPath) {
+            return $returnPath;
+        }
+
+        $sender = $this->getSender();
+        if ($sender) {
+            // Don't use array_keys
+            reset($sender); // Reset Pointer to first pos
+            return key($sender); // Get key
+        }
+
+        $from = $this->getFrom();
+        if ($from) {
+            // Don't use array_keys
+            reset($from); // Reset Pointer to first pos
+            return key($from); // Get key
+        }
+
+        return null;
+    }
+
+    /**
      * Set the priority of this message.
      *
      * The value is an integer where 1 is the highest priority and 5 is the lowest.

--- a/lib/classes/Swift/Transport/AbstractSmtpTransport.php
+++ b/lib/classes/Swift/Transport/AbstractSmtpTransport.php
@@ -234,11 +234,10 @@ abstract class Swift_Transport_AbstractSmtpTransport implements Swift_Transport
             $sent += $this->sendTo($message, $reversePath, $tos, $failedRecipients);
             $sent += $this->sendBcc($message, $reversePath, $bcc, $failedRecipients);
         } catch (Exception $e) {
-            $message->setBcc($bcc);
             throw $e;
+        } finally {
+            $message->setBcc($bcc);
         }
-
-        $message->setBcc($bcc);
 
         return $sent;
     }

--- a/lib/classes/Swift/Transport/AbstractSmtpTransport.php
+++ b/lib/classes/Swift/Transport/AbstractSmtpTransport.php
@@ -420,6 +420,31 @@ abstract class Swift_Transport_AbstractSmtpTransport implements Swift_Transport
         $this->executeCommand("\r\n.\r\n", [250]);
     }
 
+    /**
+     * Determine the best-use reverse path for this message
+     *
+     * @deprecated since SwiftMailer 6.1.0; use Swift_Mime_SimpleMessage::getReversePath() instead.
+     */
+    protected function getReversePath(Swift_Mime_SimpleMessage $message)
+    {
+        $return = $message->getReturnPath();
+        $sender = $message->getSender();
+        $from = $message->getFrom();
+        $path = null;
+        if (!empty($return)) {
+            $path = $return;
+        } elseif (!empty($sender)) {
+            // Don't use array_keys
+            reset($sender); // Reset Pointer to first pos
+            $path = key($sender); // Get key
+        } elseif (!empty($from)) {
+            reset($from); // Reset Pointer to first pos
+            $path = key($from); // Get key
+        }
+
+        return $path;
+    }
+
     /** Throw a TransportException, first sending it to any listeners */
     protected function throwException(Swift_TransportException $e)
     {

--- a/lib/classes/Swift/Transport/AbstractSmtpTransport.php
+++ b/lib/classes/Swift/Transport/AbstractSmtpTransport.php
@@ -191,7 +191,7 @@ abstract class Swift_Transport_AbstractSmtpTransport implements Swift_Transport
             }
         }
 
-        if (!$reversePath = $this->getReversePath($message)) {
+        if (!$reversePath = $message->getReversePath()) {
             $this->throwException(new Swift_TransportException('Cannot send message without a sender address'));
         }
 
@@ -402,27 +402,6 @@ abstract class Swift_Transport_AbstractSmtpTransport implements Swift_Transport
         }
         $this->buffer->setWriteTranslations([]);
         $this->executeCommand("\r\n.\r\n", [250]);
-    }
-
-    /** Determine the best-use reverse path for this message */
-    protected function getReversePath(Swift_Mime_SimpleMessage $message)
-    {
-        $return = $message->getReturnPath();
-        $sender = $message->getSender();
-        $from = $message->getFrom();
-        $path = null;
-        if (!empty($return)) {
-            $path = $return;
-        } elseif (!empty($sender)) {
-            // Don't use array_keys
-            reset($sender); // Reset Pointer to first pos
-            $path = key($sender); // Get key
-        } elseif (!empty($from)) {
-            reset($from); // Reset Pointer to first pos
-            $path = key($from); // Get key
-        }
-
-        return $path;
     }
 
     /** Throw a TransportException, first sending it to any listeners */

--- a/lib/classes/Swift/Transport/AbstractSmtpTransport.php
+++ b/lib/classes/Swift/Transport/AbstractSmtpTransport.php
@@ -177,6 +177,10 @@ abstract class Swift_Transport_AbstractSmtpTransport implements Swift_Transport
      */
     public function send(Swift_Mime_SimpleMessage $message, &$failedRecipients = null)
     {
+        if (!$this->isStarted()) {
+            $this->start();
+        }
+
         $failedRecipients = (array) $failedRecipients;
 
         if ($evt = $this->eventDispatcher->createSendEvent($this, $message)) {
@@ -233,8 +237,6 @@ abstract class Swift_Transport_AbstractSmtpTransport implements Swift_Transport
         try {
             $sent += $this->sendTo($message, $reversePath, $tos, $failedRecipients);
             $sent += $this->sendBcc($message, $reversePath, $bcc, $failedRecipients);
-        } catch (Exception $e) {
-            throw $e;
         } finally {
             $message->setBcc($bcc);
         }

--- a/lib/classes/Swift/Transport/DirectEsmtpTransport.php
+++ b/lib/classes/Swift/Transport/DirectEsmtpTransport.php
@@ -198,7 +198,6 @@ class Swift_Transport_DirectEsmtpTransport implements Swift_Transport
     protected function getEsmtpTransport(string $host): Swift_Transport_EsmtpTransport
     {
         $this->transport->setHost($host);
-        $this->transport->setPort(587);
         return $this->transport;
     }
 

--- a/lib/classes/Swift/Transport/DirectEsmtpTransport.php
+++ b/lib/classes/Swift/Transport/DirectEsmtpTransport.php
@@ -1,0 +1,217 @@
+<?php
+
+/*
+ * This file is part of SwiftMailer.
+ * (c) 2018 Christian Schmidt
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * Delivers messages directly to recipients incoming SMTP server.
+ *
+ * @author Christian Schmidt
+ */
+class Swift_Transport_DirectEsmtpTransport implements Swift_Transport
+{
+    private $eventDispatcher;
+
+    private $transport;
+
+    public function __construct(Swift_Events_EventDispatcher $eventDispatcher, Swift_Transport_EsmtpTransport $transport, Swift_AddressEncoder_IdnAddressEncoder $addressEncoder)
+    {
+        $this->eventDispatcher = $eventDispatcher;
+        $this->transport = $transport;
+        $this->addressEncoder = $addressEncoder;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isStarted()
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function start()
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function stop()
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function ping()
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function send(Swift_Mime_SimpleMessage $message, &$failedRecipients = null)
+    {
+        $sent = 0;
+        $failedRecipients = (array) $failedRecipients;
+
+        if ($evt = $this->eventDispatcher->createSendEvent($this, $message)) {
+            $this->eventDispatcher->dispatchEvent($evt, 'beforeSendPerformed');
+            if ($evt->bubbleCancelled()) {
+                return 0;
+            }
+        }
+
+        if (!$reversePath = $message->getReversePath()) {
+            $this->throwException(new Swift_TransportException(
+                'Cannot send message without a sender address'
+                )
+            );
+        }
+
+        $to = (array) $message->getTo();
+        $cc = (array) $message->getCc();
+        $tos = array_merge($to, $cc);
+        $bcc = (array) $message->getBcc();
+
+        $message->setBcc([]);
+
+        $groups = $this->groupRecipientsByMxHosts($tos, $bcc);
+        foreach ($groups as $group) {
+            try {
+                $sent += $this->sendGroup($message, $reversePath, $group, $failedRecipients);
+            } catch (Exception $e) {
+                $message->setBcc($bcc);
+                throw $e;
+            }
+        }
+
+        $message->setBcc($bcc);
+
+        if ($evt) {
+            if ($sent == count($tos) + count($bcc)) {
+                $evt->setResult(Swift_Events_SendEvent::RESULT_SUCCESS);
+            } elseif ($sent > 0) {
+                $evt->setResult(Swift_Events_SendEvent::RESULT_TENTATIVE);
+            } else {
+                $evt->setResult(Swift_Events_SendEvent::RESULT_FAILED);
+            }
+            $evt->setFailedRecipients($failedRecipients);
+            $this->eventDispatcher->dispatchEvent($evt, 'sendPerformed');
+        }
+
+        $message->generateId(); //Make sure a new Message ID is used
+
+        return $sent;
+    }
+
+    protected function sendGroup(Swift_Mime_SimpleMessage $message, string $reversePath, array $group, array &$failedRecipients)
+    {
+        $sent = 0;
+
+        foreach ($group['hosts'] as $host) {
+            $transport = $this->getEsmtpTransport($host);
+            try {
+                if (!$transport->isStarted()) {
+                    $transport->start();
+                }
+                return $transport->sendCopy($message, $reversePath, $group['tos'], $group['bcc'], $failedRecipients);
+            } catch (Swift_TransportException $e) {
+            } finally {
+                try {
+                    $transport->stop();
+                } catch (Exception $e) {
+                }
+            }
+        }
+
+        $this->throwException(new Swift_TransportException(
+            'Error sending to domains '.implode(', ', $group['domains'])
+            )
+        );
+    }
+
+    /**
+     * Register a plugin.
+     */
+    public function registerPlugin(Swift_Events_EventListener $plugin)
+    {
+        $this->eventDispatcher->bindEventListener($plugin);
+    }
+
+    protected function getMxHosts(string $domain): array
+    {
+        if (!getmxrr($domain, $hosts, $weights)) {
+            $hosts = [$domain];
+            $weights = [0];
+        }
+        array_multisort($weights, SORT_NUMERIC, $hosts, SORT_STRING);
+
+        return $hosts;
+    }
+
+    protected function groupRecipientsByMxHosts(array $tos, array $bcc): array
+    {
+        $groups = [];
+        $hostsByDomain = [];
+        foreach (['tos', 'bcc'] as $type) {
+            $addresses = $$type;
+            foreach ($addresses as $address => $name) {
+                $address = $this->addressEncoder->encodeString($address);
+                $i = strrpos($address, '@');
+                $domain = substr($address, $i + 1);
+
+                if (!isset($hostsByDomain[$domain])) {
+                    $hostsByDomain[$domain] = $this->getMxHosts($domain);
+                }
+                $key = implode(' ', $hostsByDomain[$domain]);
+
+                if (!isset($groups[$key])) {
+                    $groups[$key] = [
+                        'tos' => [],
+                        'bcc' => [],
+                        'hosts' => $hostsByDomain[$domain],
+                        'domains' => [$domain],
+                    ];
+                }
+
+                $groups[$key][$type][$address] = $name;
+
+                if (!in_array($domain, $groups[$key]['domains'])) {
+                    $groups[$key]['domains'][] = $domain;
+                }
+            }
+        }
+
+        return $groups;
+    }
+
+    protected function getEsmtpTransport(string $host): Swift_Transport_EsmtpTransport
+    {
+        $this->transport->setHost($host);
+        $this->transport->setPort(587);
+        return $this->transport;
+    }
+
+    /** Throw a TransportException, first sending it to any listeners */
+    protected function throwException(Swift_TransportException $e)
+    {
+        if ($evt = $this->eventDispatcher->createTransportExceptionEvent($this, $e)) {
+            $this->eventDispatcher->dispatchEvent($evt, 'exceptionThrown');
+            if (!$evt->bubbleCancelled()) {
+                throw $e;
+            }
+        } else {
+            throw $e;
+        }
+    }
+}

--- a/lib/classes/Swift/Transport/SendmailTransport.php
+++ b/lib/classes/Swift/Transport/SendmailTransport.php
@@ -111,7 +111,7 @@ class Swift_Transport_SendmailTransport extends Swift_Transport_AbstractSmtpTran
             }
 
             if (false === strpos($command, ' -f')) {
-                $command .= ' -f'.escapeshellarg($this->getReversePath($message));
+                $command .= ' -f'.escapeshellarg($message->getReversePath());
             }
 
             $buffer->initialize(array_merge($this->params, ['command' => $command]));

--- a/lib/dependency_maps/transport_deps.php
+++ b/lib/dependency_maps/transport_deps.php
@@ -35,6 +35,14 @@ Swift_DependencyContainer::getInstance()
     ->asNewInstanceOf('Swift_Transport_SpoolTransport')
     ->withDependencies(['transport.eventdispatcher'])
 
+    ->register('transport.directsmtp')
+    ->asNewInstanceOf('Swift_Transport_DirectEsmtpTransport')
+    ->withDependencies([
+        'transport.eventdispatcher',
+        'transport.smtp',
+        'address.idnaddressencoder',
+    ])
+
     ->register('transport.null')
     ->asNewInstanceOf('Swift_Transport_NullTransport')
     ->withDependencies(['transport.eventdispatcher'])

--- a/tests/SwiftMailerTestCase.php
+++ b/tests/SwiftMailerTestCase.php
@@ -31,8 +31,8 @@ class SwiftMailerTestCase extends \PHPUnit\Framework\TestCase
         \Mockery::close();
     }
 
-    protected function getMockery($class)
+    protected function getMockery($class, ...$args)
     {
-        return \Mockery::mock($class);
+        return \Mockery::mock($class, ...$args);
     }
 }

--- a/tests/unit/Swift/Mime/SimpleMessageTest.php
+++ b/tests/unit/Swift/Mime/SimpleMessageTest.php
@@ -639,6 +639,42 @@ class Swift_Mime_SimpleMessageTest extends Swift_Mime_MimePartTest
         $message->setBcc('bcc@domain', 'Name');
     }
 
+    public function testReversePathReturnsFrom()
+    {
+        $from = $this->createHeader('From', ['me@domain.com' => 'Me']);
+
+        $message = $this->createMessage(
+            $this->createHeaderSet(['From' => $from]),
+            $this->createEncoder(), $this->createCache()
+            );
+        $this->assertEquals('me@domain.com', $message->getReversePath());
+    }
+
+    public function testSenderIsPreferredOverFrom()
+    {
+        $from = $this->createHeader('From', ['me@domain.com' => 'Me']);
+        $sender = $this->createHeader('Sender', ['another@domain.com' => 'Someone']);
+
+        $message = $this->createMessage(
+            $this->createHeaderSet(['From' => $from, 'Sender' => $sender]),
+            $this->createEncoder(), $this->createCache()
+            );
+        $this->assertEquals('another@domain.com', $message->getReversePath());
+    }
+
+    public function testReturnPathIsPreferredOverSender()
+    {
+        $from = $this->createHeader('From', ['me@domain.com' => 'Me']);
+        $sender = $this->createHeader('Sender', ['another@domain.com' => 'Someone']);
+        $returnPath = $this->createHeader('Return-Path', 'more@domain.com');
+
+        $message = $this->createMessage(
+            $this->createHeaderSet(['From' => $from, 'Sender' => $sender, 'Return-Path' => $returnPath]),
+            $this->createEncoder(), $this->createCache()
+            );
+        $this->assertEquals('more@domain.com', $message->getReversePath());
+    }
+
     public function testPriorityIsReadFromHeader()
     {
         $prio = $this->createHeader('X-Priority', '2 (High)');

--- a/tests/unit/Swift/Transport/AbstractSmtpEventSupportTest.php
+++ b/tests/unit/Swift/Transport/AbstractSmtpEventSupportTest.php
@@ -25,9 +25,9 @@ abstract class Swift_Transport_AbstractSmtpEventSupportTest extends Swift_Transp
         $smtp = $this->getTransport($buf, $dispatcher);
         $evt = $this->getMockery('Swift_Events_SendEvent')->shouldIgnoreMissing();
 
-        $message->shouldReceive('getFrom')
+        $message->shouldReceive('getReversePath')
                 ->zeroOrMoreTimes()
-                ->andReturn(['chris@swiftmailer.org' => null]);
+                ->andReturn('chris@swiftmailer.org');
         $message->shouldReceive('getTo')
                 ->zeroOrMoreTimes()
                 ->andReturn(['mark@swiftmailer.org' => 'Mark']);
@@ -56,9 +56,9 @@ abstract class Swift_Transport_AbstractSmtpEventSupportTest extends Swift_Transp
         $smtp = $this->getTransport($buf, $dispatcher);
         $evt = $this->getMockery('Swift_Events_SendEvent')->shouldIgnoreMissing();
 
-        $message->shouldReceive('getFrom')
+        $message->shouldReceive('getReversePath')
                 ->zeroOrMoreTimes()
-                ->andReturn(['chris@swiftmailer.org' => null]);
+                ->andReturn('chris@swiftmailer.org');
         $message->shouldReceive('getTo')
                 ->zeroOrMoreTimes()
                 ->andReturn(['mark@swiftmailer.org' => 'Mark']);
@@ -87,9 +87,9 @@ abstract class Swift_Transport_AbstractSmtpEventSupportTest extends Swift_Transp
         $smtp = $this->getTransport($buf, $dispatcher);
         $message = $this->createMessage();
 
-        $message->shouldReceive('getFrom')
+        $message->shouldReceive('getReversePath')
                 ->zeroOrMoreTimes()
-                ->andReturn(['chris@swiftmailer.org' => null]);
+                ->andReturn('chris@swiftmailer.org');
         $message->shouldReceive('getTo')
                 ->zeroOrMoreTimes()
                 ->andReturn(['mark@swiftmailer.org' => 'Mark']);
@@ -138,9 +138,9 @@ abstract class Swift_Transport_AbstractSmtpEventSupportTest extends Swift_Transp
         $smtp = $this->getTransport($buf, $dispatcher);
         $message = $this->createMessage();
 
-        $message->shouldReceive('getFrom')
+        $message->shouldReceive('getReversePath')
                 ->zeroOrMoreTimes()
-                ->andReturn(['chris@swiftmailer.org' => null]);
+                ->andReturn('chris@swiftmailer.org');
         $message->shouldReceive('getTo')
                 ->zeroOrMoreTimes()
                 ->andReturn(['mark@swiftmailer.org' => 'Mark']);
@@ -189,9 +189,9 @@ abstract class Swift_Transport_AbstractSmtpEventSupportTest extends Swift_Transp
         $smtp = $this->getTransport($buf, $dispatcher);
         $message = $this->createMessage();
 
-        $message->shouldReceive('getFrom')
+        $message->shouldReceive('getReversePath')
                 ->zeroOrMoreTimes()
-                ->andReturn(['chris@swiftmailer.org' => null]);
+                ->andReturn('chris@swiftmailer.org');
         $message->shouldReceive('getTo')
                 ->zeroOrMoreTimes()
                 ->andReturn([
@@ -243,9 +243,9 @@ abstract class Swift_Transport_AbstractSmtpEventSupportTest extends Swift_Transp
         $smtp = $this->getTransport($buf, $dispatcher);
         $message = $this->createMessage();
 
-        $message->shouldReceive('getFrom')
+        $message->shouldReceive('getReversePath')
                 ->zeroOrMoreTimes()
-                ->andReturn(['chris@swiftmailer.org' => null]);
+                ->andReturn('chris@swiftmailer.org');
         $message->shouldReceive('getTo')
                 ->zeroOrMoreTimes()
                 ->andReturn([
@@ -281,9 +281,9 @@ abstract class Swift_Transport_AbstractSmtpEventSupportTest extends Swift_Transp
         $smtp = $this->getTransport($buf, $dispatcher);
         $message = $this->createMessage();
 
-        $message->shouldReceive('getFrom')
+        $message->shouldReceive('getReversePath')
                 ->zeroOrMoreTimes()
-                ->andReturn(['chris@swiftmailer.org' => null]);
+                ->andReturn('chris@swiftmailer.org');
         $message->shouldReceive('getTo')
                 ->zeroOrMoreTimes()
                 ->andReturn(['mark@swiftmailer.org' => 'Mark']);

--- a/tests/unit/Swift/Transport/AbstractSmtpTest.php
+++ b/tests/unit/Swift/Transport/AbstractSmtpTest.php
@@ -224,9 +224,9 @@ abstract class Swift_Transport_AbstractSmtpTest extends \SwiftMailerTestCase
         $buf = $this->getBuffer();
         $smtp = $this->getTransport($buf);
         $message = $this->createMessage();
-        $message->shouldReceive('getFrom')
+        $message->shouldReceive('getReversePath')
                 ->once()
-                ->andReturn(['me@domain.com' => 'Me']);
+                ->andReturn('me@domain.com');
         $message->shouldReceive('getTo')
                 ->once()
                 ->andReturn(['foo@bar' => null]);
@@ -256,9 +256,9 @@ abstract class Swift_Transport_AbstractSmtpTest extends \SwiftMailerTestCase
         $smtp = $this->getTransport($buf);
         $message = $this->createMessage();
 
-        $message->shouldReceive('getFrom')
+        $message->shouldReceive('getReversePath')
                 ->once()
-                ->andReturn(['me@domain.com' => 'Me']);
+                ->andReturn('me@domain.com');
         $message->shouldReceive('getTo')
                 ->once()
                 ->andReturn(['foo@bar' => null]);
@@ -278,67 +278,6 @@ abstract class Swift_Transport_AbstractSmtpTest extends \SwiftMailerTestCase
             $this->fail('MAIL FROM should accept a 250 response');
         } catch (Swift_TransportException $e) {
         }
-    }
-
-    public function testSenderIsPreferredOverFrom()
-    {
-        $buf = $this->getBuffer();
-        $smtp = $this->getTransport($buf);
-        $message = $this->createMessage();
-
-        $message->shouldReceive('getFrom')
-                ->once()
-                ->andReturn(['me@domain.com' => 'Me']);
-        $message->shouldReceive('getSender')
-                ->once()
-                ->andReturn(['another@domain.com' => 'Someone']);
-        $message->shouldReceive('getTo')
-                ->once()
-                ->andReturn(['foo@bar' => null]);
-        $buf->shouldReceive('write')
-            ->once()
-            ->with("MAIL FROM:<another@domain.com>\r\n")
-            ->andReturn(1);
-        $buf->shouldReceive('readLine')
-            ->once()
-            ->with(1)
-            ->andReturn('250 OK'."\r\n");
-
-        $this->finishBuffer($buf);
-        $smtp->start();
-        $smtp->send($message);
-    }
-
-    public function testReturnPathIsPreferredOverSender()
-    {
-        $buf = $this->getBuffer();
-        $smtp = $this->getTransport($buf);
-        $message = $this->createMessage();
-
-        $message->shouldReceive('getFrom')
-                ->once()
-                ->andReturn(['me@domain.com' => 'Me']);
-        $message->shouldReceive('getSender')
-                ->once()
-                ->andReturn(['another@domain.com' => 'Someone']);
-        $message->shouldReceive('getReturnPath')
-                ->once()
-                ->andReturn('more@domain.com');
-        $message->shouldReceive('getTo')
-                ->once()
-                ->andReturn(['foo@bar' => null]);
-        $buf->shouldReceive('write')
-            ->once()
-            ->with("MAIL FROM:<more@domain.com>\r\n")
-            ->andReturn(1);
-        $buf->shouldReceive('readLine')
-            ->once()
-            ->with(1)
-            ->andReturn('250 OK'."\r\n");
-
-        $this->finishBuffer($buf);
-        $smtp->start();
-        $smtp->send($message);
     }
 
     public function testSuccessfulRcptCommandWith250Response()
@@ -395,9 +334,9 @@ abstract class Swift_Transport_AbstractSmtpTest extends \SwiftMailerTestCase
         $smtp = $this->getTransport($buf);
         $message = $this->createMessage();
 
-        $message->shouldReceive('getFrom')
+        $message->shouldReceive('getReversePath')
                 ->once()
-                ->andReturn(['me@domain.com' => 'Me']);
+                ->andReturn('me@domain.com');
         $message->shouldReceive('getTo')
                 ->once()
                 ->andReturn(['foo@bar' => null]);
@@ -433,9 +372,9 @@ abstract class Swift_Transport_AbstractSmtpTest extends \SwiftMailerTestCase
         $smtp = $this->getTransport($buf);
         $message = $this->createMessage();
 
-        $message->shouldReceive('getFrom')
+        $message->shouldReceive('getReversePath')
                 ->once()
-                ->andReturn(['me@dömain.com' => 'Me']);
+                ->andReturn('me@dömain.com');
         $message->shouldReceive('getTo')
                 ->once()
                 ->andReturn(['foo@bär' => null]);
@@ -463,9 +402,9 @@ abstract class Swift_Transport_AbstractSmtpTest extends \SwiftMailerTestCase
         $smtp = $this->getTransport($buf, null, new Swift_AddressEncoder_Utf8AddressEncoder());
         $message = $this->createMessage();
 
-        $message->shouldReceive('getFrom')
+        $message->shouldReceive('getReversePath')
                 ->once()
-                ->andReturn(['më@dömain.com' => 'Me']);
+                ->andReturn('më@dömain.com');
         $message->shouldReceive('getTo')
                 ->once()
                 ->andReturn(['föö@bär' => null]);
@@ -493,9 +432,9 @@ abstract class Swift_Transport_AbstractSmtpTest extends \SwiftMailerTestCase
         $smtp = $this->getTransport($buf);
         $message = $this->createMessage();
 
-        $message->shouldReceive('getFrom')
+        $message->shouldReceive('getReversePath')
                 ->once()
-                ->andReturn(['më@domain.com' => 'Me']);
+                ->andReturn('më@domain.com');
         $message->shouldReceive('getTo')
                 ->once()
                 ->andReturn(['foo@bar' => null]);
@@ -516,9 +455,9 @@ abstract class Swift_Transport_AbstractSmtpTest extends \SwiftMailerTestCase
         $smtp = $this->getTransport($buf);
         $message = $this->createMessage();
 
-        $message->shouldReceive('getFrom')
+        $message->shouldReceive('getReversePath')
                 ->once()
-                ->andReturn(['me@domain.com' => 'Me']);
+                ->andReturn('me@domain.com');
         $message->shouldReceive('getTo')
                 ->once()
                 ->andReturn(['foo@bar' => null]);
@@ -553,9 +492,9 @@ abstract class Swift_Transport_AbstractSmtpTest extends \SwiftMailerTestCase
         $smtp = $this->getTransport($buf);
         $message = $this->createMessage();
 
-        $message->shouldReceive('getFrom')
+        $message->shouldReceive('getReversePath')
                 ->once()
-                ->andReturn(['me@domain.com' => 'Me']);
+                ->andReturn('me@domain.com');
         $message->shouldReceive('getTo')
                 ->once()
                 ->andReturn([
@@ -600,9 +539,9 @@ abstract class Swift_Transport_AbstractSmtpTest extends \SwiftMailerTestCase
         $smtp = $this->getTransport($buf);
         $message = $this->createMessage();
 
-        $message->shouldReceive('getFrom')
+        $message->shouldReceive('getReversePath')
                 ->once()
-                ->andReturn(['me@domain.com' => 'Me']);
+                ->andReturn('me@domain.com');
         $message->shouldReceive('getTo')
                 ->once()
                 ->andReturn(['foo@bar' => null]);
@@ -648,9 +587,9 @@ abstract class Swift_Transport_AbstractSmtpTest extends \SwiftMailerTestCase
         $smtp = $this->getTransport($buf);
         $message = $this->createMessage();
 
-        $message->shouldReceive('getFrom')
+        $message->shouldReceive('getReversePath')
                 ->once()
-                ->andReturn(['me@domain.com' => 'Me']);
+                ->andReturn('me@domain.com');
         $message->shouldReceive('getTo')
                 ->once()
                 ->andReturn(['foo@bar' => null]);
@@ -712,9 +651,9 @@ abstract class Swift_Transport_AbstractSmtpTest extends \SwiftMailerTestCase
         $smtp = $this->getTransport($buf);
         $message = $this->createMessage();
 
-        $message->shouldReceive('getFrom')
+        $message->shouldReceive('getReversePath')
                 ->once()
-                ->andReturn(['me@domain.com' => 'Me']);
+                ->andReturn('me@domain.com');
         $message->shouldReceive('getTo')
                 ->once()
                 ->andReturn(['foo@bar' => null]);
@@ -778,9 +717,9 @@ abstract class Swift_Transport_AbstractSmtpTest extends \SwiftMailerTestCase
         $smtp = $this->getTransport($buf);
         $message = $this->createMessage();
 
-        $message->shouldReceive('getFrom')
+        $message->shouldReceive('getReversePath')
                 ->once()
-                ->andReturn(['me@domain.com' => 'Me']);
+                ->andReturn('me@domain.com');
         $message->shouldReceive('getTo')
                 ->once()
                 ->andReturn(['foo@bar' => null]);
@@ -808,9 +747,9 @@ abstract class Swift_Transport_AbstractSmtpTest extends \SwiftMailerTestCase
         $smtp = $this->getTransport($buf);
         $message = $this->createMessage();
 
-        $message->shouldReceive('getFrom')
+        $message->shouldReceive('getReversePath')
                 ->once()
-                ->andReturn(['me@domain.com' => 'Me']);
+                ->andReturn('me@domain.com');
         $message->shouldReceive('getTo')
                 ->once()
                 ->andReturn(['foo@bar' => null]);
@@ -838,9 +777,9 @@ abstract class Swift_Transport_AbstractSmtpTest extends \SwiftMailerTestCase
         $smtp = $this->getTransport($buf);
         $message = $this->createMessage();
 
-        $message->shouldReceive('getFrom')
+        $message->shouldReceive('getReversePath')
                 ->once()
-                ->andReturn(['me@domain.com' => 'Me']);
+                ->andReturn('me@domain.com');
         $message->shouldReceive('getTo')
                 ->once()
                 ->andReturn(['foo@bar' => null]);
@@ -872,9 +811,9 @@ abstract class Swift_Transport_AbstractSmtpTest extends \SwiftMailerTestCase
         $smtp = $this->getTransport($buf);
         $message = $this->createMessage();
 
-        $message->shouldReceive('getFrom')
+        $message->shouldReceive('getReversePath')
                 ->once()
-                ->andReturn(['me@domain.com' => 'Me']);
+                ->andReturn('me@domain.com');
         $message->shouldReceive('getTo')
                 ->once()
                 ->andReturn(['foo@bar' => null]);
@@ -926,9 +865,9 @@ abstract class Swift_Transport_AbstractSmtpTest extends \SwiftMailerTestCase
         $buf = $this->getBuffer();
         $smtp = $this->getTransport($buf);
         $message = $this->createMessage();
-        $message->shouldReceive('getFrom')
+        $message->shouldReceive('getReversePath')
                 ->zeroOrMoreTimes()
-                ->andReturn(['me@domain.com' => 'Me']);
+                ->andReturn('me@domain.com');
         $message->shouldReceive('getTo')
                 ->zeroOrMoreTimes()
                 ->andReturn(['foo@bar' => null]);
@@ -955,9 +894,9 @@ abstract class Swift_Transport_AbstractSmtpTest extends \SwiftMailerTestCase
         $smtp = $this->getTransport($buf);
         $message = $this->createMessage();
 
-        $message->shouldReceive('getFrom')
+        $message->shouldReceive('getReversePath')
                 ->zeroOrMoreTimes()
-                ->andReturn(['me@domain.com' => 'Me']);
+                ->andReturn('me@domain.com');
         $message->shouldReceive('getTo')
                 ->zeroOrMoreTimes()
                 ->andReturn(['foo@bar' => null]);
@@ -1021,9 +960,9 @@ abstract class Swift_Transport_AbstractSmtpTest extends \SwiftMailerTestCase
         $smtp = $this->getTransport($buf);
         $message = $this->createMessage();
 
-        $message->shouldReceive('getFrom')
+        $message->shouldReceive('getReversePath')
                 ->zeroOrMoreTimes()
-                ->andReturn(['me@domain.com' => 'Me']);
+                ->andReturn('me@domain.com');
         $message->shouldReceive('getTo')
                 ->zeroOrMoreTimes()
                 ->andReturn(['foo@bar' => null]);
@@ -1179,9 +1118,9 @@ abstract class Swift_Transport_AbstractSmtpTest extends \SwiftMailerTestCase
         $smtp = $this->getTransport($buf);
         $message = $this->createMessage();
 
-        $message->shouldReceive('getFrom')
+        $message->shouldReceive('getReversePath')
                 ->zeroOrMoreTimes()
-                ->andReturn(['me@domain.com' => 'Me']);
+                ->andReturn('me@domain.com');
         $message->shouldReceive('getTo')
                 ->zeroOrMoreTimes()
                 ->andReturn(['foo@bar' => null]);
@@ -1243,9 +1182,9 @@ abstract class Swift_Transport_AbstractSmtpTest extends \SwiftMailerTestCase
         $buf = $this->getBuffer();
         $smtp = $this->getTransport($buf);
         $message = $this->createMessage();
-        $message->shouldReceive('getFrom')
+        $message->shouldReceive('getReversePath')
                 ->zeroOrMoreTimes()
-                ->andReturn(['me@domain.com' => 'Me']);
+                ->andReturn('me@domain.com');
         $message->shouldReceive('getTo')
                 ->zeroOrMoreTimes()
                 ->andReturn(['foo@bar' => null]);

--- a/tests/unit/Swift/Transport/DirectEsmtpTransportTest.php
+++ b/tests/unit/Swift/Transport/DirectEsmtpTransportTest.php
@@ -1,0 +1,548 @@
+<?php
+
+class Swift_Transport_DirectEsmtpTransportTest extends \SwiftMailerTestCase
+{
+    protected function getTransport($dispatcher = null, Swift_Transport_EsmtpTransport $smtp = null)
+    {
+        $dispatcher = $dispatcher ?? $this->createEventDispatcher();
+        $smtp = $smtp ?? $this->createEsmtpTransport();
+
+        return $this->getMockery(
+                'Swift_Transport_DirectEsmtpTransport',
+                [$dispatcher, $smtp, new Swift_AddressEncoder_IdnAddressEncoder()]
+            )
+            ->makePartial()
+            ->shouldAllowMockingProtectedMethods();
+    }
+
+    protected function createEventDispatcher($stub = true)
+    {
+        return $this->getMockery('Swift_Events_EventDispatcher')->shouldIgnoreMissing();
+    }
+
+    protected function createEsmtpTransport()
+    {
+        return $this->getMockery('Swift_Transport_EsmtpTransport')->shouldIgnoreMissing();
+    }
+
+    protected function createMessage()
+    {
+        return $this->getMockery('Swift_Mime_SimpleMessage')->shouldIgnoreMissing();
+    }
+
+    public function testRecipients()
+    {
+        $message = $this->createMessage();
+        $message->shouldReceive('getReversePath')
+            ->zeroOrMoreTimes()
+            ->andReturn('me@domain');
+        $message->shouldReceive('getTo')
+            ->zeroOrMoreTimes()
+            ->andReturn(['alice@example.com' => 'Alice']);
+        $message->shouldReceive('getCc')
+            ->zeroOrMoreTimes()
+            ->andReturn(['bob@example.com' => 'Bob']);
+        $message->shouldReceive('getBcc')
+            ->zeroOrMoreTimes()
+            ->andReturn(['oscar@example.org' => 'Oscar']);
+
+        $direct = $this->getTransport();
+        $direct->shouldReceive('groupRecipientsByMxHosts')
+           ->once()
+           ->with(
+                ['alice@example.com' => 'Alice', 'bob@example.com' => 'Bob'],
+                ['oscar@example.org' => 'Oscar']
+            );
+
+        $direct->send($message);
+    }
+
+    public function testSendingToMultipleDomains()
+    {
+        $message = $this->createMessage();
+        $message->shouldReceive('getReversePath')
+            ->zeroOrMoreTimes()
+            ->andReturn('me@domain');
+        $message->shouldReceive('getTo')
+            ->zeroOrMoreTimes()
+            ->andReturn(['alice@example.com' => 'Alice', 'oscar@example.org' => 'Oscar']);
+        $message->shouldReceive('getBcc')
+            ->zeroOrMoreTimes()
+            ->andReturn(['bob@example.com' => 'Bob']);
+
+        $dispatcher = $this->createEventDispatcher(false);
+        $smtp = $this->createEsmtpTransport();
+        $direct = $this->getTransport($dispatcher, $smtp);
+
+        $evt = $this->getMockery('Swift_Events_SendEvent')->shouldIgnoreMissing();
+        $dispatcher->shouldReceive('createSendEvent')
+                   ->once()
+                   ->andReturn($evt);
+        $dispatcher->shouldReceive('dispatchEvent')
+                   ->once()
+                   ->with($evt, 'beforeSendPerformed');
+        $evt->shouldReceive('bubbleCancelled')
+            ->once()
+            ->andReturn(false);
+
+        $direct->shouldReceive('groupRecipientsByMxHosts')
+           ->once()
+           ->with(
+                ['alice@example.com' => 'Alice', 'oscar@example.org' => 'Oscar'],
+                ['bob@example.com' => 'Bob']
+            )
+           ->andReturn([
+                'example.com' => [
+                    'tos' => ['alice@example.com'],
+                    'bcc' => ['bob@example.com'],
+                    'hosts' => ['smtp.example.com']
+                ],
+                'example.org' => [
+                    'tos' => ['oscar@example.org'],
+                    'bcc' => [],
+                    'hosts' => ['smtp.example.org']
+                ],
+            ]);
+
+        $smtp->shouldReceive('setHost')
+            ->with('smtp.example.com')
+            ->once();
+        $smtp->shouldReceive('setHost')
+            ->with('smtp.example.org')
+            ->once();
+
+        $smtp->shouldReceive('isStarted')
+            ->twice()
+            ->andReturn(false);
+        $smtp->shouldReceive('start')
+            ->twice();
+
+        $smtp->shouldReceive('sendCopy')
+            ->with($message, 'me@domain', ['alice@example.com'], ['bob@example.com'], [])
+            ->once()
+            ->andReturn(2);
+        $smtp->shouldReceive('sendCopy')
+            ->with($message, 'me@domain', ['oscar@example.org'], [], [])
+            ->once()
+            ->andReturn(1);
+
+        $smtp->shouldReceive('stop')
+            ->twice();
+
+        $evt->shouldReceive('setResult')
+            ->with(Swift_Events_SendEvent::RESULT_SUCCESS)
+            ->once();
+        $dispatcher->shouldReceive('dispatchEvent')
+                   ->once()
+                   ->with($evt, 'sendPerformed');
+
+        $sent = $direct->send($message);
+
+        $this->assertSame(3, $sent);
+    }
+
+    public function testFailoverToSecondoryHostsForDomain()
+    {
+        $message = $this->createMessage();
+        $message->shouldReceive('getReversePath')
+            ->zeroOrMoreTimes()
+            ->andReturn('me@domain');
+        $message->shouldReceive('getTo')
+            ->zeroOrMoreTimes()
+            ->andReturn(['alice@example.com' => 'Alice']);
+
+        $dispatcher = $this->createEventDispatcher(false);
+        $smtp = $this->createEsmtpTransport();
+        $direct = $this->getTransport($dispatcher, $smtp);
+
+        $evt = $this->getMockery('Swift_Events_SendEvent')->shouldIgnoreMissing();
+        $dispatcher->shouldReceive('createSendEvent')
+                   ->once()
+                   ->andReturn($evt);
+        $dispatcher->shouldReceive('dispatchEvent')
+                   ->once()
+                   ->with($evt, 'beforeSendPerformed');
+        $evt->shouldReceive('bubbleCancelled')
+            ->once()
+            ->andReturn(false);
+
+        $direct->shouldReceive('groupRecipientsByMxHosts')
+           ->once()
+           ->andReturn([
+                'example.com' => [
+                    'tos' => ['alice@example.com'],
+                    'bcc' => [],
+                    'hosts' => ['smtp1.example.com', 'smtp2.example.com', 'smtp3.example.com']
+                ],
+            ]);
+
+        $smtp->shouldReceive('setHost')
+            ->with('smtp1.example.com')
+            ->once();
+        $smtp->shouldReceive('setHost')
+            ->with('smtp2.example.com')
+            ->once();
+        $smtp->shouldReceive('setHost')
+            ->with('smtp3.example.com')
+            ->never();
+
+        $smtp->shouldReceive('isStarted')
+            ->twice()
+            ->andReturn(false);
+        $smtp->shouldReceive('start')
+            ->twice();
+
+        $i = 0;
+        $smtp->shouldReceive('sendCopy')
+            ->with($message, 'me@domain', ['alice@example.com'], [], \Mockery::any())
+            ->twice()
+            ->andReturnUsing(function () use (&$i) {
+                if ($i++ == 0) {
+                    throw new Swift_TransportException('smtp1 is down');
+                } else {
+                    return 1;
+                }
+            });
+
+        $smtp->shouldReceive('stop')
+            ->twice();
+
+        $evt->shouldReceive('setResult')
+            ->with(Swift_Events_SendEvent::RESULT_SUCCESS)
+            ->once();
+        $dispatcher->shouldReceive('dispatchEvent')
+                   ->once()
+                   ->with($evt, 'sendPerformed');
+
+        $sent = $direct->send($message, $failedRecipients);
+
+        $this->assertSame(1, $sent);
+        $this->assertEmpty($failedRecipients);
+    }
+
+    public function testAllHostsForDomainFail()
+    {
+        $message = $this->createMessage();
+        $message->shouldReceive('getReversePath')
+            ->zeroOrMoreTimes()
+            ->andReturn('me@domain');
+        $message->shouldReceive('getTo')
+            ->zeroOrMoreTimes()
+            ->andReturn(['alice@example.com' => 'Alice']);
+
+        $dispatcher = $this->createEventDispatcher(false);
+        $smtp = $this->createEsmtpTransport();
+        $direct = $this->getTransport($dispatcher, $smtp);
+
+        $evt = $this->getMockery('Swift_Events_SendEvent')->shouldIgnoreMissing();
+        $dispatcher->shouldReceive('createSendEvent')
+                   ->once()
+                   ->andReturn($evt);
+        $dispatcher->shouldReceive('dispatchEvent')
+                   ->once()
+                   ->with($evt, 'beforeSendPerformed');
+        $evt->shouldReceive('bubbleCancelled')
+            ->once()
+            ->andReturn(false);
+
+        $direct->shouldReceive('groupRecipientsByMxHosts')
+           ->once()
+           ->andReturn([
+                'example.com' => [
+                    'tos' => ['alice@example.com'],
+                    'bcc' => [],
+                    'hosts' => ['smtp1.example.com', 'smtp2.example.com']
+                ],
+            ]);
+
+        $smtp->shouldReceive('setHost')
+            ->with('smtp1.example.com')
+            ->once();
+        $smtp->shouldReceive('setHost')
+            ->with('smtp2.example.com')
+            ->once();
+
+        $smtp->shouldReceive('isStarted')
+            ->twice()
+            ->andReturn(false);
+        $smtp->shouldReceive('start')
+            ->twice();
+
+        $smtp->shouldReceive('sendCopy')
+            ->with($message, 'me@domain', ['alice@example.com'], [], \Mockery::any())
+            ->twice()
+            ->andThrow(new Swift_TransportException('smtp is down'));
+
+        $smtp->shouldReceive('stop')
+            ->twice();
+
+        $evt->shouldReceive('setResult')
+            ->with(Swift_Events_SendEvent::RESULT_FAILED)
+            ->once();
+        $dispatcher->shouldReceive('dispatchEvent')
+                   ->once()
+                   ->with($evt, 'sendPerformed');
+
+        $sent = $direct->send($message, $failedRecipients);
+
+        $this->assertSame(0, $sent);
+        $this->assertSame(['alice@example.com'], $failedRecipients);
+    }
+
+    public function testSomeDomainsFail()
+    {
+        $message = $this->createMessage();
+        $message->shouldReceive('getReversePath')
+            ->zeroOrMoreTimes()
+            ->andReturn('me@domain');
+
+        $dispatcher = $this->createEventDispatcher(false);
+        $smtp = $this->createEsmtpTransport();
+        $direct = $this->getTransport($dispatcher, $smtp);
+
+        $evt = $this->getMockery('Swift_Events_SendEvent')->shouldIgnoreMissing();
+        $dispatcher->shouldReceive('createSendEvent')
+                   ->once()
+                   ->andReturn($evt);
+        $dispatcher->shouldReceive('dispatchEvent')
+                   ->once()
+                   ->with($evt, 'beforeSendPerformed');
+        $evt->shouldReceive('bubbleCancelled')
+            ->once()
+            ->andReturn(false);
+
+        $direct->shouldReceive('groupRecipientsByMxHosts')
+           ->once()
+           ->andReturn([
+                'example.com' => [
+                    'tos' => ['alice@example.com'],
+                    'bcc' => [],
+                    'hosts' => ['smtp.example.com']
+                ],
+                'example.org' => [
+                    'tos' => ['bob@example.org'],
+                    'bcc' => [],
+                    'hosts' => ['smtp.example.org']
+                ],
+            ]);
+
+        $smtp->shouldReceive('setHost')
+            ->with('smtp.example.com')
+            ->once();
+        $smtp->shouldReceive('setHost')
+            ->with('smtp.example.org')
+            ->once();
+
+        $smtp->shouldReceive('isStarted')
+            ->twice()
+            ->andReturn(false);
+        $smtp->shouldReceive('start')
+            ->twice();
+
+        $smtp->shouldReceive('sendCopy')
+            ->with($message, 'me@domain', ['alice@example.com'], [], \Mockery::any())
+            ->once()
+            ->andThrow(new Swift_TransportException('smtp is down'));
+        $smtp->shouldReceive('sendCopy')
+            ->with($message, 'me@domain', ['bob@example.org'], [], \Mockery::any())
+            ->once()
+            ->andReturn(1);
+
+        $smtp->shouldReceive('stop')
+            ->twice();
+
+        $evt->shouldReceive('setResult')
+            ->with(Swift_Events_SendEvent::RESULT_TENTATIVE)
+            ->once();
+        $dispatcher->shouldReceive('dispatchEvent')
+                   ->once()
+                   ->with($evt, 'sendPerformed');
+
+        $sent = $direct->send($message, $failedRecipients);
+
+        $this->assertSame(1, $sent);
+        $this->assertSame(['alice@example.com'], $failedRecipients);
+    }
+
+    public function testGetMxHostsInvokedWithDomain()
+    {
+        $message = $this->createMessage();
+        $message->shouldReceive('getReversePath')
+            ->zeroOrMoreTimes()
+            ->andReturn('me@domain');
+        $message->shouldReceive('getTo')
+            ->zeroOrMoreTimes()
+            ->andReturn(['alice@example.com' => 'Alice']);
+
+        $smtp = $this->createEsmtpTransport();
+        $direct = $this->getTransport(null, $smtp);
+
+        $direct->shouldReceive('getmxrr')
+            ->with('example.com', \Mockery::any(), \Mockery::any())
+            ->once()
+            ->andReturnUsing(function ($domain, &$hosts, &$weights) {
+                $hosts = ['smtp2.example.com', 'smtp1.example.com'];
+                $weights = [20, 10];
+                return true;
+            });
+
+        $smtp->shouldReceive('setHost')
+            ->with('smtp1.example.com')
+            ->once();
+        $smtp->shouldReceive('setHost')
+            ->with('smtp2.example.com')
+            ->never();
+
+        $sent = $direct->send($message);
+    }
+
+    public function testGetMxHostsForDomainWithoutMxHosts()
+    {
+        $message = $this->createMessage();
+        $message->shouldReceive('getReversePath')
+            ->zeroOrMoreTimes()
+            ->andReturn('me@domain');
+        $message->shouldReceive('getTo')
+            ->zeroOrMoreTimes()
+            ->andReturn(['alice@example.com' => 'Alice']);
+
+        $smtp = $this->createEsmtpTransport();
+        $direct = $this->getTransport(null, $smtp);
+
+        $direct->shouldReceive('getmxrr')
+            ->with('example.com', \Mockery::any(), \Mockery::any())
+            ->once()
+            ->andReturn(false);
+
+        $smtp->shouldReceive('setHost')
+            ->with('example.com')
+            ->once();
+
+        $sent = $direct->send($message);
+    }
+
+    public function testGetMxHostsForUtf8Domain()
+    {
+        $message = $this->createMessage();
+        $message->shouldReceive('getReversePath')
+            ->zeroOrMoreTimes()
+            ->andReturn('me@domain');
+        $message->shouldReceive('getTo')
+            ->zeroOrMoreTimes()
+            ->andReturn(['alice@exämple.com' => 'Alice']);
+
+        $smtp = $this->createEsmtpTransport();
+        $direct = $this->getTransport(null, $smtp);
+
+        $direct->shouldReceive('getmxrr')
+            ->with('xn--exmple-cua.com', \Mockery::any(), \Mockery::any())
+            ->once()
+             ->andReturnUsing(function ($domain, &$hosts, &$weights) {
+                $hosts = ['smtp.example.com'];
+                $weights = [10];
+                return true;
+            });
+
+        $smtp->shouldReceive('setHost')
+            ->with('smtp.example.com')
+            ->once();
+
+        $sent = $direct->send($message);
+    }
+
+    public function testRegisterPluginLoadsPluginInEventDispatcher()
+    {
+        $dispatcher = $this->createEventDispatcher(false);
+        $listener = $this->getMockery('Swift_Events_EventListener');
+        $direct = $this->getTransport($dispatcher);
+        $dispatcher->shouldReceive('bindEventListener')
+                   ->once()
+                   ->with($listener);
+
+        $direct->registerPlugin($listener);
+    }
+
+    public function testCancellingEventBubbleBeforeSendStopsEvent()
+    {
+        $dispatcher = $this->createEventDispatcher(false);
+        $evt = $this->getMockery('Swift_Events_SendEvent')->shouldIgnoreMissing();
+        $diredt = $this->getTransport($dispatcher);
+        $message = $this->createMessage();
+
+        $message->shouldReceive('getReversePath')
+                ->zeroOrMoreTimes()
+                ->andReturn('chris@swiftmailer.org');
+        $message->shouldReceive('getTo')
+                ->zeroOrMoreTimes()
+                ->andReturn(['mark@swiftmailer.org' => 'Mark']);
+        $dispatcher->shouldReceive('createSendEvent')
+                   ->zeroOrMoreTimes()
+                   ->with($diredt, \Mockery::any())
+                   ->andReturn($evt);
+        $dispatcher->shouldReceive('dispatchEvent')
+                   ->once()
+                   ->with($evt, 'beforeSendPerformed');
+        $dispatcher->shouldReceive('dispatchEvent')
+                   ->zeroOrMoreTimes();
+        $evt->shouldReceive('bubbleCancelled')
+            ->atLeast()->once()
+            ->andReturn(true);
+
+        $diredt->start();
+        $this->assertEquals(0, $diredt->send($message));
+    }
+
+    public function testExceptionsCauseExceptionEvents()
+    {
+        $message = $this->createMessage();
+        $message->shouldReceive('getReversePath')
+            ->zeroOrMoreTimes()
+            ->andReturn(false);
+
+        $dispatcher = $this->createEventDispatcher(false);
+        $evt = $this->getMockery('Swift_Events_TransportExceptionEvent');
+        $diredt = $this->getTransport($dispatcher);
+
+        $dispatcher->shouldReceive('createTransportExceptionEvent')
+                   ->zeroOrMoreTimes()
+                   ->with($diredt, \Mockery::any())
+                   ->andReturn($evt);
+        $dispatcher->shouldReceive('dispatchEvent')
+                   ->once()
+                   ->with($evt, 'exceptionThrown');
+        $evt->shouldReceive('bubbleCancelled')
+            ->atLeast()->once()
+            ->andReturn(false);
+
+        try {
+            $diredt->send($message);
+            $this->fail('TransportException should be thrown on invalid response');
+        } catch (Swift_TransportException $e) {
+        }
+    }
+
+    public function testExceptionBubblesCanBeCancelled()
+    {
+        $message = $this->createMessage();
+        $message->shouldReceive('getReversePath')
+            ->zeroOrMoreTimes()
+            ->andReturn(false);
+
+        $dispatcher = $this->createEventDispatcher(false);
+        $evt = $this->getMockery('Swift_Events_TransportExceptionEvent');
+        $diredt = $this->getTransport($dispatcher);
+
+        $dispatcher->shouldReceive('createTransportExceptionEvent')
+                   ->once()
+                   ->with($diredt, \Mockery::any())
+                   ->andReturn($evt);
+        $dispatcher->shouldReceive('dispatchEvent')
+                   ->once()
+                   ->with($evt, 'exceptionThrown');
+        $evt->shouldReceive('bubbleCancelled')
+            ->atLeast()->once()
+            ->andReturn(true);
+
+        $diredt->send($message);
+    }
+}

--- a/tests/unit/Swift/Transport/EsmtpTransport/ExtensionSupportTest.php
+++ b/tests/unit/Swift/Transport/EsmtpTransport/ExtensionSupportTest.php
@@ -147,9 +147,9 @@ class Swift_Transport_EsmtpTransport_ExtensionSupportTest extends Swift_Transpor
         $ext3 = $this->getMockery('Swift_Transport_EsmtpHandler')->shouldIgnoreMissing();
         $message = $this->createMessage();
 
-        $message->shouldReceive('getFrom')
+        $message->shouldReceive('getReversePath')
                 ->zeroOrMoreTimes()
-                ->andReturn(['me@domain' => 'Me']);
+                ->andReturn('me@domain');
         $message->shouldReceive('getTo')
                 ->zeroOrMoreTimes()
                 ->andReturn(['foo@bar' => null]);
@@ -249,9 +249,9 @@ class Swift_Transport_EsmtpTransport_ExtensionSupportTest extends Swift_Transpor
         $ext3 = $this->getMockery('Swift_Transport_EsmtpHandler')->shouldIgnoreMissing();
         $message = $this->createMessage();
 
-        $message->shouldReceive('getFrom')
+        $message->shouldReceive('getReversePath')
                 ->zeroOrMoreTimes()
-                ->andReturn(['me@domain' => 'Me']);
+                ->andReturn('me@domain');
         $message->shouldReceive('getTo')
                 ->zeroOrMoreTimes()
                 ->andReturn(['foo@bar' => null]);

--- a/tests/unit/Swift/Transport/EsmtpTransportTest.php
+++ b/tests/unit/Swift/Transport/EsmtpTransportTest.php
@@ -285,9 +285,9 @@ class Swift_Transport_EsmtpTransportTest extends Swift_Transport_AbstractSmtpEve
         $this->assertNull($smtp->getPipelining());
 
         $message = $this->createMessage();
-        $message->shouldReceive('getFrom')
+        $message->shouldReceive('getReversePath')
                 ->zeroOrMoreTimes()
-                ->andReturn(['me@domain.com' => 'Me']);
+                ->andReturn('me@domain.com');
         $message->shouldReceive('getTo')
                 ->zeroOrMoreTimes()
                 ->andReturn(['foo@bar' => null]);
@@ -601,9 +601,9 @@ class Swift_Transport_EsmtpTransportTest extends Swift_Transport_AbstractSmtpEve
         $this->assertSame($enabled, $smtp->getPipelining());
 
         $message = $this->createMessage();
-        $message->shouldReceive('getFrom')
+        $message->shouldReceive('getReversePath')
                 ->zeroOrMoreTimes()
-                ->andReturn(['me@domain.com' => 'Me']);
+                ->andReturn('me@domain.com');
 
         $buf->shouldReceive('initialize')
             ->once();

--- a/tests/unit/Swift/Transport/EsmtpTransportTest.php
+++ b/tests/unit/Swift/Transport/EsmtpTransportTest.php
@@ -355,9 +355,9 @@ class Swift_Transport_EsmtpTransportTest extends Swift_Transport_AbstractSmtpEve
         $this->assertNull($smtp->getPipelining());
 
         $message = $this->createMessage();
-        $message->shouldReceive('getFrom')
+        $message->shouldReceive('getReversePath')
                 ->zeroOrMoreTimes()
-                ->andReturn(['me@domain.com' => 'Me']);
+                ->andReturn('me@domain.com');
         $message->shouldReceive('getTo')
                 ->zeroOrMoreTimes()
                 ->andReturn([
@@ -453,9 +453,9 @@ class Swift_Transport_EsmtpTransportTest extends Swift_Transport_AbstractSmtpEve
         $this->assertNull($smtp->getPipelining());
 
         $message = $this->createMessage();
-        $message->shouldReceive('getFrom')
+        $message->shouldReceive('getReversePath')
                 ->zeroOrMoreTimes()
-                ->andReturn(['me@domain.com' => 'Me']);
+                ->andReturn('me@domain.com');
         $message->shouldReceive('getTo')
                 ->zeroOrMoreTimes()
                 ->andReturn(['foo@bar' => null]);
@@ -513,9 +513,9 @@ class Swift_Transport_EsmtpTransportTest extends Swift_Transport_AbstractSmtpEve
         $this->assertNull($smtp->getPipelining());
 
         $message = $this->createMessage();
-        $message->shouldReceive('getFrom')
+        $message->shouldReceive('getReversePath')
                 ->zeroOrMoreTimes()
-                ->andReturn(['me@domain.com' => 'Me']);
+                ->andReturn('me@domain.com');
         $message->shouldReceive('getTo')
                 ->zeroOrMoreTimes()
                 ->andReturn(['foo@bar' => null]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Doc update?   | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 
| License       | MIT

In some hosting scenarious you don't have access to an outbound SMTP server. With few changes, Swift Mailer can deliver the message directly to the recipient's mail server.

This may also be useful if you need instant feedback on delivery errors, rather than waiting days for a delivery status notification to be returned.