### PR TITLE
Remove reference to Swift_Validate::email()

### DIFF
--- a/doc/sending.rst
+++ b/doc/sending.rst
@@ -347,10 +347,11 @@ Mailer will throw a ``Swift_RfcComplianceException``.
 
 If you add recipients automatically based on a data source that may contain
 invalid email addresses, you can prevent possible exceptions by validating the
-addresses using ``Swift_Validate::email($email)`` and only adding addresses
-that validate. Another way would be to wrap your ``setTo()``, ``setCc()`` and
-``setBcc()`` calls in a try-catch block and handle the
-``Swift_RfcComplianceException`` in the catch block.
+addresses using ``Egulias\EmailValidator\EmailValidator`` (a dependency that is
+installed with Swift Mailer) and only adding addresses that validate. Another
+way would be to wrap your ``setTo()``, ``setCc()`` and ``setBcc()`` calls in a
+try-catch block and handle the ``Swift_RfcComplianceException`` in the catch
+block.
 
 Handling invalid addresses properly is especially important when sending emails
 in large batches since a single invalid address might cause an unhandled


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes (documentation error)
| New feature?  | no
| Doc update?   | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 
| License       | MIT

The documentation references `Swift_Validate::email()`. This class was removed in 6776d293954416a9ee7df4d76f24cea6eb3370a9.