### PR TITLE
Document how to use IPv6 addresses

### DIFF
--- a/lib/classes/Swift/Plugins/PopBeforeSmtpPlugin.php
+++ b/lib/classes/Swift/Plugins/PopBeforeSmtpPlugin.php
@@ -45,7 +45,8 @@ class Swift_Plugins_PopBeforeSmtpPlugin implements Swift_Events_TransportChangeL
     /**
      * Create a new PopBeforeSmtpPlugin for $host and $port.
      *
-     * @param string $host
+     * @param string $host Hostname or IP. Literal IPv6 addresses should be
+     *                     wrapped in square brackets.
      * @param int    $port
      * @param string $crypto as "tls" or "ssl"
      */

--- a/lib/classes/Swift/Transport/EsmtpTransport.php
+++ b/lib/classes/Swift/Transport/EsmtpTransport.php
@@ -60,6 +60,8 @@ class Swift_Transport_EsmtpTransport extends Swift_Transport_AbstractSmtpTranspo
     /**
      * Set the host to connect to.
      *
+     * Literal IPv6 addresses should be wrapped in square brackets.
+     *
      * @param string $host
      *
      * @return $this
@@ -187,6 +189,8 @@ class Swift_Transport_EsmtpTransport extends Swift_Transport_AbstractSmtpTranspo
 
     /**
      * Sets the source IP.
+     *
+     * IPv6 addresses should be wrapped in square brackets.
      *
      * @param string $source
      *


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Doc update?   | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets |
| License       | MIT

Add a notice about how to specify an IPv6 address for sourceIp and SMTP/POP host.