### PR TITLE
Add 8BITMIME support

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -8,6 +8,7 @@ Changelog
  * introduced new dependencies: transport.smtphandlers and transport.authhandlers
  * deprecated Swift_Signers_OpenDKIMSigner; use Swift_Signers_DKIMSigner instead
  * added support for SMTP pipelining
+ * added Swift_Transport_Esmtp_EightBitMimeHandler
 
 6.0.2 (2017-09-30)
 ------------------

--- a/doc/messages.rst
+++ b/doc/messages.rst
@@ -839,7 +839,7 @@ sent to this address.
 Setting the Character Set
 -------------------------
 
-The character set of the message (and it's MIME parts) is set with the
+The character set of the message (and its MIME parts) is set with the
 ``setCharset()`` method. You can also change the global default of UTF-8 by
 working with the ``Swift_Preferences`` class.
 
@@ -876,6 +876,31 @@ To set the character set of your Message:
 
     // Approach 4: Specify the charset for each part added
     $message->addPart('My part', 'text/plain', 'iso-8859-2');
+
+Setting the Encoding
+--------------------
+
+The body of each MIME part needs to be encoded. Binary attachments are encoded
+in base64 using the ``Swift_Mime_ContentEncoder_Base64ContentEncoder``. Text
+parts are traditionally encoded in quoted-printable using
+``Swift_Mime_ContentEncoder_QpContentEncoder`` or
+``Swift_Mime_ContentEncoder_NativeQpContentEncoder``.
+
+The encoder of the message or MIME part is set with the ``setEncoder()`` method.
+
+Quoted-printable is the safe choice, because it converts 8-bit text as 7-bit.
+Most modern SMTP servers support 8-bit text. This is advertised via the 8BITMIME
+SMTP extension. If your outbound SMTP server supports this SMTP extension, and
+it supports downgrading the message (e.g converting to quoted-printable on the
+fly) when delivering to a downstream server that does not support the extension,
+you may wish to use ``Swift_Mime_ContentEncoder_PlainContentEncoder`` in
+``8bit`` mode instead. This has the advantage that the source data is slightly
+more readable and compact, especially for non-Western languages.
+
+        $eightBitMime = new Swift_Transport_Esmtp_EightBitMimeHandler();
+        $transport->setExtensionHandlers([$eightBitMime]);
+        $plainEncoder = new Swift_Mime_ContentEncoder_PlainContentEncoder('8bit');
+        $message->setEncoder($plainEncoder);
 
 Setting the Line Length
 -----------------------

--- a/lib/classes/Swift/Mime/ContentEncoder/PlainContentEncoder.php
+++ b/lib/classes/Swift/Mime/ContentEncoder/PlainContentEncoder.php
@@ -11,6 +11,10 @@
 /**
  * Handles binary/7/8-bit Transfer Encoding in Swift Mailer.
  *
+ * When sending 8-bit content over SMTP, you should use
+ * Swift_Transport_Esmtp_EightBitMimeHandler to enable the 8BITMIME SMTP
+ * extension.
+ *
  * @author Chris Corbyn
  */
 class Swift_Mime_ContentEncoder_PlainContentEncoder implements Swift_Mime_ContentEncoder

--- a/lib/classes/Swift/Mime/ContentEncoder/RawContentEncoder.php
+++ b/lib/classes/Swift/Mime/ContentEncoder/RawContentEncoder.php
@@ -11,6 +11,10 @@
 /**
  * Handles raw Transfer Encoding in Swift Mailer.
  *
+ * When sending 8-bit content over SMTP, you should use
+ * Swift_Transport_Esmtp_EightBitMimeHandler to enable the 8BITMIME SMTP
+ * extension.
+ *
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  */
 class Swift_Mime_ContentEncoder_RawContentEncoder implements Swift_Mime_ContentEncoder

--- a/lib/classes/Swift/Transport/Esmtp/EightBitMimeHandler.php
+++ b/lib/classes/Swift/Transport/Esmtp/EightBitMimeHandler.php
@@ -28,7 +28,7 @@ class Swift_Transport_Esmtp_EightBitMimeHandler implements Swift_Transport_Esmtp
      * @param string $encoding The parameter so send with the MAIL FROM command;
      *                         either "8BITMIME" or "7BIT"
      */
-    public function __construct($encoding = '8BITMIME')
+    public function __construct(string $encoding = '8BITMIME')
     {
         $this->encoding = $encoding;
     }

--- a/lib/classes/Swift/Transport/Esmtp/EightBitMimeHandler.php
+++ b/lib/classes/Swift/Transport/Esmtp/EightBitMimeHandler.php
@@ -1,0 +1,113 @@
+<?php
+
+/*
+ * This file is part of SwiftMailer.
+ * (c) 2018 Christian Schmidt
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * An ESMTP handler for 8BITMIME support (RFC 6152).
+ *
+ * 8BITMIME is required when sending 8-bit content to over SMTP, e.g. when using
+ * Swift_Mime_ContentEncoder_PlainContentEncoder in "8bit" mode.
+ *
+ * 8BITMIME mode is enabled unconditionally, even when sending ASCII-only
+ * messages, so it should only be used with an outbound SMTP server that will
+ * convert the message to 7-bit MIME if the next hop does not support 8BITMIME.
+ *
+ * @author Christian Schmidt
+ */
+class Swift_Transport_Esmtp_EightBitMimeHandler implements Swift_Transport_EsmtpHandler
+{
+    protected $encoding;
+
+    /**
+     * @param string $encoding The parameter so send with the MAIL FROM command;
+     *                         either "8BITMIME" or "7BIT"
+     */
+    public function __construct($encoding = '8BITMIME')
+    {
+        $this->encoding = $encoding;
+    }
+
+    /**
+     * Get the name of the ESMTP extension this handles.
+     *
+     * @return string
+     */
+    public function getHandledKeyword()
+    {
+        return '8BITMIME';
+    }
+
+    /**
+     * Not used.
+     */
+    public function setKeywordParams(array $parameters)
+    {
+    }
+
+    /**
+     * Not used.
+     */
+    public function afterEhlo(Swift_Transport_SmtpAgent $agent)
+    {
+    }
+
+    /**
+     * Get params which are appended to MAIL FROM:<>.
+     *
+     * @return string[]
+     */
+    public function getMailParams()
+    {
+        return ['BODY='.$this->encoding];
+    }
+
+    /**
+     * Not used.
+     */
+    public function getRcptParams()
+    {
+        return [];
+    }
+
+    /**
+     * Not used.
+     */
+    public function onCommand(Swift_Transport_SmtpAgent $agent, $command, $codes = array(), &$failedRecipients = null, &$stop = false)
+    {
+    }
+
+    /**
+     * Returns +1, -1 or 0 according to the rules for usort().
+     *
+     * This method is called to ensure extensions can be execute in an appropriate order.
+     *
+     * @param string $esmtpKeyword to compare with
+     *
+     * @return int
+     */
+    public function getPriorityOver($esmtpKeyword)
+    {
+        return 0;
+    }
+
+    /**
+     * Not used.
+     */
+    public function exposeMixinMethods()
+    {
+        return [];
+    }
+
+    /**
+     * Not used.
+     */
+    public function resetState()
+    {
+    }
+}

--- a/lib/dependency_maps/mime_deps.php
+++ b/lib/dependency_maps/mime_deps.php
@@ -25,7 +25,7 @@ Swift_DependencyContainer::getInstance()
     ->asNewInstanceOf('Swift_Mime_SimpleMessage')
     ->withDependencies([
         'mime.headerset',
-        'mime.qpcontentencoder',
+        'mime.textcontentencoder',
         'cache',
         'mime.idgenerator',
         'properties.charset',
@@ -35,7 +35,7 @@ Swift_DependencyContainer::getInstance()
     ->asNewInstanceOf('Swift_Mime_MimePart')
     ->withDependencies([
         'mime.headerset',
-        'mime.qpcontentencoder',
+        'mime.textcontentencoder',
         'cache',
         'mime.idgenerator',
         'properties.charset',
@@ -94,6 +94,9 @@ Swift_DependencyContainer::getInstance()
 
     ->register('mime.characterreaderfactory')
     ->asSharedInstanceOf('Swift_CharacterReaderFactory_SimpleCharacterReaderFactory')
+
+    ->register('mime.textcontentencoder')
+    ->asAliasOf('mime.qpcontentencoder')
 
     ->register('mime.safeqpcontentencoder')
     ->asNewInstanceOf('Swift_Mime_ContentEncoder_QpContentEncoder')

--- a/lib/dependency_maps/transport_deps.php
+++ b/lib/dependency_maps/transport_deps.php
@@ -45,11 +45,7 @@ Swift_DependencyContainer::getInstance()
 
     ->register('transport.smtphandlers')
     ->asArray()
-    ->withDependencies([
-        'transport.authhandler',
-        'transport.8bitmimehandler',
-        'transport.smtputf8handler',
-    ])
+    ->withDependencies(['transport.authhandler'])
 
     ->register('transport.authhandler')
     ->asNewInstanceOf('Swift_Transport_Esmtp_AuthHandler')

--- a/lib/dependency_maps/transport_deps.php
+++ b/lib/dependency_maps/transport_deps.php
@@ -64,6 +64,10 @@ Swift_DependencyContainer::getInstance()
     ->register('transport.smtputf8handler')
     ->asNewInstanceOf('Swift_Transport_Esmtp_SmtpUtf8Handler')
 
+    ->register('transport.8bitmimehandler')
+    ->asNewInstanceOf('Swift_Transport_Esmtp_EightBitMimeHandler')
+    ->addConstructorValue('8BITMIME')
+
     ->register('transport.crammd5auth')
     ->asNewInstanceOf('Swift_Transport_Esmtp_Auth_CramMd5Authenticator')
 

--- a/lib/dependency_maps/transport_deps.php
+++ b/lib/dependency_maps/transport_deps.php
@@ -45,7 +45,11 @@ Swift_DependencyContainer::getInstance()
 
     ->register('transport.smtphandlers')
     ->asArray()
-    ->withDependencies(['transport.authhandler', 'transport.smtputf8handler'])
+    ->withDependencies([
+        'transport.authhandler',
+        'transport.8bitmimehandler',
+        'transport.smtputf8handler',
+    ])
 
     ->register('transport.authhandler')
     ->asNewInstanceOf('Swift_Transport_Esmtp_AuthHandler')


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Doc update?   | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets |
| License       | MIT

It is not permitted to sent 8-bit content over plain SMTP. The [8BITMIME](https://tools.ietf.org/html/rfc6152) SMTP extension makes this possible.

This PR adds a new SMTP handler that adds support for 8BITMIME. This handler should be used e.g. when using `Swift_Mime_ContentEncoder_PlainContentEncoder` in `8bit` mode.