### PR TITLE
Support PIPELINING SMTP extension

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,7 @@ Changelog
 
  * added support for non-ASCII email addresses
  * introduced new dependencies: transport.smtphandlers and transport.authhandlers
+ * added support for SMTP pipelining
 
 6.0.2 (2017-09-30)
 ------------------

--- a/lib/classes/Swift/Transport/AbstractSmtpTransport.php
+++ b/lib/classes/Swift/Transport/AbstractSmtpTransport.php
@@ -30,7 +30,7 @@ abstract class Swift_Transport_AbstractSmtpTransport implements Swift_Transport
     protected $addressEncoder;
 
     /** Whether the PIPELINING SMTP extension is enabled (RFC 2920) */
-    protected $pipelining = false;
+    protected $pipelining = null;
 
     /** The pipelined commands waiting for response */
     protected $pipeline = [];

--- a/lib/classes/Swift/Transport/AbstractSmtpTransport.php
+++ b/lib/classes/Swift/Transport/AbstractSmtpTransport.php
@@ -29,6 +29,12 @@ abstract class Swift_Transport_AbstractSmtpTransport implements Swift_Transport
 
     protected $addressEncoder;
 
+    /** Whether the PIPELINING SMTP extension is enabled (RFC 2920) */
+    protected $pipelining = false;
+
+    /** The pipelined commands waiting for response */
+    protected $pipeline = [];
+
     /** Source Ip */
     protected $sourceIp;
 
@@ -289,7 +295,7 @@ abstract class Swift_Transport_AbstractSmtpTransport implements Swift_Transport
      */
     public function reset()
     {
-        $this->executeCommand("RSET\r\n", [250]);
+        $this->executeCommand("RSET\r\n", [250], $failures, true);
     }
 
     /**
@@ -311,18 +317,28 @@ abstract class Swift_Transport_AbstractSmtpTransport implements Swift_Transport
      * @param string   $command
      * @param int[]    $codes
      * @param string[] $failures An array of failures by-reference
+     * @param bool     $pipeline Do not wait for response
      *
-     * @return string
+     * @return string|null The server response, or null if pipelining is enabled
      */
-    public function executeCommand($command, $codes = [], &$failures = null)
+    public function executeCommand($command, $codes = [], &$failures = null, $pipeline = false)
     {
         $failures = (array) $failures;
         $seq = $this->buffer->write($command);
-        $response = $this->getFullResponse($seq);
         if ($evt = $this->eventDispatcher->createCommandEvent($this, $command, $codes)) {
             $this->eventDispatcher->dispatchEvent($evt, 'commandSent');
         }
-        $this->assertResponseCode($response, $codes);
+
+        $this->pipeline[] = [$command, $seq, $codes];
+        if ($pipeline && $this->pipelining) {
+            $response = null;
+        } else {
+            while ($this->pipeline) {
+                list($command, $seq, $codes) = array_shift($this->pipeline);
+                $response = $this->getFullResponse($seq);
+                $this->assertResponseCode($response, $codes);
+            }
+        }
 
         return $response;
     }
@@ -346,7 +362,7 @@ abstract class Swift_Transport_AbstractSmtpTransport implements Swift_Transport
     {
         $address = $this->addressEncoder->encodeString($address);
         $this->executeCommand(
-            sprintf("MAIL FROM:<%s>\r\n", $address), [250]
+            sprintf("MAIL FROM:<%s>\r\n", $address), [250], $failures, true
             );
     }
 
@@ -355,7 +371,7 @@ abstract class Swift_Transport_AbstractSmtpTransport implements Swift_Transport
     {
         $address = $this->addressEncoder->encodeString($address);
         $this->executeCommand(
-            sprintf("RCPT TO:<%s>\r\n", $address), [250, 251, 252]
+            sprintf("RCPT TO:<%s>\r\n", $address), [250, 251, 252], $failures, true
             );
     }
 

--- a/lib/classes/Swift/Transport/EsmtpTransport.php
+++ b/lib/classes/Swift/Transport/EsmtpTransport.php
@@ -254,10 +254,11 @@ class Swift_Transport_EsmtpTransport extends Swift_Transport_AbstractSmtpTranspo
      * @param string   $command
      * @param int[]    $codes
      * @param string[] $failures An array of failures by-reference
+     * @param bool     $pipeline Do not wait for response
      *
      * @return string
      */
-    public function executeCommand($command, $codes = [], &$failures = null)
+    public function executeCommand($command, $codes = [], &$failures = null, $pipeline = false)
     {
         $failures = (array) $failures;
         $stopSignal = false;
@@ -271,7 +272,7 @@ class Swift_Transport_EsmtpTransport extends Swift_Transport_AbstractSmtpTranspo
             }
         }
 
-        return parent::executeCommand($command, $codes, $failures);
+        return parent::executeCommand($command, $codes, $failures, $pipeline);
     }
 
     /** Mixin handling method for ESMTP handlers */
@@ -331,6 +332,7 @@ class Swift_Transport_EsmtpTransport extends Swift_Transport_AbstractSmtpTranspo
         }
 
         $this->capabilities = $this->getCapabilities($response);
+        $this->pipelining = isset($this->capabilities['PIPELINING']);
         $this->setHandlerParams();
         foreach ($this->getActiveHandlers() as $handler) {
             $handler->afterEhlo($this);
@@ -348,7 +350,7 @@ class Swift_Transport_EsmtpTransport extends Swift_Transport_AbstractSmtpTranspo
         }
         $paramStr = !empty($params) ? ' '.implode(' ', $params) : '';
         $this->executeCommand(
-            sprintf("MAIL FROM:<%s>%s\r\n", $address, $paramStr), [250]
+            sprintf("MAIL FROM:<%s>%s\r\n", $address, $paramStr), [250], $failures, true
             );
     }
 
@@ -363,7 +365,7 @@ class Swift_Transport_EsmtpTransport extends Swift_Transport_AbstractSmtpTranspo
         }
         $paramStr = !empty($params) ? ' '.implode(' ', $params) : '';
         $this->executeCommand(
-            sprintf("RCPT TO:<%s>%s\r\n", $address, $paramStr), [250, 251, 252]
+            sprintf("RCPT TO:<%s>%s\r\n", $address, $paramStr), [250, 251, 252], $failures, true
             );
     }
 

--- a/lib/classes/Swift/Transport/EsmtpTransport.php
+++ b/lib/classes/Swift/Transport/EsmtpTransport.php
@@ -214,6 +214,35 @@ class Swift_Transport_EsmtpTransport extends Swift_Transport_AbstractSmtpTranspo
     }
 
     /**
+     * Sets whether SMTP pipelining is enabled.
+     *
+     * By default, support is auto-detected using the PIPELINING SMTP extension.
+     * Use this function to override that in the unlikely event of compatibility
+     * issues.
+     *
+     * @param bool $enabled
+     *
+     * @return $this
+     */
+    public function setPipelining($enabled)
+    {
+        $this->pipelining = $enabled;
+
+        return $this;
+    }
+
+    /**
+     * Returns whether SMTP pipelining is enabled.
+     *
+     * @return bool|null a boolean if pipelining is explicitly enabled or disabled,
+     *                   or null if support is auto-detected.
+     */
+    public function getPipelining()
+    {
+        return $this->pipelining;
+    }
+
+    /**
      * Set ESMTP extension handlers.
      *
      * @param Swift_Transport_EsmtpHandler[] $handlers
@@ -332,7 +361,10 @@ class Swift_Transport_EsmtpTransport extends Swift_Transport_AbstractSmtpTranspo
         }
 
         $this->capabilities = $this->getCapabilities($response);
-        $this->pipelining = isset($this->capabilities['PIPELINING']);
+        if (!isset($this->pipelining)) {
+            $this->pipelining = isset($this->capabilities['PIPELINING']);
+        }
+
         $this->setHandlerParams();
         foreach ($this->getActiveHandlers() as $handler) {
             $handler->afterEhlo($this);

--- a/tests/unit/Swift/Transport/EsmtpTransportTest.php
+++ b/tests/unit/Swift/Transport/EsmtpTransportTest.php
@@ -278,6 +278,69 @@ class Swift_Transport_EsmtpTransportTest extends Swift_Transport_AbstractSmtpEve
         $smtp->start();
     }
 
+    public function testPipelining()
+    {
+        $buf = $this->getBuffer();
+        $smtp = $this->getTransport($buf);
+        $message = $this->createMessage();
+        $message->shouldReceive('getFrom')
+                ->zeroOrMoreTimes()
+                ->andReturn(['me@domain.com' => 'Me']);
+        $message->shouldReceive('getTo')
+                ->zeroOrMoreTimes()
+                ->andReturn(['foo@bar' => null]);
+
+        $buf->shouldReceive('initialize')
+            ->once();
+        $buf->shouldReceive('readLine')
+            ->once()
+            ->with(0)
+            ->andReturn("220 some.server.tld bleh\r\n");
+        $buf->shouldReceive('write')
+            ->once()
+            ->with('~^EHLO .+?\r\n$~D')
+            ->andReturn(1);
+        $buf->shouldReceive('readLine')
+            ->once()
+            ->with(1)
+            ->andReturn('250-ServerName'."\r\n");
+        $buf->shouldReceive('readLine')
+            ->once()
+            ->with(1)
+            ->andReturn('250 PIPELINING'."\r\n");
+
+        $buf->shouldReceive('write')
+            ->ordered()
+            ->once()
+            ->with("MAIL FROM:<me@domain.com>\r\n")
+            ->andReturn(1);
+        $buf->shouldReceive('write')
+            ->ordered()
+            ->once()
+            ->with("RCPT TO:<foo@bar>\r\n")
+            ->andReturn(2);
+        $buf->shouldReceive('write')
+            ->ordered()
+            ->once()
+            ->with("DATA\r\n")->andReturn(3);
+        $buf->shouldReceive('readLine')
+            ->ordered()
+            ->once()
+            ->with(1)->andReturn("250 OK\r\n");
+        $buf->shouldReceive('readLine')
+            ->ordered()
+            ->once()
+            ->with(2)->andReturn("250 OK\r\n");
+        $buf->shouldReceive('readLine')
+            ->ordered()
+            ->once()
+            ->with(3)->andReturn("354 OK\r\n");
+
+        $this->finishBuffer($buf);
+        $smtp->start();
+        $smtp->send($message);
+    }
+
     public function testFluidInterface()
     {
         $buf = $this->getBuffer();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Doc update?   | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets |
| License       | MIT

Add support for the PIPELINING SMTP extension defined in [RFC 2920](https://tools.ietf.org/html/rfc2920). This speeds up delivery, especially when using a SMTP server on a high-latency connection.