### PR TITLE
OpenDKIM fixes

### DIFF
--- a/lib/classes/Swift/Mime/Header.php
+++ b/lib/classes/Swift/Mime/Header.php
@@ -85,7 +85,7 @@ interface Swift_Mime_Header
     public function getFieldBody();
 
     /**
-     * Get this Header rendered as a compliant string.
+     * Get this Header rendered as a compliant string, including trailing CRLF.
      *
      * @return string
      */

--- a/lib/classes/Swift/Mime/Headers/OpenDKIMHeader.php
+++ b/lib/classes/Swift/Mime/Headers/OpenDKIMHeader.php
@@ -111,7 +111,7 @@ class Swift_Mime_Headers_OpenDKIMHeader implements Swift_Mime_Header
      */
     public function toString()
     {
-        return $this->fieldName.': '.$this->value;
+        return $this->fieldName.': '.$this->value."\r\n";
     }
 
     /**

--- a/lib/classes/Swift/Signers/OpenDKIMSigner.php
+++ b/lib/classes/Swift/Signers/OpenDKIMSigner.php
@@ -42,7 +42,7 @@ class Swift_Signers_OpenDKIMSigner extends Swift_Signers_DKIMSigner
     {
         $header = new Swift_Mime_Headers_OpenDKIMHeader('DKIM-Signature');
         $headerVal = $this->dkimHandler->getSignatureHeader();
-        if (!$headerVal) {
+        if ($headerVal === false || is_int($headerVal)) {
             throw new Swift_SwiftException('OpenDKIM Error: '.$this->dkimHandler->getError());
         }
         $header->setValue($headerVal);
@@ -53,14 +53,10 @@ class Swift_Signers_OpenDKIMSigner extends Swift_Signers_DKIMSigner
 
     public function setHeaders(Swift_Mime_SimpleHeaderSet $headers)
     {
-        $bodyLen = $this->bodyLen;
-        if (is_bool($bodyLen)) {
-            $bodyLen = -1;
-        }
         $hash = 'rsa-sha1' == $this->hashAlgorithm ? OpenDKIMSign::ALG_RSASHA1 : OpenDKIMSign::ALG_RSASHA256;
         $bodyCanon = 'simple' == $this->bodyCanon ? OpenDKIMSign::CANON_SIMPLE : OpenDKIMSign::CANON_RELAXED;
         $headerCanon = 'simple' == $this->headerCanon ? OpenDKIMSign::CANON_SIMPLE : OpenDKIMSign::CANON_RELAXED;
-        $this->dkimHandler = new OpenDKIMSign($this->privateKey, $this->selector, $this->domainName, $headerCanon, $bodyCanon, $hash, $bodyLen);
+        $this->dkimHandler = new OpenDKIMSign($this->privateKey, $this->selector, $this->domainName, $headerCanon, $bodyCanon, $hash, -1);
         // Hardcode signature Margin for now
         $this->dkimHandler->setMargin(78);
 
@@ -172,7 +168,7 @@ class Swift_Signers_OpenDKIMSigner extends Swift_Signers_DKIMSigner
         if (!$this->peclLoaded) {
             return parent::canonicalizeBody($string);
         }
-        if (false && true === $this->dropFirstLF) {
+        if (true === $this->dropFirstLF) {
             if ("\r" == $string[0] && "\n" == $string[1]) {
                 $string = substr($string, 2);
             }


### PR DESCRIPTION
<!-- Please fill in this template according to the PR you're about to submit. -->

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc update?   | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #640
| License       | MIT

`Swift_Signers_OpenDKIMSigner` is severely broken. It depends on a PHP extension that is poorly documented and not included in any OS distribution (AFAIK). I suggest removing it altogether in favour of `Swift_Signers_DKIMSigner`, but FWIW here are some fixes that are necessary to make it run at all (at with least the latest version of the extension).

I didn't find a way to use `relaxed` for body — this throws an error `OpenDKIM Error: private key load failure` no matter what I do.