### PR TITLE
Deprecate Swift_Signers_OpenDKIMSigner

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,7 @@ Changelog
 
  * added support for non-ASCII email addresses
  * introduced new dependencies: transport.smtphandlers and transport.authhandlers
+ * deprecated Swift_Signers_OpenDKIMSigner; use Swift_Signers_DKIMSigner instead
 
 6.0.2 (2017-09-30)
 ------------------

--- a/lib/classes/Swift/Mime/Headers/OpenDKIMHeader.php
+++ b/lib/classes/Swift/Mime/Headers/OpenDKIMHeader.php
@@ -12,6 +12,8 @@
  * An OpenDKIM Specific Header using only raw header datas without encoding.
  *
  * @author De Cock Xavier <xdecock@gmail.com>
+ *
+ * @deprecated since SwiftMailer 6.1.0; use Swift_Signers_DKIMSigner instead.
  */
 class Swift_Mime_Headers_OpenDKIMHeader implements Swift_Mime_Header
 {

--- a/lib/classes/Swift/Signers/OpenDKIMSigner.php
+++ b/lib/classes/Swift/Signers/OpenDKIMSigner.php
@@ -13,6 +13,8 @@
  * Takes advantage of pecl extension.
  *
  * @author     Xavier De Cock <xdecock@gmail.com>
+ *
+ * @deprecated since SwiftMailer 6.1.0; use Swift_Signers_DKIMSigner instead.
  */
 class Swift_Signers_OpenDKIMSigner extends Swift_Signers_DKIMSigner
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Doc update?   | no
| BC breaks?    | no
| Deprecations? | yes
| Fixed tickets |
| License       | MIT

As mentioned in #1066, `Swift_Signers_OpenDKIMSigner` is severely broken. It depends on a [PHP extension](https://github.com/xdecock/php-opendkim) that has no documentation, and is not included in any OS distribution (AFAIK).

Prior to the fixes in #1066, as reported in #640, it did not work at all — at least with not the latest version of the php-opendkim extension.

I didn't find a way to use `relaxed` for the body — this throws an error `OpenDKIM Error: private key load failure` no matter what I do.

This PR deprecates `Swift_Signers_OpenDKIMSigner` in favour of `Swift_Signers_DKIMSigner`.