### PR TITLE
Reset content type after sending mail

### DIFF
--- a/lib/classes/Swift/Transport/AbstractSmtpTransport.php
+++ b/lib/classes/Swift/Transport/AbstractSmtpTransport.php
@@ -202,7 +202,9 @@ abstract class Swift_Transport_AbstractSmtpTransport implements Swift_Transport
         $message->setBcc([]);
 
         try {
+            $bccContentType = $message->getContentType();
             $sent += $this->sendTo($message, $reversePath, $tos, $failedRecipients);
+            $message->setContentType($bccContentType);
             $sent += $this->sendBcc($message, $reversePath, $bcc, $failedRecipients);
         } catch (Exception $e) {
             $message->setBcc($bcc);


### PR DESCRIPTION
<!-- Please fill in this template according to the PR you're about to submit. -->

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc update?   | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #1073
| License       | MIT


This commit would fix issue #1073. I would like it better if the $message object could be cloned before sending the first message, but this causes some problems during the test runs.
