### PR TITLE
Correct doc blocks of signer methods

### DIFF
--- a/lib/classes/Swift/Message.php
+++ b/lib/classes/Swift/Message.php
@@ -75,7 +75,7 @@ class Swift_Message extends Swift_Mime_SimpleMessage
     }
 
     /**
-     * Detach a signature handler from a message.
+     * Attach a new signature handler to the message.
      *
      * @return $this
      */
@@ -91,7 +91,7 @@ class Swift_Message extends Swift_Mime_SimpleMessage
     }
 
     /**
-     * Attach a new signature handler to the message.
+     * Detach a signature handler from a message.
      *
      * @return $this
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc update?   | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | N/A
| License       | MIT

The short descriptions for the `attachSigner` and `detachSigner` methods are on the wrong methods.  This is now corrected.