### PR TITLE
always return arrays (instead of null) for headers that should return arrays fixes #693

### DIFF
--- a/lib/classes/Swift/Mime/SimpleMessage.php
+++ b/lib/classes/Swift/Mime/SimpleMessage.php
@@ -170,7 +170,7 @@ class Swift_Mime_SimpleMessage extends Swift_Mime_MimePart
      */
     public function getSender()
     {
-        return $this->getHeaderFieldModel('Sender');
+        return $this->getHeaderFieldModel('Sender', []);
     }
 
     /**
@@ -224,7 +224,7 @@ class Swift_Mime_SimpleMessage extends Swift_Mime_MimePart
      */
     public function getFrom()
     {
-        return $this->getHeaderFieldModel('From');
+        return $this->getHeaderFieldModel('From', []);
     }
 
     /**
@@ -278,7 +278,7 @@ class Swift_Mime_SimpleMessage extends Swift_Mime_MimePart
      */
     public function getReplyTo()
     {
-        return $this->getHeaderFieldModel('Reply-To');
+        return $this->getHeaderFieldModel('Reply-To', []);
     }
 
     /**
@@ -333,7 +333,7 @@ class Swift_Mime_SimpleMessage extends Swift_Mime_MimePart
      */
     public function getTo()
     {
-        return $this->getHeaderFieldModel('To');
+        return $this->getHeaderFieldModel('To', []);
     }
 
     /**
@@ -385,7 +385,7 @@ class Swift_Mime_SimpleMessage extends Swift_Mime_MimePart
      */
     public function getCc()
     {
-        return $this->getHeaderFieldModel('Cc');
+        return $this->getHeaderFieldModel('Cc', []);
     }
 
     /**
@@ -437,7 +437,7 @@ class Swift_Mime_SimpleMessage extends Swift_Mime_MimePart
      */
     public function getBcc()
     {
-        return $this->getHeaderFieldModel('Bcc');
+        return $this->getHeaderFieldModel('Bcc', []);
     }
 
     /**
@@ -514,7 +514,7 @@ class Swift_Mime_SimpleMessage extends Swift_Mime_MimePart
      */
     public function getReadReceiptTo()
     {
-        return $this->getHeaderFieldModel('Disposition-Notification-To');
+        return $this->getHeaderFieldModel('Disposition-Notification-To', []);
     }
 
     /**

--- a/lib/classes/Swift/Mime/SimpleMimeEntity.php
+++ b/lib/classes/Swift/Mime/SimpleMimeEntity.php
@@ -574,11 +574,12 @@ class Swift_Mime_SimpleMimeEntity implements Swift_Mime_CharsetObserver, Swift_M
     /**
      * Get the model data (usually an array or a string) for $field.
      */
-    protected function getHeaderFieldModel($field)
+    protected function getHeaderFieldModel($field, $default = null)
     {
         if ($this->headers->has($field)) {
             return $this->headers->get($field)->getFieldBodyModel();
         }
+        return $default;
     }
 
     /**

--- a/tests/unit/Swift/Mime/SimpleMessageTest.php
+++ b/tests/unit/Swift/Mime/SimpleMessageTest.php
@@ -218,6 +218,15 @@ class Swift_Mime_SimpleMessageTest extends Swift_Mime_MimePartTest
         $this->assertEquals(['sender@domain' => 'Name'], $message->getSender());
     }
 
+    public function testEmptySenderIsReturnedFromHeader()
+    {
+        $message = $this->createMessage(
+            $this->createHeaderSet([]),
+            $this->createEncoder(), $this->createCache()
+        );
+        $this->assertEquals([], $message->getSender());
+    }
+
     public function testSenderIsSetInHeader()
     {
         $sender = $this->createHeader('Sender', ['sender@domain' => 'Name'],
@@ -275,6 +284,15 @@ class Swift_Mime_SimpleMessageTest extends Swift_Mime_MimePartTest
             $this->createEncoder(), $this->createCache()
             );
         $this->assertEquals(['from@domain' => 'Name'], $message->getFrom());
+    }
+
+    public function testEmptyFromIsReturnedFromHeader()
+    {
+        $message = $this->createMessage(
+            $this->createHeaderSet([]),
+            $this->createEncoder(), $this->createCache()
+        );
+        $this->assertEquals([], $message->getFrom());
     }
 
     public function testFromIsSetInHeader()
@@ -352,6 +370,15 @@ class Swift_Mime_SimpleMessageTest extends Swift_Mime_MimePartTest
         $this->assertEquals(['reply@domain' => 'Name'], $message->getReplyTo());
     }
 
+    public function testEmptyReplyToIsReturnedFromHeader()
+    {
+        $message = $this->createMessage(
+            $this->createHeaderSet([]),
+            $this->createEncoder(), $this->createCache()
+        );
+        $this->assertEquals([], $message->getReplyTo());
+    }
+
     public function testReplyToIsSetInHeader()
     {
         $reply = $this->createHeader('Reply-To', ['reply@domain' => 'Name'],
@@ -425,6 +452,15 @@ class Swift_Mime_SimpleMessageTest extends Swift_Mime_MimePartTest
             $this->createEncoder(), $this->createCache()
             );
         $this->assertEquals(['to@domain' => 'Name'], $message->getTo());
+    }
+
+    public function testEmptyToIsReturnedFromHeader()
+    {
+        $message = $this->createMessage(
+            $this->createHeaderSet([]),
+            $this->createEncoder(), $this->createCache()
+        );
+        $this->assertEquals([], $message->getTo());
     }
 
     public function testToIsSetInHeader()
@@ -502,6 +538,15 @@ class Swift_Mime_SimpleMessageTest extends Swift_Mime_MimePartTest
         $this->assertEquals(['cc@domain' => 'Name'], $message->getCc());
     }
 
+    public function testEmptyCcIsReturnedFromHeader()
+    {
+        $message = $this->createMessage(
+            $this->createHeaderSet([]),
+            $this->createEncoder(), $this->createCache()
+        );
+        $this->assertEquals([], $message->getCc());
+    }
+
     public function testCcIsSetInHeader()
     {
         $cc = $this->createHeader('Cc', ['cc@domain' => 'Name'],
@@ -575,6 +620,15 @@ class Swift_Mime_SimpleMessageTest extends Swift_Mime_MimePartTest
             $this->createEncoder(), $this->createCache()
             );
         $this->assertEquals(['bcc@domain' => 'Name'], $message->getBcc());
+    }
+
+    public function testEmptyBccIsReturnedFromHeader()
+    {
+        $message = $this->createMessage(
+            $this->createHeaderSet([]),
+            $this->createEncoder(), $this->createCache()
+        );
+        $this->assertEquals([], $message->getBcc());
     }
 
     public function testBccIsSetInHeader()
@@ -690,6 +744,15 @@ class Swift_Mime_SimpleMessageTest extends Swift_Mime_MimePartTest
         $this->assertEquals(['chris@swiftmailer.org' => 'Chris'],
             $message->getReadReceiptTo()
             );
+    }
+
+    public function testEmptyReadReceiptAddressReadFromHeader()
+    {
+        $message = $this->createMessage(
+            $this->createHeaderSet([]),
+            $this->createEncoder(), $this->createCache()
+        );
+        $this->assertEquals([], $message->getReadReceiptTo());
     }
 
     public function testReadReceiptIsSetInHeader()


### PR DESCRIPTION
Q | A
-- | --
Bug fix? | yes
New feature? | no
Doc update? | yes
BC breaks? | yes
Deprecations? | no
Fixed tickets | #693 
License | MIT