### PR TITLE
Fix return type in MessageLogger

### DIFF
--- a/lib/classes/Swift/Plugins/MessageLogger.php
+++ b/lib/classes/Swift/Plugins/MessageLogger.php
@@ -16,7 +16,7 @@
 class Swift_Plugins_MessageLogger implements Swift_Events_SendListener
 {
     /**
-     * @var Swift_Mime_Message[]
+     * @var Swift_Mime_SimpleMessage[]
      */
     private $messages;
 
@@ -28,7 +28,7 @@ class Swift_Plugins_MessageLogger implements Swift_Events_SendListener
     /**
      * Get the message list.
      *
-     * @return Swift_Mime_Message[]
+     * @return Swift_Mime_SimpleMessage[]
      */
     public function getMessages()
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc update?   | yes
| BC breaks?    | no
| Deprecations? | no

Method `Swift_Events_SendEvent::getMessage()` returns `Swift_Mime_SimpleMessage`
https://github.com/swiftmailer/swiftmailer/blob/master/lib/classes/Swift/Events/SendEvent.php#L77
