### PR TITLE
Handle recipient errors when pipelining

### DIFF
--- a/lib/classes/Swift/Transport/EsmtpTransport.php
+++ b/lib/classes/Swift/Transport/EsmtpTransport.php
@@ -284,10 +284,11 @@ class Swift_Transport_EsmtpTransport extends Swift_Transport_AbstractSmtpTranspo
      * @param int[]    $codes
      * @param string[] $failures An array of failures by-reference
      * @param bool     $pipeline Do not wait for response
+     * @param string   $address  The address, if command is RCPT TO.
      *
-     * @return string
+     * @return string|null The server response, or null if pipelining is enabled
      */
-    public function executeCommand($command, $codes = [], &$failures = null, $pipeline = false)
+    public function executeCommand($command, $codes = [], &$failures = null, $pipeline = false, $address = null)
     {
         $failures = (array) $failures;
         $stopSignal = false;
@@ -301,7 +302,7 @@ class Swift_Transport_EsmtpTransport extends Swift_Transport_AbstractSmtpTranspo
             }
         }
 
-        return parent::executeCommand($command, $codes, $failures, $pipeline);
+        return parent::executeCommand($command, $codes, $failures, $pipeline, $address);
     }
 
     /** Mixin handling method for ESMTP handlers */
@@ -397,7 +398,7 @@ class Swift_Transport_EsmtpTransport extends Swift_Transport_AbstractSmtpTranspo
         }
         $paramStr = !empty($params) ? ' '.implode(' ', $params) : '';
         $this->executeCommand(
-            sprintf("RCPT TO:<%s>%s\r\n", $address, $paramStr), [250, 251, 252], $failures, true
+            sprintf("RCPT TO:<%s>%s\r\n", $address, $paramStr), [250, 251, 252], $failures, true, $address
             );
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc update?   | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #1106
| License       | MIT

When using SMTP PIPELINING, unexpected replies may throw exceptions in the function that cause the pipeline to be processed (usually `doDataCommand()`) rather than the command that sends the offending command (e.g. `doRcptToCommand()`).

This is a problem in `doMailTransaction()` that wants to catch exceptions caused by invalid recipients rejected in `doRcptToCommand()`.

In fact, this issue was a BC break introduced in #1065. Would the appropriate fix be to roll back this feature for the 6.x branch and postpone it to 7.x?

I would like to give this patch some though. I'll post an update in a few days.