### PR TITLE
Fixed missing property addressEncoder in SimpleHeaderFactory class

### DIFF
--- a/lib/classes/Swift/Mime/SimpleHeaderFactory.php
+++ b/lib/classes/Swift/Mime/SimpleHeaderFactory.php
@@ -29,6 +29,9 @@ class Swift_Mime_SimpleHeaderFactory implements Swift_Mime_CharsetObserver
     /** The charset of created Headers */
     private $charset;
 
+    /** Swift_AddressEncoder */
+    private $addressEncoder;
+
     /**
      * Creates a new SimpleHeaderFactory using $encoder and $paramEncoder.
      *


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc update?   | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #1116
| License       | MIT


### Observed behaviour
[{
    "message": "Symfony\\Component\\Debug\\Exception\\ContextErrorException: Notice: Undefined property: Swift_Mime_SimpleHeaderFactory::$addressEncoder (uncaught exception) at /var/www/project/releases/20180808073330/project/vendor/swiftmailer/swiftmailer/lib/classes/Swift/Mime/SimpleHeaderFactory.php line 56 while running console command `swiftmailer:spool:send`",
    "context": {
        "exception": {
            "class": "Symfony\\Component\\Debug\\Exception\\ContextErrorException",
            "message": "Notice: Undefined property: Swift_Mime_SimpleHeaderFactory::$addressEncoder",
            "code": 0,
            "file": "/var/www/project/releases/20180808073330/project/vendor/swiftmailer/swiftmailer/lib/classes/Swift/Mime/SimpleHeaderFactory.php:56"
        }
    },
    "level": 500,
    "level_name": "CRITICAL",
    "channel": "app",
    "datetime": {
        "date": "2018-08-08 07:38:02.956462",
        "timezone_type": 3,
        "timezone": "UTC"
    },
    "extra": []
}]

### Expected behaviour
There should be no exception
