### PR TITLE
re-queue message when an exception occurred

### DIFF
--- a/lib/classes/Swift/MemorySpool.php
+++ b/lib/classes/Swift/MemorySpool.php
@@ -100,8 +100,14 @@ class Swift_MemorySpool implements Swift_Spool
                     // wait half a second before we try again
                     usleep(500000);
                 } else {
+                    array_unshift($this->messages, $message);
+                    
                     throw $exception;
                 }
+            } catch (\Exception $exception) {
+                array_unshift($this->messages, $message);
+                    
+                throw $exception;
             }
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Doc update?   | no
| BC breaks?    | no
| Deprecations? | no
| License       | MIT


re-queue message when all retries failed and when an other type of exception occurred.

