### PR TITLE
bcc no longer sent in separate messages #1132

### DIFF
--- a/lib/classes/Swift/Transport/AbstractSmtpTransport.php
+++ b/lib/classes/Swift/Transport/AbstractSmtpTransport.php
@@ -197,14 +197,13 @@ abstract class Swift_Transport_AbstractSmtpTransport implements Swift_Transport
 
         $to = (array) $message->getTo();
         $cc = (array) $message->getCc();
-        $tos = array_merge($to, $cc);
         $bcc = (array) $message->getBcc();
+        $tos = array_merge($to, $cc, $bcc);
 
         $message->setBcc([]);
 
         try {
             $sent += $this->sendTo($message, $reversePath, $tos, $failedRecipients);
-            $sent += $this->sendBcc($message, $reversePath, $bcc, $failedRecipients);
         } finally {
             $message->setBcc($bcc);
         }
@@ -514,20 +513,6 @@ abstract class Swift_Transport_AbstractSmtpTransport implements Swift_Transport
 
         return $this->doMailTransaction($message, $reversePath, array_keys($to),
             $failedRecipients);
-    }
-
-    /** Send a message to all Bcc: recipients */
-    private function sendBcc(Swift_Mime_SimpleMessage $message, $reversePath, array $bcc, array &$failedRecipients)
-    {
-        $sent = 0;
-        foreach ($bcc as $forwardPath => $name) {
-            $message->setBcc([$forwardPath => $name]);
-            $sent += $this->doMailTransaction(
-                $message, $reversePath, [$forwardPath], $failedRecipients
-                );
-        }
-
-        return $sent;
     }
 
     /**


### PR DESCRIPTION
<!-- Please fill in this template according to the PR you're about to submit. -->

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc update?   | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #1132
| License       | MIT


Bcc recipients are sent as additional rcpt to, not as separate messages. required by recent changes to Microsoft Office365.
