### PR TITLE
Mute errors when writing to the stream

### DIFF
--- a/lib/classes/Swift/Transport/StreamBuffer.php
+++ b/lib/classes/Swift/Transport/StreamBuffer.php
@@ -228,7 +228,7 @@ class Swift_Transport_StreamBuffer extends Swift_ByteStream_AbstractFilterableIn
             $totalBytesWritten = 0;
 
             while ($totalBytesWritten < $bytesToWrite) {
-                $bytesWritten = fwrite($this->in, substr($bytes, $totalBytesWritten));
+                $bytesWritten = @fwrite($this->in, substr($bytes, $totalBytesWritten));
                 if (false === $bytesWritten || 0 === $bytesWritten) {
                     break;
                 }


### PR DESCRIPTION
This allows cooperating with other error handlers that convert errors into ErrorExceptions. Success in writing to the stream is checked at the next line.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc update?   | no
| BC breaks?    | no
| Deprecations? | no
| License       | MIT

Ran into an issue where writing into the stream failed. `fwrite` triggered an error, which was then converted to an `ErrorException` by one of the error handlers in my application. Hence, sending the email failed.

Since the return value of `fwrite` is already checked, there is no need to also trigger an error so we can use the silence operator.