### PR TITLE
Update transport_deps.php

### DIFF
--- a/lib/dependency_maps/transport_deps.php
+++ b/lib/dependency_maps/transport_deps.php
@@ -5,7 +5,7 @@ Swift_DependencyContainer::getInstance()
     // As SERVER_NAME can come from the user in certain configurations, check that
     // it does not contain forbidden characters (see RFC 952 and RFC 2181). Use
     // preg_replace() instead of preg_match() to prevent DoS attacks with long host names.
-    ->asValue(!empty($_SERVER['SERVER_NAME']) && '' === preg_replace('/(?:^\[)?[a-zA-Z0-9-:\]_]+\.?/', '', $_SERVER['SERVER_NAME']) ? trim($_SERVER['SERVER_NAME'], '[]') : '127.0.0.1')
+    ->asValue(!empty($_SERVER['SERVER_NAME']) && '' === preg_replace('/(?:^\[)?[a-zA-Z0-9-:\]_]+\.?/', '', $_SERVER['SERVER_NAME']) ? trim($_SERVER['SERVER_NAME'], '[]') : gethostname())
 
     ->register('transport.smtp')
     ->asNewInstanceOf('Swift_Transport_EsmtpTransport')


### PR DESCRIPTION
when we use php-cli the variable SERVER_NAME does not exist. Need to use gethostname() to fetch the client host.

<!-- Please fill in this template according to the PR you're about to submit. -->

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc update?   | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT


when we use php-cli the variable SERVER_NAME does not exist. Need to use gethostname() to fetch the client host.
