### PR TITLE
Skip Swift_Smoke_HtmlWithAttachmentSmokeTest if the smoke tests aren't run

### DIFF
--- a/tests/smoke/Swift/Smoke/HtmlWithAttachmentSmokeTest.php
+++ b/tests/smoke/Swift/Smoke/HtmlWithAttachmentSmokeTest.php
@@ -5,10 +5,12 @@
  */
 class Swift_Smoke_HtmlWithAttachmentSmokeTest extends SwiftMailerSmokeTestCase
 {
-    private $_attFile;
+    private $attFile;
 
     protected function setUp()
     {
+        parent::setUp();
+
         $this->attFile = __DIR__.'/../../../_samples/files/textfile.zip';
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc update?   | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | N/A
| License       | MIT


Currently, the unit tests fail if the smoke tests aren't configured to run. This PR fixes this.

#SymfonyConHackday
