### PR TITLE
Fix exception containing stack trace

### DIFF
--- a/lib/classes/Swift/Transport/Esmtp/AuthHandler.php
+++ b/lib/classes/Swift/Transport/Esmtp/AuthHandler.php
@@ -179,7 +179,7 @@ class Swift_Transport_Esmtp_AuthHandler implements Swift_Transport_EsmtpHandler
                         }
                     } catch (Swift_TransportException $e) {
                         // keep the error message, but tries the other authenticators
-                        $errors[] = [$authenticator->getAuthKeyword(), $e];
+                        $errors[] = [$authenticator->getAuthKeyword(), $e->getMessage()];
                     }
                 }
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc update?   | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 
| License       | MIT

Right now the error message of `TransportException` can contain very long messages including stack traces of other exceptions. For example:

```
Failed to authenticate on SMTP server with username "example@domain.tld" using 1 possible authenticators. Authenticator LOGIN returned Swift_TransportException: Expected response code 235 but got code "535", with message "535-5.7.8 Username and Password not accepted. Learn more at
535 5.7.8  https://support.google.com/mail/?p=BadCredentials 202sm24485739wmt.8 - gsmtp
" in .../vendor/swiftmailer/swiftmailer/lib/classes/Swift/Transport/AbstractSmtpTransport.php:457
Stack trace:
#0 .../vendor/swiftmailer/swiftmailer/lib/classes/Swift/Transport/AbstractSmtpTransport.php(341): Swift_Transport_AbstractSmtpTransport->assertResponseCode('535-5.7.8 Usern...', Array)
#1 .../vendor/swiftmailer/swiftmailer/lib/classes/Swift/Transport/EsmtpTransport.php(305): Swift_Transport_AbstractSmtpTransport->executeCommand('\r\n', Array, Array, false, NULL)
#2 .../vendor/swiftmailer/swiftmailer/lib/classes/Swift/Transport/Esmtp/Auth/LoginAuthenticator.php(36): Swift_Transport_EsmtpTransport->executeCommand('\r\n', Array)
#3 .../vendor/swiftmailer/swiftmailer/lib/classes/Swift/Transport/Esmtp/AuthHandler.php(177): Swift_Transport_Esmtp_Auth_LoginAuthenticator->authenticate(Object(Swift_Transport_EsmtpTransport), 'example@d...', '')
#4 .../vendor/swiftmailer/swiftmailer/lib/classes/Swift/Transport/EsmtpTransport.php(371): Swift_Transport_Esmtp_AuthHandler->afterEhlo(Object(Swift_Transport_EsmtpTransport))
#5 .../vendor/swiftmailer/swiftmailer/lib/classes/Swift/Transport/AbstractSmtpTransport.php(148): Swift_Transport_EsmtpTransport->doHeloCommand()
#6 .../src/AppBundle/Service/Mailer/OptionsAwareTransport.php(68): Swift_Transport_AbstractSmtpTransport->start()
#7 .../src/AppBundle/Controller/SystemStatusController.php(69): AppBundle\Service\Mailer\OptionsAwareTransport->realStart()
#8 .../vendor/symfony/http-kernel/HttpKernel.php(151): AppBundle\Controller\SystemStatusController->checkMailerAction()
#9 .../vendor/symfony/http-kernel/HttpKernel.php(68): Symfony\Component\HttpKernel\HttpKernel->handleRaw(Object(Symfony\Component\HttpFoundation\Request), 1)
#10 .../vendor/symfony/http-kernel/Kernel.php(200): Symfony\Component\HttpKernel\HttpKernel->handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#11 .../web/app_dev.php(49): Symfony\Component\HttpKernel\Kernel->handle(Object(Symfony\Component\HttpFoundation\Request))
#12 {main}.
```

In my opinion the exception message should only contain messages of the other exceptions, not their stack traces. For example the exception message above would be reduced to this:

```
Failed to authenticate on SMTP server with username "example@domain.tld" using 1 possible authenticators. Authenticator LOGIN returned Expected response code 235 but got code "535", with message "535-5.7.8 Username and Password not accepted. Learn more at
535 5.7.8  https://support.google.com/mail/?p=BadCredentials 202sm24485739wmt.8 - gsmtp ".
```