### PR TITLE
Issues #1166 & #1165 :

### DIFF
--- a/lib/classes/Swift/EmailValidator.php
+++ b/lib/classes/Swift/EmailValidator.php
@@ -1,0 +1,172 @@
+<?php
+use Egulias\EmailValidator\EmailValidator;
+use Egulias\EmailValidator\Validation\RFCValidation;
+
+/*
+ * This file is part of SwiftMailer.
+ * (c) 2019 André Renaut
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * A class to encapsulate Egulias Email Validator
+ *
+ *
+ * For the record (wikipedia) :
+ *     the format of email addresses is : local-part@domain-part
+ *         the local  part may be up to 64 characters long and the domain may have a maximum of 255 characters.
+ *         the domain part is a list of dot-separated DNS labels, each label being limited to a length of 63 characters
+ *     this rule is only applied by function rfc822 (so email gets validated by either two others) !
+ *
+ * @author André Renaut
+ */
+class Swift_EmailValidator
+{
+    private $rfc2822_validator = null;
+
+    private $rfc653x_validator = null;
+    private $rfc653x_rules     = null;
+
+    public $rfc     = null;
+    public $message = null;
+
+    function __construct()
+    {
+    }
+
+    /**
+     * @param string $email
+     */
+    public function isValid( $email )
+    {
+        switch( true )
+        {
+            case ( $this->rfc822(  $email ) ) :
+            break;
+            case ( $this->rfc2822( $email ) ) :
+            break;
+            case (( defined('SWIFT_ADDRESSENCODER' )   &&
+                  ( SWIFT_ADDRESSENCODER == 'utf8' ) ) &&
+                  ( $this->rfc653x( $email )       ) ) :
+            break;
+            default :
+                return $this->rfc = false;
+            break;
+        }
+        return true;
+    }
+
+    /**
+    *    rfc822 - Standard for the Format of ARPA Internet Text Messages
+    * 
+    *    For the record (php.net) : 
+    *    This validates e-mail addresses against the syntax in RFC 822, 
+    *    with the exceptions that comments and whitespace folding
+    *    and dotless domain names are not supported.
+    *
+    * @param string $email
+    */
+    private function rfc822( $email )
+    {
+         $this->rfc = 'rfc822';
+         return filter_var( $email, FILTER_VALIDATE_EMAIL );
+    }
+
+    /**
+    *    rfc2822 - Internet Message Format
+    *
+    *   inspired by deprecated Swift_Mime_Grammar
+    *
+    * @param string $email
+    */
+    protected function rfc2822( $email )
+    {
+        $this->rfc = 'rfc822';
+        return $this->isValid_rfc2822( $email );
+    }
+
+    /**
+    *    rfc5321 - Simple Mail Transfer Protocol
+    *    rfc5322 - Internet Message Format
+    */
+
+    // nothing here
+
+    /**
+    *    rfc6530 - Overview and Framework for Internationalized Email
+    *    rfc6531 - SMTP Extension for Internationalized Email
+    *    rfc6532 - Internationalized Email Headers
+    *
+    * @param string $email
+    */
+    protected function rfc653x( $email )
+    {
+        $this->rfc = 'rfc653x';
+        if ( !isset( $this->rfc653x_validator ) ) 
+        {
+            $this->rfc653x_validator = new EmailValidator;
+            $this->rfc653x_rules     = new RFCValidation();
+        }
+        return $this->rfc653x_validator->isValid( $email, $this->rfc653x_rules );
+    }
+
+    //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\\
+    //*   Defines the grammar to use for validation,
+    //*   implements the RFC 2822 (and friends) ABNF grammar definitions.
+
+    /**
+    *
+    * @param string $email
+    */
+    private function isValid_rfc2822( $email )
+    {
+        if ( !isset( $this->rfc2822_validator ) ) $this->initialize_rfc2822();
+        return ( preg_match( '/^' . $this->rfc2822_validator . '$/D', $email ) );
+    }
+
+    protected function initialize_rfc2822()
+    {
+        /*** Refer to RFC 2822 for ABNF grammar ***/
+        
+        //All basic building blocks
+        $g['NO-WS-CTL'] = '[\x01-\x08\x0B\x0C\x0E-\x19\x7F]';
+        $g['WSP'] = '[ \t]';
+        $g['CRLF'] = '(?:\r\n)';
+        $g['FWS'] = '(?:(?:' . $g['WSP'] . '*' . $g['CRLF'] . ')?' . $g['WSP'] . ')';
+        $g['text'] = '[\x00-\x08\x0B\x0C\x0E-\x7F]';
+        $g['quoted-pair'] = '(?:\\\\' . $g['text'] . ')';
+        $g['ctext'] = '(?:' . $g['NO-WS-CTL'] . '|[\x21-\x27\x2A-\x5B\x5D-\x7E])';
+        //Uses recursive PCRE (?1) -- 
+        $g['ccontent'] = '(?:' . $g['ctext'] . '|' . $g['quoted-pair'] . '|(?1))';
+        $g['comment'] = '(\((?:' . $g['FWS'] . '|' . $g['ccontent']. ')*' . $g['FWS'] . '?\))';
+        $g['CFWS'] = '(?:(?:' . $g['FWS'] . '?' . $g['comment'] . ')*(?:(?:' . $g['FWS'] . '?' . $g['comment'] . ')|' . $g['FWS'] . '))';
+        $g['qtext'] = '(?:' . $g['NO-WS-CTL'] . '|[\x21\x23-\x5B\x5D-\x7E])';
+        $g['qcontent'] = '(?:' . $g['qtext'] . '|' . $g['quoted-pair'] . ')';
+        $g['quoted-string'] = '(?:' . $g['CFWS'] . '?"' . '(' . $g['FWS'] . '?' . $g['qcontent'] . ')*' . $g['FWS'] . '?"' . $g['CFWS'] . '?)';
+        $g['atext'] = '[a-zA-Z0-9!#\$%&\'\*\+\-\/=\?\^_`\{\}\|~]';
+        $g['atom'] = '(?:' . $g['CFWS'] . '?' . $g['atext'] . '+' . $g['CFWS'] . '?)';
+        $g['dot-atom-text'] = '(?:' . $g['atext'] . '+' . '(\.' . $g['atext'] . '+)*)';
+        $g['dot-atom'] = '(?:' . $g['CFWS'] . '?' . $g['dot-atom-text'] . '+' . $g['CFWS'] . '?)';
+        $g['word'] = '(?:' . $g['atom'] . '|' . $g['quoted-string'] . ')';
+        $g['phrase'] = '(?:' . $g['word'] . '+?)';
+        $g['no-fold-quote'] = '(?:"(?:' . $g['qtext'] . '|' . $g['quoted-pair'] . ')*")';
+        $g['dtext'] = '(?:' . $g['NO-WS-CTL'] . '|[\x21-\x5A\x5E-\x7E])';
+        $g['no-fold-literal'] = '(?:\[(?:' . $g['dtext'] . '|' . $g['quoted-pair'] . ')*\])';
+
+        //Message IDs
+        $g['id-left'] = '(?:' . $g['dot-atom-text'] . '|' . $g['no-fold-quote'] . ')';
+        $g['id-right'] = '(?:' . $g['dot-atom-text'] . '|' . $g['no-fold-literal'] . ')';
+
+        //Addresses, mailboxes and paths
+        $g['local-part'] = '(?:' . $g['dot-atom'] . '|' . $g['quoted-string'] . ')';
+        $g['dcontent'] = '(?:' . $g['dtext'] . '|' . $g['quoted-pair'] . ')';
+        $g['domain-literal'] = '(?:' . $g['CFWS'] . '?\[(' . $g['FWS'] . '?' . $g['dcontent'] . ')*?' . $g['FWS'] . '?\]' . $g['CFWS'] . '?)';
+        $g['domain'] = '(?:' . $g['dot-atom'] . '|' . $g['domain-literal'] . ')';
+
+        $this->rfc2822_validator = '(?:' . $g['local-part'] . '@' . $g['domain'] . ')';
+
+        unset( $g );
+    }
+}

--- a/lib/classes/Swift/Mime/Headers/IdentificationHeader.php
+++ b/lib/classes/Swift/Mime/Headers/IdentificationHeader.php
@@ -8,9 +8,6 @@
  * file that was distributed with this source code.
  */
 
-use Egulias\EmailValidator\EmailValidator;
-use Egulias\EmailValidator\Validation\RFCValidation;
-
 /**
  * An ID MIME Header for something like Message-ID or Content-ID.
  *
@@ -28,7 +25,7 @@ class Swift_Mime_Headers_IdentificationHeader extends Swift_Mime_Headers_Abstrac
     private $ids = [];
 
     /**
-     * The strict EmailValidator.
+     * Swift_EmailValidator.
      *
      * @var EmailValidator
      */
@@ -41,7 +38,7 @@ class Swift_Mime_Headers_IdentificationHeader extends Swift_Mime_Headers_Abstrac
      *
      * @param string $name
      */
-    public function __construct($name, EmailValidator $emailValidator, Swift_AddressEncoder $addressEncoder = null)
+    public function __construct($name, Swift_EmailValidator $emailValidator, Swift_AddressEncoder $addressEncoder = null)
     {
         $this->setFieldName($name);
         $this->emailValidator = $emailValidator;
@@ -179,7 +176,7 @@ class Swift_Mime_Headers_IdentificationHeader extends Swift_Mime_Headers_Abstrac
      */
     private function assertValidId($id)
     {
-        if (!$this->emailValidator->isValid($id, new RFCValidation())) {
+        if (!$this->emailValidator->isValid($id)) {
             throw new Swift_RfcComplianceException('Invalid ID given <'.$id.'>');
         }
     }

--- a/lib/classes/Swift/Mime/Headers/MailboxHeader.php
+++ b/lib/classes/Swift/Mime/Headers/MailboxHeader.php
@@ -8,9 +8,6 @@
  * file that was distributed with this source code.
  */
 
-use Egulias\EmailValidator\EmailValidator;
-use Egulias\EmailValidator\Validation\RFCValidation;
-
 /**
  * A Mailbox Address MIME Header for something like From or Sender.
  *
@@ -26,7 +23,7 @@ class Swift_Mime_Headers_MailboxHeader extends Swift_Mime_Headers_AbstractHeader
     private $mailboxes = [];
 
     /**
-     * The strict EmailValidator.
+     * Swift_EmailValidator
      *
      * @var EmailValidator
      */
@@ -39,7 +36,7 @@ class Swift_Mime_Headers_MailboxHeader extends Swift_Mime_Headers_AbstractHeader
      *
      * @param string $name of Header
      */
-    public function __construct($name, Swift_Mime_HeaderEncoder $encoder, EmailValidator $emailValidator, Swift_AddressEncoder $addressEncoder = null)
+    public function __construct($name, Swift_Mime_HeaderEncoder $encoder, Swift_EmailValidator $emailValidator, Swift_AddressEncoder $addressEncoder = null)
     {
         $this->setFieldName($name);
         $this->setEncoder($encoder);
@@ -343,7 +340,7 @@ class Swift_Mime_Headers_MailboxHeader extends Swift_Mime_Headers_AbstractHeader
     }
 
     /**
-     * Throws an Exception if the address passed does not comply with RFC 2822.
+     * Throws an Exception if the address passed does not comply with applicable RFC.
      *
      * @param string $address
      *
@@ -351,9 +348,9 @@ class Swift_Mime_Headers_MailboxHeader extends Swift_Mime_Headers_AbstractHeader
      */
     private function assertValidAddress($address)
     {
-        if (!$this->emailValidator->isValid($address, new RFCValidation())) {
+        if (!$this->emailValidator->isValid($address)) {
             throw new Swift_RfcComplianceException(
-                'Address in mailbox given ['.$address.'] does not comply with RFC 2822, 3.6.2.'
+                'Address in mailbox given ['.$address.'] does not comply with applicable RFC.'
             );
         }
     }

--- a/lib/classes/Swift/Mime/Headers/PathHeader.php
+++ b/lib/classes/Swift/Mime/Headers/PathHeader.php
@@ -8,9 +8,6 @@
  * file that was distributed with this source code.
  */
 
-use Egulias\EmailValidator\EmailValidator;
-use Egulias\EmailValidator\Validation\RFCValidation;
-
 /**
  * A Path Header in Swift Mailer, such a Return-Path.
  *
@@ -26,7 +23,7 @@ class Swift_Mime_Headers_PathHeader extends Swift_Mime_Headers_AbstractHeader
     private $address;
 
     /**
-     * The strict EmailValidator.
+     * Swift_EmailValidator
      *
      * @var EmailValidator
      */
@@ -39,7 +36,7 @@ class Swift_Mime_Headers_PathHeader extends Swift_Mime_Headers_AbstractHeader
      *
      * @param string $name
      */
-    public function __construct($name, EmailValidator $emailValidator, Swift_AddressEncoder $addressEncoder = null)
+    public function __construct($name, Swift_EmailValidator $emailValidator, Swift_AddressEncoder $addressEncoder = null)
     {
         $this->setFieldName($name);
         $this->emailValidator = $emailValidator;
@@ -138,7 +135,7 @@ class Swift_Mime_Headers_PathHeader extends Swift_Mime_Headers_AbstractHeader
     }
 
     /**
-     * Throws an Exception if the address passed does not comply with RFC 2822.
+     * Throws an Exception if the address passed does not comply with applicable RFC.
      *
      * @param string $address
      *
@@ -146,9 +143,9 @@ class Swift_Mime_Headers_PathHeader extends Swift_Mime_Headers_AbstractHeader
      */
     private function assertValidAddress($address)
     {
-        if (!$this->emailValidator->isValid($address, new RFCValidation())) {
+        if (!$this->emailValidator->isValid($address)) {
             throw new Swift_RfcComplianceException(
-                'Address set in PathHeader does not comply with addr-spec of RFC 2822.'
+                'Address set in PathHeader does not comply with applicable RFC.'
             );
         }
     }

--- a/lib/classes/Swift/Mime/SimpleHeaderFactory.php
+++ b/lib/classes/Swift/Mime/SimpleHeaderFactory.php
@@ -8,8 +8,6 @@
  * file that was distributed with this source code.
  */
 
-use Egulias\EmailValidator\EmailValidator;
-
 /**
  * Creates MIME headers.
  *
@@ -23,7 +21,7 @@ class Swift_Mime_SimpleHeaderFactory implements Swift_Mime_CharsetObserver
     /** The Encoder used by parameters */
     private $paramEncoder;
 
-    /** Strict EmailValidator */
+    /** Swift_EmailValidator */
     private $emailValidator;
 
     /** The charset of created Headers */
@@ -37,7 +35,7 @@ class Swift_Mime_SimpleHeaderFactory implements Swift_Mime_CharsetObserver
      *
      * @param string|null $charset
      */
-    public function __construct(Swift_Mime_HeaderEncoder $encoder, Swift_Encoder $paramEncoder, EmailValidator $emailValidator, $charset = null, Swift_AddressEncoder $addressEncoder = null)
+    public function __construct(Swift_Mime_HeaderEncoder $encoder, Swift_Encoder $paramEncoder, Swift_EmailValidator $emailValidator, $charset = null, Swift_AddressEncoder $addressEncoder = null)
     {
         $this->encoder = $encoder;
         $this->paramEncoder = $paramEncoder;

--- a/lib/classes/Swift/SmtpTransportSMTPUTF8.php
+++ b/lib/classes/Swift/SmtpTransportSMTPUTF8.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of SwiftMailer.
+ * (c) 2019 André Renaut
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * Sends Messages over SMTP with ESMTP & SMTPUTF8 support.
+ *
+ * @author     Chris Corbyn
+ *
+ * @method Swift_SmtpTransport_SMTPUTF8 	setUsername(string $username) Set the username to authenticate with.
+ * @method string              			getUsername()                 Get the username to authenticate with.
+ * @method Swift_SmtpTransport_SMTPUTF8 	setPassword(string $password) Set the password to authenticate with.
+ * @method string              			getPassword()                 Get the password to authenticate with.
+ * @method Swift_SmtpTransport_SMTPUTF8 	setAuthMode(string $mode)     Set the auth mode to use to authenticate.
+ * @method string              			getAuthMode()                 Get the auth mode to use to authenticate.
+ */
+class Swift_SmtpTransportSMTPUTF8 extends Swift_Transport_EsmtpTransport
+{
+    /**
+     * @param string $host
+     * @param int    $port
+     * @param string $encryption
+     */
+    public function __construct($host = 'localhost', $port = 25, $encryption = null)
+    {
+        call_user_func_array(
+            [$this, 'Swift_Transport_EsmtpTransport::__construct'],
+            Swift_DependencyContainer::getInstance()
+                ->createDependenciesFor('transport.smtp_SMTPUTF8')
+            );
+
+        $this->setHost($host);
+        $this->setPort($port);
+        $this->setEncryption($encryption);
+    }
+}

--- a/lib/dependency_maps/mime_deps.php
+++ b/lib/dependency_maps/mime_deps.php
@@ -7,7 +7,7 @@ Swift_DependencyContainer::getInstance()
     ->asValue('utf-8')
 
     ->register('email.validator')
-    ->asSharedInstanceOf('Egulias\EmailValidator\EmailValidator')
+    ->asSharedInstanceOf('Swift_EmailValidator')
 
     ->register('mime.idgenerator.idright')
     // As SERVER_NAME can come from the user in certain configurations, check that
@@ -68,7 +68,7 @@ Swift_DependencyContainer::getInstance()
         'mime.rfc2231encoder',
         'email.validator',
         'properties.charset',
-        'address.idnaddressencoder',
+        'address.' . SWIFT_ADDRESSENCODER . 'addressencoder',
     ])
 
     ->register('mime.headerset')

--- a/lib/dependency_maps/transport_deps.php
+++ b/lib/dependency_maps/transport_deps.php
@@ -17,6 +17,16 @@ Swift_DependencyContainer::getInstance()
         'address.idnaddressencoder',
     ])
 
+    ->register('transport.smtp_SMTPUTF8')
+    ->asNewInstanceOf('Swift_Transport_EsmtpTransport')
+    ->withDependencies([
+        'transport.buffer',
+        'transport.smtputf8handlers',
+        'transport.eventdispatcher',
+        'transport.localdomain',
+        'address.utf8addressencoder',
+    ])
+
     ->register('transport.sendmail')
     ->asNewInstanceOf('Swift_Transport_SendmailTransport')
     ->withDependencies([
@@ -46,6 +56,10 @@ Swift_DependencyContainer::getInstance()
     ->register('transport.smtphandlers')
     ->asArray()
     ->withDependencies(['transport.authhandler'])
+
+    ->register('transport.smtputf8handlers')
+    ->asArray()
+    ->withDependencies(['transport.authhandler', 'transport.smtputf8handler'])
 
     ->register('transport.authhandler')
     ->asNewInstanceOf('Swift_Transport_Esmtp_AuthHandler')

--- a/lib/swift_required.php
+++ b/lib/swift_required.php
@@ -11,6 +11,7 @@
 require __DIR__.'/classes/Swift.php';
 
 Swift::registerAutoload(function () {
+    defined('SWIFT_ADDRESSENCODER') or define ('SWIFT_ADDRESSENCODER', 'idn');
     // Load in dependency maps
     require __DIR__.'/dependency_maps/cache_deps.php';
     require __DIR__.'/dependency_maps/mime_deps.php';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| Doc update?   | no
| BC breaks?    | yes/no
| Deprecations? | yes/no
| Fixed tickets | #1166 & #1165
| License       | MIT

* to make SMTPUTF8 working (#1166), 
  - New Smtp Transport refering to new dependency_maps/transport_deps (as long as SMTPUTF8 might not be supported by all smtp servers)
  - mime_deps are loaded at the first call of a Swift class
  - some mail headers have to be coded in utf8 as well
The only way i found is to create a constant : i called it SWIFT_ADDRESSENCODER.
This constant can take two values : 'idn' (default) or 'utf8'.
So before loading composer autoloader, i declare SWIFT_ADDRESSENCODER with value 'utf8'.

* Encapsulate Egulias class in a new class : Swift_EmailValidator (#1165)
  - Email validation limited to non-international emails (SWIFT_ADDRESSENCODER != 'utf8')
  - Files using Egulias EmailValidator modified
Needs testing !

I think you got the idea.
Last time on Github was 7 years ago ... wish me luck !

Merci de votre indulgence !

patch file hereunder
[#1166 & #1165.zip](https://github.com/swiftmailer/swiftmailer/files/2784452/1166.1165.zip)

