### PR TITLE
Make the default of debugHeadersData an array

### DIFF
--- a/lib/classes/Swift/Signers/DKIMSigner.php
+++ b/lib/classes/Swift/Signers/DKIMSigner.php
@@ -129,9 +129,9 @@ class Swift_Signers_DKIMSigner implements Swift_Signers_HeaderSigner
     /**
      * If debugHeaders is set store debugData here.
      *
-     * @var string
+     * @var string[]
      */
-    private $debugHeadersData = '';
+    private $debugHeadersData = [];
 
     /**
      * Stores the bodyHash.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc update?   | ?
| BC breaks?    | ?
| Deprecations? | no
| Fixed tickets |
| License       | MIT


See https://github.com/php/php-src/blob/PHP-7.1.26/UPGRADING#L81-L82

> The empty index operator (e.g. $str[] = $x) is not supported for strings
> anymore, and throws a fatal error instead of silently converting to array.

```
php > $x = new stdClass();
php > $x->prop = '';
php > $x->prop[] = 'value';
Warning: Uncaught Error: [] operator not supported for strings in php shell code:1
Stack trace:
#0 {main}
  thrown in php shell code on line 1
```

Detected via static analysis.

**The same issue is also detected in v5.4.12 in private $_debugHeadersData - I'm not sure if v5 aims to support php 7.1**
