### PR TITLE
Do not allow attachments with duplicate content-id

### DIFF
--- a/lib/classes/Swift/Mime/SimpleMessage.php
+++ b/lib/classes/Swift/Mime/SimpleMessage.php
@@ -524,6 +524,10 @@ class Swift_Mime_SimpleMessage extends Swift_Mime_MimePart
      */
     public function attach(Swift_Mime_SimpleMimeEntity $entity)
     {
+        if ($entity->getHeaders()->has('Content-ID')) {
+            $this->detach($entity);
+        }
+
         $this->setChildren(array_merge($this->getChildren(), [$entity]));
 
         return $this;

--- a/tests/unit/Swift/Mime/AbstractMimeEntityTest.php
+++ b/tests/unit/Swift/Mime/AbstractMimeEntityTest.php
@@ -990,7 +990,7 @@ abstract class Swift_Mime_AbstractMimeEntityTest extends \SwiftMailerTestCase
 
     abstract protected function createEntity($headers, $encoder, $cache);
 
-    protected function createChild($level = null, $string = '', $stub = true)
+    protected function createChild($level = null, $string = '', $stub = true, $headers = [])
     {
         $child = $this->getMockery('Swift_Mime_SimpleMimeEntity')->shouldIgnoreMissing();
         if (isset($level)) {
@@ -1001,6 +1001,9 @@ abstract class Swift_Mime_AbstractMimeEntityTest extends \SwiftMailerTestCase
         $child->shouldReceive('toString')
               ->zeroOrMoreTimes()
               ->andReturn($string);
+        $child->shouldReceive('getHeaders')
+              ->zeroOrMoreTimes()
+              ->andReturn($this->createHeaderSet($headers));
 
         return $child;
     }

--- a/tests/unit/Swift/Mime/SimpleMessageTest.php
+++ b/tests/unit/Swift/Mime/SimpleMessageTest.php
@@ -782,6 +782,22 @@ class Swift_Mime_SimpleMessageTest extends Swift_Mime_MimePartTest
         $this->assertEquals('cid:foo@bar', $message->embed($child));
     }
 
+    public function testDuplicateAttachmentId()
+    {
+        $message = $this->createMessage(
+            $this->createHeaderSet(),
+            $this->createEncoder(),
+            $this->createCache()
+        );
+
+        $child = $this->createChild(null, '', true, ['Content-ID' => 'foo@bar']);
+
+        $message->attach($child);
+        $message->attach($child);
+
+        $this->assertCount(1, $message->getChildren());
+    }
+
     public function testFluidInterface()
     {
         $child = $this->createChild();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| Doc update?   | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #1173
| License       | MIT

As per RFC2392 Content-ID should be unique:

> The Content-ID of a MIME body part is required to be globally
> unique. However, in many systems that store messages, body
> parts are not indexed independently their context (message).

This patch de-duplicates attachments with a Content-ID header,
potentially also lowering the total size of the message.

This partially fixes #1173, but a more thorough fix would de-duplicate on calls to `toString` as well, in case someone adds a header to a `SimpleMimeEntity` after attaching. I'm not sure what would be involved with that, so I'd rather not touch it myself.