### PR TITLE
fix(SimpleHeaderSet): invalid return type for `get()`

### DIFF
--- a/lib/classes/Swift/Mime/SimpleHeaderSet.php
+++ b/lib/classes/Swift/Mime/SimpleHeaderSet.php
@@ -177,7 +177,7 @@ class Swift_Mime_SimpleHeaderSet implements Swift_Mime_CharsetObserver
      * @param string $name
      * @param int    $index
      *
-     * @return Swift_Mime_Header
+     * @return Swift_Mime_Header|null
      */
     public function get($name, $index = 0)
     {


### PR DESCRIPTION
<!-- Please fill in this template according to the PR you're about to submit. -->

phpdoc comment says the `get` method returns NULL if the header is not present, but it's not reflected in the `@return`

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc update?   | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | n/a
| License       | MIT


<!-- Replace this comment by the description of your issue. -->
