### PR TITLE
Fix error message when connecting to a stream raises an error before connect()

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,7 +4,7 @@ Changelog
 6.2.2 (2019-XX-XX)
 ------------------
 
- * n/a
+ * fixed error message when connecting to a stream raises an error before connect()
 
 6.2.1 (2019-04-21)
 ------------------


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc update?   | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #1201
| License       | MIT


<!-- Replace this comment by the description of your issue. -->
