### PR TITLE
Fix RfcComplianceException handling on messages without To field

### DIFF
--- a/lib/classes/Swift/Mailer.php
+++ b/lib/classes/Swift/Mailer.php
@@ -70,8 +70,16 @@ class Swift_Mailer
         try {
             $sent = $this->transport->send($message, $failedRecipients);
         } catch (Swift_RfcComplianceException $e) {
-            foreach ($message->getTo() as $address => $name) {
-                $failedRecipients[] = $address;
+            $recipientTypes = ['To', 'Cc', 'Bcc'];
+
+            foreach ($recipientTypes as $recipientType) {
+                $recipients = call_user_func([$message, 'get'.$recipientType]);
+
+                if (is_array($recipients)) {
+                    foreach ($recipients as $address => $name) {
+                        $failedRecipients[] = $address;
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc update?   | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #1209 
| License       | MIT

See issue #1209 for description of the bug.
This patch does the following:

allow for messages without To field
include Cc- and Bcc-Fields into failedRecipients array on RfcComplianceException