### PR TITLE
bugfix and code refactor: $response var might be initialized fixed; nested condition is converted to guard clause in to improve code readability

### DIFF
--- a/lib/classes/Swift/Transport/AbstractSmtpTransport.php
+++ b/lib/classes/Swift/Transport/AbstractSmtpTransport.php
@@ -331,20 +331,23 @@ abstract class Swift_Transport_AbstractSmtpTransport implements Swift_Transport
         }
 
         $this->pipeline[] = [$command, $seq, $codes, $address];
+
         if ($pipeline && $this->pipelining) {
-            $response = null;
-        } else {
-            while ($this->pipeline) {
-                list($command, $seq, $codes, $address) = array_shift($this->pipeline);
-                $response = $this->getFullResponse($seq);
-                try {
-                    $this->assertResponseCode($response, $codes);
-                } catch (Swift_TransportException $e) {
-                    if ($this->pipeline && $address) {
-                        $failures[] = $address;
-                    } else {
-                        $this->throwException($e);
-                    }
+            return null;
+        }
+
+        $response = null;
+
+        while ($this->pipeline) {
+            list($command, $seq, $codes, $address) = array_shift($this->pipeline);
+            $response = $this->getFullResponse($seq);
+            try {
+                $this->assertResponseCode($response, $codes);
+            } catch (Swift_TransportException $e) {
+                if ($this->pipeline && $address) {
+                    $failures[] = $address;
+                } else {
+                    $this->throwException($e);
                 }
             }
         }


### PR DESCRIPTION


<!-- Please fill in this template according to the PR you're about to submit. -->

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes/no
| Doc update?   | yes/no
| BC breaks?    | yes/no
| Deprecations? | yes/no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT


$response var might be initialized - added its initialization to null
also nested condition is converted to guard clause in order to improve code readability
