### PR TITLE
Added message expiration feature.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,7 @@
 Changelog
 =========
+6.3.0 (2019-XX-XX)
+ * Added message expiration feature @cyberemissary
 
 6.2.2 (2019-XX-XX)
 ------------------

--- a/lib/classes/Swift/ConfigurableSpool.php
+++ b/lib/classes/Swift/ConfigurableSpool.php
@@ -21,6 +21,9 @@ abstract class Swift_ConfigurableSpool implements Swift_Spool
     /** The time limit per flush */
     private $time_limit;
 
+    /** The maximum attempts to resend the message in case of failures */
+    private $resend_attempts = 30;
+
     /**
      * Sets the maximum number of messages to send per flush.
      *
@@ -59,5 +62,25 @@ abstract class Swift_ConfigurableSpool implements Swift_Spool
     public function getTimeLimit()
     {
         return $this->time_limit;
+    }
+
+    /**
+     * Gets the maximum send attempts for a single message in case of errors.
+     *
+     * @return int Max attempts
+     */
+    public function getResendAttempts()
+    {
+        return $this->resend_attempts;
+    }
+
+    /**
+     * Sets the maximum send attempts for a single message in case of errors.
+     *
+     * @param int $attempts Max attempts
+     */
+    public function setResendAttempts($attempts)
+    {
+        $this->resend_attempts = (int) $attempts;
     }
 }

--- a/tests/unit/Swift/FileSpoolTest.php
+++ b/tests/unit/Swift/FileSpoolTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @covers \Swift_FileSpool
+ */
+class FileSpoolTest extends \PHPUnit\Framework\TestCase
+{
+    /** @var string */
+    private $path;
+
+    protected function setUp()
+    {
+        $this->getName(false);
+        // make sure we start with clean directory every time
+        $this->path = sys_get_temp_dir().'/'.$this->getName(false).time();
+        @mkdir($this->path);
+    }
+
+    protected function tearDown()
+    {
+        $this->cleanupDir($this->path);
+    }
+
+    private function cleanupDir($dir)
+    {
+        foreach (new DirectoryIterator($dir) as $file) {
+            if ($file->isDot()) {
+                continue;
+            }
+            $path = $file->getPathname();
+            $file->isDir() ? $this->cleanupDir($path) : unlink($path);
+        }
+
+        rmdir($dir);
+    }
+
+    public function testRetryAttempts()
+    {
+        $moreAttemptsFile = $this->path.'/abc.9.message.sending';
+        $afterRecover = $this->path.'/abc.10.message';
+        $maxReached = $this->path.'/max.10.message.sending';
+        $expired = $this->path.'/expired/max.10.message';
+
+        file_put_contents($moreAttemptsFile, '');
+        file_put_contents($maxReached, '');
+
+        $spool = new Swift_FileSpool($this->path);
+        $spool->setResendAttempts(10);
+
+        $spool->recover(0);
+
+        $this->assertTrue(is_file($afterRecover));
+        $this->assertFalse(is_file($moreAttemptsFile));
+        $this->assertFalse(is_file($maxReached));
+        $this->assertTrue(is_file($expired));
+    }
+
+    public function testRecoveryTime()
+    {
+        $moreAttemptsFile = $this->path.'/abc.9.message.sending';
+        $maxReached = $this->path.'/max.10.message.sending';
+
+        file_put_contents($moreAttemptsFile, '');
+        file_put_contents($maxReached, '');
+
+        $spool = new Swift_FileSpool($this->path);
+
+        $spool->recover(); // nothing should change if files have not reach the timeout
+
+        $this->assertTrue(is_file($moreAttemptsFile));
+        $this->assertTrue(is_file($maxReached));
+    }
+
+    public function testQueueMessage()
+    {
+        $spool = new Swift_FileSpool($this->path);
+
+        $message = new Swift_Message('Test');
+        $spool->queueMessage($message);
+
+        $foundMessage = false;
+        foreach (new DirectoryIterator($this->path) as $file) {
+            if ($file->isDot()) {
+                continue;
+            }
+
+            $file = $file->getRealPath();
+            @unlink($file);
+
+            if (preg_match('/\.(\d+)\.message$/i', $file, $matches)) {
+                $this->assertEquals(0, $matches[1]);
+                $foundMessage = true;
+            }
+        }
+
+        $this->assertTrue($foundMessage);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Doc update?   | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #311
| License       | MIT

This PR adds a message expiration feature. Basically the idea is to eventually stop trying to resend the same message over and over again if it keep failing (which eventually results in the issue described in #311). 

File spool will now add an *attempt* number to the message filename and use that to track how many delivery attempts were done on that particular file. 

When the maximum retry attempts have been reached the failed message will be moved to `expired` directory inside the spool directory, so administrators can potentially review those messages if needed.
