### PR TITLE
Sleep fixes

### DIFF
--- a/lib/classes/Swift/Plugins/AntiFloodPlugin.php
+++ b/lib/classes/Swift/Plugins/AntiFloodPlugin.php
@@ -131,7 +131,9 @@ class Swift_Plugins_AntiFloodPlugin implements Swift_Events_SendListener, Swift_
         if (isset($this->sleeper)) {
             $this->sleeper->sleep($seconds);
         } else {
-            sleep($seconds);
+            do {
+                $seconds = sleep($seconds);
+            } while ($seconds > 0);
         }
     }
 }

--- a/lib/classes/Swift/Plugins/ThrottlerPlugin.php
+++ b/lib/classes/Swift/Plugins/ThrottlerPlugin.php
@@ -134,7 +134,9 @@ class Swift_Plugins_ThrottlerPlugin extends Swift_Plugins_BandwidthMonitorPlugin
         if (isset($this->sleeper)) {
             $this->sleeper->sleep($seconds);
         } else {
-            sleep($seconds);
+            do {
+                $seconds = sleep($seconds);
+            } while ($seconds > 0);
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc update?   | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 
| License       | MIT

Sleep can be interrupted by pcntl signal receiving and returns the number of seconds left to sleep.