### PR TITLE
fix: wrong phpdoc for Swift_Mime_SimpleHeaderSet::get() method

### DIFF
--- a/lib/classes/Swift/Mime/SimpleHeaderSet.php
+++ b/lib/classes/Swift/Mime/SimpleHeaderSet.php
@@ -177,7 +177,7 @@ class Swift_Mime_SimpleHeaderSet implements Swift_Mime_CharsetObserver
      * @param string $name
      * @param int    $index
      *
-     * @return Swift_Mime_Header
+     * @return Swift_Mime_Header|null
      */
     public function get($name, $index = 0)
     {


### PR DESCRIPTION
<!-- Please fill in this template according to the PR you're about to submit. -->

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc update?   | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT


As per https://github.com/swiftmailer/swiftmailer/blob/master/lib/classes/Swift/Mime/SimpleHeaderSet.php#L190 `Swift_Mime_SimpleHeaderSet::get()` may return `Swift_Mime_Header|null`, but phpdoc states that it always returns `Swift_Mime_Header` which is not true and which breaks code validation tools like phpstan