### PR TITLE
Send RSET command when DATA commands fails.

### DIFF
--- a/lib/classes/Swift/Transport/AbstractSmtpTransport.php
+++ b/lib/classes/Swift/Transport/AbstractSmtpTransport.php
@@ -497,7 +497,13 @@ abstract class Swift_Transport_AbstractSmtpTransport implements Swift_Transport
 
         if (0 != $sent) {
             $sent += count($failedRecipients);
-            $this->doDataCommand($failedRecipients);
+            try {
+                $this->doDataCommand($failedRecipients);
+            } catch (Swift_TransportException $e) {
+                $this->reset();
+
+                throw $e;
+            }
             $sent -= count($failedRecipients);
 
             $this->streamMessage($message);


### PR DESCRIPTION
<!-- Please fill in this template according to the PR you're about to submit. -->

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc update?   | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | https://github.com/swiftmailer/swiftmailer/issues/1265
| License       | MIT

When using SMTP PIPELINING, unexpected replies may throw exceptions only when the pipeline is sent (in `doDataCommand()`). In that case the `MAIL` command remains open and might cause `503 Bad sequence of commands` error when the next `MAIL` command is issued.

Applied solution here is to send a `RSET` command in such case.

This is my first commit in this repository, feedback are more than welcome 🙂 
