### PR TITLE
Add missing Swift_RfcComplianceException throw tag

### DIFF
--- a/lib/classes/Swift/Mime/Headers/MailboxHeader.php
+++ b/lib/classes/Swift/Mime/Headers/MailboxHeader.php
@@ -255,6 +255,8 @@ class Swift_Mime_Headers_MailboxHeader extends Swift_Mime_Headers_AbstractHeader
      * @param string[] $mailboxes
      *
      * @return string[]
+     *
+     * @throws Swift_RfcComplianceException
      */
     protected function normalizeMailboxes(array $mailboxes)
     {

--- a/lib/classes/Swift/Mime/SimpleHeaderFactory.php
+++ b/lib/classes/Swift/Mime/SimpleHeaderFactory.php
@@ -53,6 +53,8 @@ class Swift_Mime_SimpleHeaderFactory implements Swift_Mime_CharsetObserver
      * @param array|string|null $addresses
      *
      * @return Swift_Mime_Header
+     *
+     * @throws Swift_RfcComplianceException
      */
     public function createMailboxHeader($name, $addresses = null)
     {

--- a/lib/classes/Swift/Mime/SimpleHeaderSet.php
+++ b/lib/classes/Swift/Mime/SimpleHeaderSet.php
@@ -65,6 +65,8 @@ class Swift_Mime_SimpleHeaderSet implements Swift_Mime_CharsetObserver
      *
      * @param string       $name
      * @param array|string $addresses
+     *
+     * @throws Swift_RfcComplianceException
      */
     public function addMailboxHeader($name, $addresses = null)
     {

--- a/lib/classes/Swift/Mime/SimpleMessage.php
+++ b/lib/classes/Swift/Mime/SimpleMessage.php
@@ -149,6 +149,8 @@ class Swift_Mime_SimpleMessage extends Swift_Mime_MimePart
      * @param string $name    optional
      *
      * @return $this
+     *
+     * @throws Swift_RfcComplianceException
      */
     public function setSender($address, $name = null)
     {
@@ -203,6 +205,8 @@ class Swift_Mime_SimpleMessage extends Swift_Mime_MimePart
      * @param string       $name      optional
      *
      * @return $this
+     *
+     * @throws Swift_RfcComplianceException
      */
     public function setFrom($addresses, $name = null)
     {
@@ -257,6 +261,8 @@ class Swift_Mime_SimpleMessage extends Swift_Mime_MimePart
      * @param string $name      optional
      *
      * @return $this
+     *
+     * @throws Swift_RfcComplianceException
      */
     public function setReplyTo($addresses, $name = null)
     {
@@ -312,6 +318,8 @@ class Swift_Mime_SimpleMessage extends Swift_Mime_MimePart
      * @param string $name      optional
      *
      * @return $this
+     *
+     * @throws Swift_RfcComplianceException
      */
     public function setTo($addresses, $name = null)
     {
@@ -364,6 +372,8 @@ class Swift_Mime_SimpleMessage extends Swift_Mime_MimePart
      * @param string $name      optional
      *
      * @return $this
+     *
+     * @throws Swift_RfcComplianceException
      */
     public function setCc($addresses, $name = null)
     {
@@ -416,6 +426,8 @@ class Swift_Mime_SimpleMessage extends Swift_Mime_MimePart
      * @param string $name      optional
      *
      * @return $this
+     *
+     * @throws Swift_RfcComplianceException
      */
     public function setBcc($addresses, $name = null)
     {
@@ -496,6 +508,8 @@ class Swift_Mime_SimpleMessage extends Swift_Mime_MimePart
      * @param array $addresses
      *
      * @return $this
+     *
+     * @throws Swift_RfcComplianceException
      */
     public function setReadReceiptTo($addresses)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Doc update?   | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #1272
| License       | MIT

Couple of function are possibly throwing `Swift_RfcComplianceException` ; it was documented, but the phpDoc wasn't up to date. Updating the phpDoc would be useful for static analysis because they're looking for missing `try/catch`.