### PR TITLE
FileByteStream compatibility with PHP 7.4

### DIFF
--- a/lib/classes/Swift/ByteStream/FileByteStream.php
+++ b/lib/classes/Swift/ByteStream/FileByteStream.php
@@ -81,7 +81,7 @@ class Swift_ByteStream_FileByteStream extends Swift_ByteStream_AbstractFilterabl
 
             // If we read one byte after reaching the end of the file
             // feof() will return false and an empty string is returned
-            if ('' === $bytes && feof($fp)) {
+            if (false === $bytes && feof($fp)) {
                 $this->resetReadHandle();
 
                 return false;

--- a/lib/classes/Swift/ByteStream/FileByteStream.php
+++ b/lib/classes/Swift/ByteStream/FileByteStream.php
@@ -81,7 +81,7 @@ class Swift_ByteStream_FileByteStream extends Swift_ByteStream_AbstractFilterabl
 
             // If we read one byte after reaching the end of the file
             // feof() will return false and an empty string is returned
-            if (false === $bytes && feof($fp)) {
+            if ((false === $bytes || '' === $bytes) && feof($fp)) {
                 $this->resetReadHandle();
 
                 return false;


### PR DESCRIPTION
| Q                  | A
| ------------- | ---
| Bug fix?         | yes
| New feature?  | no
| Doc update?   | no
| BC breaks?    | no
| Deprecations? | yes
| Fixed tickets | #
| License       | MIT

Since the deprecation of returning an empty string in the `fread` function when an error occurs, checking for `false` is required for compatibility with PHP7.4.

See: https://www.php.net/manual/en/migration74.incompatible.php#migration74.incompatible.core.fread-fwrite