### PR TITLE
don't use deprecated PHPUnit method

### DIFF
--- a/tests/acceptance/Swift/Mime/SimpleMessageAcceptanceTest.php
+++ b/tests/acceptance/Swift/Mime/SimpleMessageAcceptanceTest.php
@@ -679,7 +679,7 @@ class Swift_Mime_SimpleMessageAcceptanceTest extends \PHPUnit\Framework\TestCase
 
         $message->attach($attachment);
 
-        $this->assertRegExp(
+        $this->assertMatchesRegularExpression(
             '~^'.
             'Return-Path: <chris@w3style.co.uk>'."\r\n".
             'Message-ID: <'.$id.'>'."\r\n".
@@ -750,7 +750,7 @@ class Swift_Mime_SimpleMessageAcceptanceTest extends \PHPUnit\Framework\TestCase
 
         $cid = $file->getId();
 
-        $this->assertRegExp(
+        $this->assertMatchesRegularExpression(
             '~^'.
             'Return-Path: <chris@w3style.co.uk>'."\r\n".
             'Message-ID: <'.$id.'>'."\r\n".
@@ -834,7 +834,7 @@ class Swift_Mime_SimpleMessageAcceptanceTest extends \PHPUnit\Framework\TestCase
 
         $cid = $file->getId();
 
-        $this->assertRegExp(
+        $this->assertMatchesRegularExpression(
             '~^'.
             'Return-Path: <chris@w3style.co.uk>'."\r\n".
             'Message-ID: <'.$id.'>'."\r\n".
@@ -915,7 +915,7 @@ class Swift_Mime_SimpleMessageAcceptanceTest extends \PHPUnit\Framework\TestCase
 
         $message->detach($attachment);
 
-        $this->assertRegExp(
+        $this->assertMatchesRegularExpression(
             '~^'.
             'Return-Path: <chris@w3style.co.uk>'."\r\n".
             'Message-ID: <'.$id.'>'."\r\n".

--- a/tests/acceptance/Swift/Transport/StreamBuffer/AbstractStreamBufferAcceptanceTest.php
+++ b/tests/acceptance/Swift/Transport/StreamBuffer/AbstractStreamBufferAcceptanceTest.php
@@ -25,11 +25,11 @@ abstract class Swift_Transport_StreamBuffer_AbstractStreamBufferAcceptanceTest e
         $this->initializeBuffer();
 
         $line = $this->buffer->readLine(0);
-        $this->assertRegExp('/^[0-9]{3}.*?\r\n$/D', $line);
+        $this->assertMatchesRegularExpression('/^[0-9]{3}.*?\r\n$/D', $line);
         $seq = $this->buffer->write("QUIT\r\n");
         $this->assertTrue((bool) $seq);
         $line = $this->buffer->readLine($seq);
-        $this->assertRegExp('/^[0-9]{3}.*?\r\n$/D', $line);
+        $this->assertMatchesRegularExpression('/^[0-9]{3}.*?\r\n$/D', $line);
         $this->buffer->terminate();
     }
 
@@ -38,17 +38,17 @@ abstract class Swift_Transport_StreamBuffer_AbstractStreamBufferAcceptanceTest e
         $this->initializeBuffer();
 
         $line = $this->buffer->readLine(0);
-        $this->assertRegExp('/^[0-9]{3}.*?\r\n$/D', $line);
+        $this->assertMatchesRegularExpression('/^[0-9]{3}.*?\r\n$/D', $line);
 
         $seq = $this->buffer->write("HELO foo\r\n");
         $this->assertTrue((bool) $seq);
         $line = $this->buffer->readLine($seq);
-        $this->assertRegExp('/^[0-9]{3}.*?\r\n$/D', $line);
+        $this->assertMatchesRegularExpression('/^[0-9]{3}.*?\r\n$/D', $line);
 
         $seq = $this->buffer->write("QUIT\r\n");
         $this->assertTrue((bool) $seq);
         $line = $this->buffer->readLine($seq);
-        $this->assertRegExp('/^[0-9]{3}.*?\r\n$/D', $line);
+        $this->assertMatchesRegularExpression('/^[0-9]{3}.*?\r\n$/D', $line);
         $this->buffer->terminate();
     }
 

--- a/tests/acceptance/Swift/Transport/StreamBuffer/SocketTimeoutTest.php
+++ b/tests/acceptance/Swift/Transport/StreamBuffer/SocketTimeoutTest.php
@@ -53,7 +53,7 @@ class Swift_Transport_StreamBuffer_SocketTimeoutTest extends \PHPUnit\Framework\
         } catch (Exception $e) {
         }
         $this->assertInstanceOf('Swift_IoException', $e, 'IO Exception Not Thrown On Connection Timeout');
-        $this->assertRegExp('/Connection to .* Timed Out/', $e->getMessage());
+        $this->assertMatchesRegularExpression('/Connection to .* Timed Out/', $e->getMessage());
     }
 
     protected function tearDown(): void

--- a/tests/bug/Swift/Bug34Test.php
+++ b/tests/bug/Swift/Bug34Test.php
@@ -29,7 +29,7 @@ class Swift_Bug34Test extends \PHPUnit\Framework\TestCase
         $boundary = $message->getBoundary();
         $cidVal = $image->getId();
 
-        $this->assertRegExp(
+        $this->assertMatchesRegularExpression(
         '~^'.
         'Sender: Other <other@domain.tld>'."\r\n".
         'Message-ID: <'.$id.'>'."\r\n".

--- a/tests/bug/Swift/Bug35Test.php
+++ b/tests/bug/Swift/Bug35Test.php
@@ -28,7 +28,7 @@ class Swift_Bug35Test extends \PHPUnit\Framework\TestCase
         $date = preg_quote($message->getDate()->format('r'), '~');
         $boundary = $message->getBoundary();
 
-        $this->assertRegExp(
+        $this->assertMatchesRegularExpression(
         '~^'.
         'Sender: Other <other@domain.tld>'."\r\n".
         'Message-ID: <'.$id.'>'."\r\n".

--- a/tests/bug/Swift/Bug38Test.php
+++ b/tests/bug/Swift/Bug38Test.php
@@ -187,6 +187,6 @@ class Swift_Bug38Test extends \PHPUnit\Framework\TestCase
         while (false !== $bytes = $stream->read(8192)) {
             $string .= $bytes;
         }
-        $this->assertRegExp($pattern, $string, $message);
+        $this->assertMatchesRegularExpression($pattern, $string, $message);
     }
 }

--- a/tests/bug/Swift/Bug71Test.php
+++ b/tests/bug/Swift/Bug71Test.php
@@ -12,9 +12,9 @@ class Swift_Bug71Test extends \PHPUnit\Framework\TestCase
     public function testCallingToStringAfterSettingNewBodyReflectsChanges()
     {
         $this->message->setBody('BODY1');
-        $this->assertRegExp('/BODY1/', $this->message->toString());
+        $this->assertMatchesRegularExpression('/BODY1/', $this->message->toString());
 
         $this->message->setBody('BODY2');
-        $this->assertRegExp('/BODY2/', $this->message->toString());
+        $this->assertMatchesRegularExpression('/BODY2/', $this->message->toString());
     }
 }

--- a/tests/unit/Swift/Encoder/Base64EncoderTest.php
+++ b/tests/unit/Swift/Encoder/Base64EncoderTest.php
@@ -65,7 +65,7 @@ class Swift_Encoder_Base64EncoderTest extends \PHPUnit\Framework\TestCase
 
         for ($i = 0; $i < 30; ++$i) {
             $input = pack('C', random_int(0, 255));
-            $this->assertRegExp(
+            $this->assertMatchesRegularExpression(
                 '~^[a-zA-Z0-9/\+]{2}==$~', $this->encoder->encodeString($input),
                 '%s: A single byte should have 2 bytes of padding'
                 );
@@ -73,7 +73,7 @@ class Swift_Encoder_Base64EncoderTest extends \PHPUnit\Framework\TestCase
 
         for ($i = 0; $i < 30; ++$i) {
             $input = pack('C*', random_int(0, 255), random_int(0, 255));
-            $this->assertRegExp(
+            $this->assertMatchesRegularExpression(
                 '~^[a-zA-Z0-9/\+]{3}=$~', $this->encoder->encodeString($input),
                 '%s: Two bytes should have 1 byte of padding'
                 );
@@ -81,7 +81,7 @@ class Swift_Encoder_Base64EncoderTest extends \PHPUnit\Framework\TestCase
 
         for ($i = 0; $i < 30; ++$i) {
             $input = pack('C*', random_int(0, 255), random_int(0, 255), random_int(0, 255));
-            $this->assertRegExp(
+            $this->assertMatchesRegularExpression(
                 '~^[a-zA-Z0-9/\+]{4}$~', $this->encoder->encodeString($input),
                 '%s: Three bytes should have no padding'
                 );

--- a/tests/unit/Swift/Encoder/Rfc2231EncoderTest.php
+++ b/tests/unit/Swift/Encoder/Rfc2231EncoderTest.php
@@ -39,7 +39,7 @@ class Swift_Encoder_Rfc2231EncoderTest extends \SwiftMailerTestCase
         $encoded = $encoder->encodeString($string);
 
         foreach (explode("\r\n", $encoded) as $line) {
-            $this->assertRegExp($this->rfc2045Token, $line,
+            $this->assertMatchesRegularExpression($this->rfc2045Token, $line,
                 '%s: Encoder should always return a valid RFC 2045 token.');
         }
     }
@@ -69,7 +69,7 @@ class Swift_Encoder_Rfc2231EncoderTest extends \SwiftMailerTestCase
         $encoded = $encoder->encodeString($string);
 
         foreach (explode("\r\n", $encoded) as $line) {
-            $this->assertRegExp($this->rfc2045Token, $line,
+            $this->assertMatchesRegularExpression($this->rfc2045Token, $line,
                 '%s: Encoder should always return a valid RFC 2045 token.');
         }
     }

--- a/tests/unit/Swift/Mime/AbstractMimeEntityTest.php
+++ b/tests/unit/Swift/Mime/AbstractMimeEntityTest.php
@@ -166,7 +166,7 @@ abstract class Swift_Mime_AbstractMimeEntityTest extends \SwiftMailerTestCase
         $entity = $this->createEntity($this->createHeaderSet(),
             $this->createEncoder(), $this->createCache()
             );
-        $this->assertRegExp('/^.*?@.*?$/D', $entity->getId());
+        $this->assertMatchesRegularExpression('/^.*?@.*?$/D', $entity->getId());
     }
 
     public function testGenerateIdCreatesNewId()
@@ -367,7 +367,7 @@ abstract class Swift_Mime_AbstractMimeEntityTest extends \SwiftMailerTestCase
         $entity = $this->createEntity($this->createHeaderSet(),
             $this->createEncoder(), $this->createCache()
             );
-        $this->assertRegExp(
+        $this->assertMatchesRegularExpression(
             '/^[a-zA-Z0-9\'\(\)\+_\-,\.\/:=\?\ ]{0,69}[a-zA-Z0-9\'\(\)\+_\-,\.\/:=\?]$/D',
             $entity->getBoundary()
             );
@@ -608,7 +608,7 @@ abstract class Swift_Mime_AbstractMimeEntityTest extends \SwiftMailerTestCase
         $entity->setBoundary('xxx');
         $entity->setChildren([$part, $attachment]);
 
-        $this->assertRegExp(
+        $this->assertMatchesRegularExpression(
             '~^'.
             "Content-Type: multipart/mixed; boundary=\"xxx\"\r\n".
             "\r\n\r\n--xxx\r\n".

--- a/tests/unit/Swift/Mime/ContentEncoder/Base64ContentEncoderTest.php
+++ b/tests/unit/Swift/Mime/ContentEncoder/Base64ContentEncoderTest.php
@@ -88,7 +88,7 @@ class Swift_Mime_ContentEncoder_Base64ContentEncoderTest extends \SwiftMailerTes
                ->andReturn(false);
 
             $this->encoder->encodeByteStream($os, $is);
-            $this->assertRegExp('~^[a-zA-Z0-9/\+]{2}==$~', $collection->content,
+            $this->assertMatchesRegularExpression('~^[a-zA-Z0-9/\+]{2}==$~', $collection->content,
                 '%s: A single byte should have 2 bytes of padding'
                 );
         }
@@ -109,7 +109,7 @@ class Swift_Mime_ContentEncoder_Base64ContentEncoderTest extends \SwiftMailerTes
                ->andReturn(false);
 
             $this->encoder->encodeByteStream($os, $is);
-            $this->assertRegExp('~^[a-zA-Z0-9/\+]{3}=$~', $collection->content,
+            $this->assertMatchesRegularExpression('~^[a-zA-Z0-9/\+]{3}=$~', $collection->content,
                 '%s: Two bytes should have 1 byte of padding'
                 );
         }
@@ -130,7 +130,7 @@ class Swift_Mime_ContentEncoder_Base64ContentEncoderTest extends \SwiftMailerTes
                ->andReturn(false);
 
             $this->encoder->encodeByteStream($os, $is);
-            $this->assertRegExp('~^[a-zA-Z0-9/\+]{4}$~', $collection->content,
+            $this->assertMatchesRegularExpression('~^[a-zA-Z0-9/\+]{4}$~', $collection->content,
                 '%s: Three bytes should have no padding'
                 );
         }

--- a/tests/unit/Swift/Mime/Headers/UnstructuredHeaderTest.php
+++ b/tests/unit/Swift/Mime/Headers/UnstructuredHeaderTest.php
@@ -77,7 +77,7 @@ class Swift_Mime_Headers_UnstructuredHeaderTest extends \SwiftMailerTestCase
         $nonAsciiChar = pack('C', 0x8F);
         $header = $this->getHeader('X-Test', $this->getEncoder('Q', true));
         $header->setValue($nonAsciiChar);
-        $this->assertRegExp(
+        $this->assertMatchesRegularExpression(
             '~^[^:\x00-\x20\x80-\xFF]+: [^\x80-\xFF\r\n]+\r\n$~s',
             $header->toString()
             );
@@ -94,7 +94,7 @@ class Swift_Mime_Headers_UnstructuredHeaderTest extends \SwiftMailerTestCase
         $nonAsciiChar = pack('C', 0x8F);
         $header = $this->getHeader('X-Test', $this->getEncoder('Q', true));
         $header->setValue($nonAsciiChar);
-        $this->assertRegExp(
+        $this->assertMatchesRegularExpression(
             '~^X-Test: \=?.*?\?.*?\?.*?\?=\r\n$~s',
             $header->toString()
             );

--- a/tests/unit/Swift/Mime/IdGeneratorTest.php
+++ b/tests/unit/Swift/Mime/IdGeneratorTest.php
@@ -24,7 +24,7 @@ class Swift_Mime_IdGeneratorTest extends \PHPUnit\Framework\TestCase
 
         $id = $idGenerator->generateId();
         $this->assertTrue($emailValidator->isValid($id, new RFCValidation()));
-        $this->assertRegExp('/^.{32}@example.net$/', $id);
+        $this->assertMatchesRegularExpression('/^.{32}@example.net$/', $id);
 
         $anotherId = $idGenerator->generateId();
         $this->assertNotEquals($id, $anotherId);

--- a/tests/unit/Swift/Plugins/Reporters/HtmlReporterTest.php
+++ b/tests/unit/Swift/Plugins/Reporters/HtmlReporterTest.php
@@ -19,8 +19,8 @@ class Swift_Plugins_Reporters_HtmlReporterTest extends \PHPUnit\Framework\TestCa
             );
         $html = ob_get_clean();
 
-        $this->assertRegExp('~ok|pass~i', $html, '%s: Reporter should indicate pass');
-        $this->assertRegExp('~foo@bar\.tld~', $html, '%s: Reporter should show address');
+        $this->assertMatchesRegularExpression('~ok|pass~i', $html, '%s: Reporter should indicate pass');
+        $this->assertMatchesRegularExpression('~foo@bar\.tld~', $html, '%s: Reporter should show address');
     }
 
     public function testReportingFail()
@@ -31,8 +31,8 @@ class Swift_Plugins_Reporters_HtmlReporterTest extends \PHPUnit\Framework\TestCa
             );
         $html = ob_get_clean();
 
-        $this->assertRegExp('~fail~i', $html, '%s: Reporter should indicate fail');
-        $this->assertRegExp('~zip@button~', $html, '%s: Reporter should show address');
+        $this->assertMatchesRegularExpression('~fail~i', $html, '%s: Reporter should indicate fail');
+        $this->assertMatchesRegularExpression('~zip@button~', $html, '%s: Reporter should show address');
     }
 
     public function testMultipleReports()
@@ -46,9 +46,9 @@ class Swift_Plugins_Reporters_HtmlReporterTest extends \PHPUnit\Framework\TestCa
             );
         $html = ob_get_clean();
 
-        $this->assertRegExp('~ok|pass~i', $html, '%s: Reporter should indicate pass');
-        $this->assertRegExp('~foo@bar\.tld~', $html, '%s: Reporter should show address');
-        $this->assertRegExp('~fail~i', $html, '%s: Reporter should indicate fail');
-        $this->assertRegExp('~zip@button~', $html, '%s: Reporter should show address');
+        $this->assertMatchesRegularExpression('~ok|pass~i', $html, '%s: Reporter should indicate pass');
+        $this->assertMatchesRegularExpression('~foo@bar\.tld~', $html, '%s: Reporter should show address');
+        $this->assertMatchesRegularExpression('~fail~i', $html, '%s: Reporter should indicate fail');
+        $this->assertMatchesRegularExpression('~zip@button~', $html, '%s: Reporter should show address');
     }
 }

--- a/tests/unit/Swift/Signers/SMimeSignerTest.php
+++ b/tests/unit/Swift/Signers/SMimeSignerTest.php
@@ -542,7 +542,7 @@ OEL;
         $expected = str_replace("\n", "\r\n", $expected);
 
         $actual = self::getBodyOfMessage($actual);
-        if (!$this->assertRegExp('%^'.$expected.'$\s*%m', $actual)) {
+        if (!$this->assertMatchesRegularExpression('%^'.$expected.'$\s*%m', $actual)) {
             return false;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Doc update?   | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | N/A <!-- #-prefixed issue number(s), if any -->
| License       | MIT

`assertRegExp()` --> `assertMatchesRegularExpression()`

this method has been deprecated and will be removed in PHPUnit 10

https://github.com/sebastianbergmann/phpunit/issues/4086
