### PR TITLE
PHP 8 Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ matrix:
         - php: 7.2
         - php: 7.3
         - php: 7.4
+        - php: nightly #php 8
     fast_finish: true
 
 cache:

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": "^7.2.5",
+        "php": ">=7.2.5",
         "egulias/email-validator": "^2.0",
         "symfony/polyfill-iconv": "^1.0",
         "symfony/polyfill-mbstring": "^1.0",

--- a/tests/acceptance/Swift/ByteStream/FileByteStreamAcceptanceTest.php
+++ b/tests/acceptance/Swift/ByteStream/FileByteStreamAcceptanceTest.php
@@ -80,18 +80,18 @@ class Swift_ByteStream_FileByteStreamAcceptanceTest extends \PHPUnit\Framework\T
         $is1 = $this->createMockInputStream();
         $is2 = $this->createMockInputStream();
 
-        $is1->expects($this->at(0))
+        $is1->expects($this->exactly(2))
             ->method('write')
-            ->with('x');
-        $is1->expects($this->at(1))
+            ->withConsecutive(
+                ['x'],
+                ['y']
+            );
+        $is2->expects($this->exactly(2))
             ->method('write')
-            ->with('y');
-        $is2->expects($this->at(0))
-            ->method('write')
-            ->with('x');
-        $is2->expects($this->at(1))
-            ->method('write')
-            ->with('y');
+            ->withConsecutive(
+                ['x'],
+                ['y']
+            );
 
         $file->bind($is1);
         $file->bind($is2);
@@ -125,12 +125,12 @@ class Swift_ByteStream_FileByteStreamAcceptanceTest extends \PHPUnit\Framework\T
         $is1 = $this->createMockInputStream();
         $is2 = $this->createMockInputStream();
 
-        $is1->expects($this->at(0))
+        $is1->expects($this->exactly(2))
             ->method('write')
-            ->with('x');
-        $is1->expects($this->at(1))
-            ->method('write')
-            ->with('y');
+            ->withConsecutive(
+                ['x'],
+                ['y']
+            );
         $is2->expects($this->once())
             ->method('write')
             ->with('x');

--- a/tests/acceptance/Swift/Transport/StreamBuffer/AbstractStreamBufferAcceptanceTest.php
+++ b/tests/acceptance/Swift/Transport/StreamBuffer/AbstractStreamBufferAcceptanceTest.php
@@ -59,18 +59,18 @@ abstract class Swift_Transport_StreamBuffer_AbstractStreamBufferAcceptanceTest e
         $is1 = $this->createMockInputStream();
         $is2 = $this->createMockInputStream();
 
-        $is1->expects($this->at(0))
+        $is1->expects($this->exactly(2))
             ->method('write')
-            ->with('x');
-        $is1->expects($this->at(1))
+            ->withConsecutive(
+                ['x'],
+                ['y']
+            );
+        $is2->expects($this->exactly(2))
             ->method('write')
-            ->with('y');
-        $is2->expects($this->at(0))
-            ->method('write')
-            ->with('x');
-        $is2->expects($this->at(1))
-            ->method('write')
-            ->with('y');
+            ->withConsecutive(
+                ['x'],
+                ['y']
+            );
 
         $this->buffer->bind($is1);
         $this->buffer->bind($is2);
@@ -104,12 +104,12 @@ abstract class Swift_Transport_StreamBuffer_AbstractStreamBufferAcceptanceTest e
         $is1 = $this->createMockInputStream();
         $is2 = $this->createMockInputStream();
 
-        $is1->expects($this->at(0))
+        $is1->expects($this->exactly(2))
             ->method('write')
-            ->with('x');
-        $is1->expects($this->at(1))
-            ->method('write')
-            ->with('y');
+            ->withConsecutive(
+                ['x'],
+                ['y']
+            );
         $is2->expects($this->once())
             ->method('write')
             ->with('x');

--- a/tests/unit/Swift/ByteStream/ArrayByteStreamTest.php
+++ b/tests/unit/Swift/ByteStream/ArrayByteStreamTest.php
@@ -132,18 +132,18 @@ class Swift_ByteStream_ArrayByteStreamTest extends \PHPUnit\Framework\TestCase
         $is1 = $this->getMockBuilder('Swift_InputByteStream')->getMock();
         $is2 = $this->getMockBuilder('Swift_InputByteStream')->getMock();
 
-        $is1->expects($this->at(0))
+        $is1->expects($this->exactly(2))
             ->method('write')
-            ->with('x');
-        $is1->expects($this->at(1))
+            ->withConsecutive(
+                ['x'],
+                ['y']
+            );
+        $is2->expects($this->exactly(2))
             ->method('write')
-            ->with('y');
-        $is2->expects($this->at(0))
-            ->method('write')
-            ->with('x');
-        $is2->expects($this->at(1))
-            ->method('write')
-            ->with('y');
+            ->withConsecutive(
+                ['x'],
+                ['y']
+            );
 
         $bs->bind($is1);
         $bs->bind($is2);
@@ -175,12 +175,12 @@ class Swift_ByteStream_ArrayByteStreamTest extends \PHPUnit\Framework\TestCase
         $is1 = $this->getMockBuilder('Swift_InputByteStream')->getMock();
         $is2 = $this->getMockBuilder('Swift_InputByteStream')->getMock();
 
-        $is1->expects($this->at(0))
+        $is1->expects($this->exactly(2))
             ->method('write')
-            ->with('x');
-        $is1->expects($this->at(1))
-            ->method('write')
-            ->with('y');
+            ->withConsecutive(
+                ['x'],
+                ['y']
+            );
         $is2->expects($this->once())
             ->method('write')
             ->with('x');

--- a/tests/unit/Swift/CharacterStream/ArrayCharacterStreamTest.php
+++ b/tests/unit/Swift/CharacterStream/ArrayCharacterStreamTest.php
@@ -271,6 +271,7 @@ class Swift_CharacterStream_ArrayCharacterStreamTest extends \SwiftMailerTestCas
         $reader->shouldReceive('validateByteSequence')->once()->with([0xD0], 1)->andReturn(1);
         $reader->shouldReceive('validateByteSequence')->once()->with([0xD0], 1)->andReturn(1);
 
+        $stream->flushContents();
         $stream->importByteStream($os);
     }
 
@@ -302,6 +303,7 @@ class Swift_CharacterStream_ArrayCharacterStreamTest extends \SwiftMailerTestCas
         $reader->shouldReceive('validateByteSequence')->once()->with([0xD0], 1)->andReturn(1);
         $reader->shouldReceive('validateByteSequence')->once()->with([0xD0], 1)->andReturn(1);
 
+        $stream->flushContents();
         $stream->importByteStream($os);
 
         $this->assertIdenticalBinary(pack('C*', 0xD0, 0x94), $stream->read(1));

--- a/tests/unit/Swift/KeyCache/ArrayKeyCacheTest.php
+++ b/tests/unit/Swift/KeyCache/ArrayKeyCacheTest.php
@@ -87,15 +87,9 @@ class Swift_KeyCache_ArrayKeyCacheTest extends \PHPUnit\Framework\TestCase
     public function testByteStreamCanBeImported()
     {
         $os = $this->createOutputStream();
-        $os->expects($this->at(0))
+        $os->expects($this->exactly(3))
            ->method('read')
-           ->willReturn('abc');
-        $os->expects($this->at(1))
-           ->method('read')
-           ->willReturn('def');
-        $os->expects($this->at(2))
-           ->method('read')
-           ->willReturn(false);
+           ->willReturnOnConsecutiveCalls('abc', 'def', false);
 
         $is = $this->createKeyCacheInputStream();
         $cache = $this->createCache($is);
@@ -108,26 +102,14 @@ class Swift_KeyCache_ArrayKeyCacheTest extends \PHPUnit\Framework\TestCase
     public function testByteStreamCanBeAppended()
     {
         $os1 = $this->createOutputStream();
-        $os1->expects($this->at(0))
+        $os1->expects($this->exactly(3))
             ->method('read')
-            ->willReturn('abc');
-        $os1->expects($this->at(1))
-            ->method('read')
-            ->willReturn('def');
-        $os1->expects($this->at(2))
-            ->method('read')
-            ->willReturn(false);
+            ->willReturnOnConsecutiveCalls('abc', 'def', false);
 
         $os2 = $this->createOutputStream();
-        $os2->expects($this->at(0))
+        $os2->expects($this->exactly(3))
             ->method('read')
-            ->willReturn('xyz');
-        $os2->expects($this->at(1))
-            ->method('read')
-            ->willReturn('uvw');
-        $os2->expects($this->at(2))
-            ->method('read')
-            ->willReturn(false);
+            ->willReturnOnConsecutiveCalls('xyz', 'uvw', false);
 
         $is = $this->createKeyCacheInputStream(true);
 
@@ -146,15 +128,9 @@ class Swift_KeyCache_ArrayKeyCacheTest extends \PHPUnit\Framework\TestCase
     public function testByteStreamAndStringCanBeAppended()
     {
         $os = $this->createOutputStream();
-        $os->expects($this->at(0))
+        $os->expects($this->exactly(3))
            ->method('read')
-           ->willReturn('abc');
-        $os->expects($this->at(1))
-           ->method('read')
-           ->willReturn('def');
-        $os->expects($this->at(2))
-           ->method('read')
-           ->willReturn(false);
+           ->willReturnOnConsecutiveCalls('abc', 'def', false);
 
         $is = $this->createKeyCacheInputStream(true);
 

--- a/tests/unit/Swift/KeyCache/SimpleKeyCacheInputStreamTest.php
+++ b/tests/unit/Swift/KeyCache/SimpleKeyCacheInputStreamTest.php
@@ -7,15 +7,13 @@ class Swift_KeyCache_SimpleKeyCacheInputStreamTest extends \PHPUnit\Framework\Te
     public function testStreamWritesToCacheInAppendMode()
     {
         $cache = $this->getMockBuilder('Swift_KeyCache')->getMock();
-        $cache->expects($this->at(0))
+        $cache->expects($this->exactly(3))
               ->method('setString')
-              ->with($this->nsKey, 'foo', 'a', Swift_KeyCache::MODE_APPEND);
-        $cache->expects($this->at(1))
-              ->method('setString')
-              ->with($this->nsKey, 'foo', 'b', Swift_KeyCache::MODE_APPEND);
-        $cache->expects($this->at(2))
-              ->method('setString')
-              ->with($this->nsKey, 'foo', 'c', Swift_KeyCache::MODE_APPEND);
+              ->withConsecutive(
+                  [$this->nsKey, 'foo', 'a', Swift_KeyCache::MODE_APPEND],
+                  [$this->nsKey, 'foo', 'b', Swift_KeyCache::MODE_APPEND],
+                  [$this->nsKey, 'foo', 'c', Swift_KeyCache::MODE_APPEND]
+              );
 
         $stream = new Swift_KeyCache_SimpleKeyCacheInputStream();
         $stream->setKeyCache($cache);
@@ -45,15 +43,13 @@ class Swift_KeyCache_SimpleKeyCacheInputStreamTest extends \PHPUnit\Framework\Te
     public function testClonedStreamStillReferencesSameCache()
     {
         $cache = $this->getMockBuilder('Swift_KeyCache')->getMock();
-        $cache->expects($this->at(0))
+        $cache->expects($this->exactly(3))
               ->method('setString')
-              ->with($this->nsKey, 'foo', 'a', Swift_KeyCache::MODE_APPEND);
-        $cache->expects($this->at(1))
-              ->method('setString')
-              ->with($this->nsKey, 'foo', 'b', Swift_KeyCache::MODE_APPEND);
-        $cache->expects($this->at(2))
-              ->method('setString')
-              ->with('test', 'bar', 'x', Swift_KeyCache::MODE_APPEND);
+              ->withConsecutive(
+                  [$this->nsKey, 'foo', 'a', Swift_KeyCache::MODE_APPEND],
+                  [$this->nsKey, 'foo', 'b', Swift_KeyCache::MODE_APPEND],
+                  ['test', 'bar', 'x', Swift_KeyCache::MODE_APPEND]
+              );
 
         $stream = new Swift_KeyCache_SimpleKeyCacheInputStream();
         $stream->setKeyCache($cache);

--- a/tests/unit/Swift/Mime/HeaderEncoder/QpHeaderEncoderTest.php
+++ b/tests/unit/Swift/Mime/HeaderEncoder/QpHeaderEncoderTest.php
@@ -27,7 +27,7 @@ class Swift_Mime_HeaderEncoder_QpHeaderEncoderTest extends \SwiftMailerTestCase
                    ->andReturn([\ord('a')], [0x20], [0x09], [0x20], [\ord('b')], false);
 
         $encoder = $this->createEncoder($charStream);
-        $this->assertNotRegExp('~[ \t]~', $encoder->encodeString("a \t b"),
+        $this->assertDoesNotMatchRegularExpression('~[ \t]~', $encoder->encodeString("a \t b"),
             '%s: encoded-words in headers cannot contain LWSP as per RFC 2047.'
             );
     }

--- a/tests/unit/Swift/Mime/SimpleHeaderSetTest.php
+++ b/tests/unit/Swift/Mime/SimpleHeaderSetTest.php
@@ -204,14 +204,16 @@ class Swift_Mime_SimpleHeaderSetTest extends \PHPUnit\Framework\TestCase
     public function testHasCanDistinguishMultipleHeaders()
     {
         $factory = $this->createFactory();
-        $factory->expects($this->at(0))
+        $factory->expects($this->exactly(2))
                 ->method('createIdHeader')
-                ->with('Message-ID', 'some@id')
-                ->willReturn($this->createHeader('Message-ID'));
-        $factory->expects($this->at(1))
-                ->method('createIdHeader')
-                ->with('Message-ID', 'other@id')
-                ->willReturn($this->createHeader('Message-ID'));
+                ->withConsecutive(
+                    ['Message-ID', 'some@id'],
+                    ['Message-ID', 'other@id']
+                )
+                ->willReturnOnConsecutiveCalls(
+                    $this->createHeader('Message-ID'),
+                    $this->createHeader('Message-ID')
+                );
 
         $set = $this->createSet($factory);
         $set->addIdHeader('Message-ID', 'some@id');
@@ -239,18 +241,18 @@ class Swift_Mime_SimpleHeaderSetTest extends \PHPUnit\Framework\TestCase
         $header1 = $this->createHeader('Message-ID');
         $header2 = $this->createHeader('Message-ID');
         $factory = $this->createFactory();
-        $factory->expects($this->at(0))
+        $factory->expects($this->exactly(3))
                 ->method('createIdHeader')
-                ->with('Message-ID', 'some@id')
-                ->willReturn($header0);
-        $factory->expects($this->at(1))
-                ->method('createIdHeader')
-                ->with('Message-ID', 'other@id')
-                ->willReturn($header1);
-        $factory->expects($this->at(2))
-                ->method('createIdHeader')
-                ->with('Message-ID', 'more@id')
-                ->willReturn($header2);
+                ->withConsecutive(
+                    ['Message-ID', 'some@id'],
+                    ['Message-ID', 'other@id'],
+                    ['Message-ID', 'more@id']
+                )
+                ->willReturnOnConsecutiveCalls(
+                    $header0,
+                    $header1,
+                    $header2
+                );
 
         $set = $this->createSet($factory);
         $set->addIdHeader('Message-ID', 'some@id');
@@ -271,18 +273,18 @@ class Swift_Mime_SimpleHeaderSetTest extends \PHPUnit\Framework\TestCase
         $header1 = $this->createHeader('Message-ID');
         $header2 = $this->createHeader('Message-ID');
         $factory = $this->createFactory();
-        $factory->expects($this->at(0))
+        $factory->expects($this->exactly(3))
                 ->method('createIdHeader')
-                ->with('Message-ID', 'some@id')
-                ->willReturn($header0);
-        $factory->expects($this->at(1))
-                ->method('createIdHeader')
-                ->with('Message-ID', 'other@id')
-                ->willReturn($header1);
-        $factory->expects($this->at(2))
-                ->method('createIdHeader')
-                ->with('Message-ID', 'more@id')
-                ->willReturn($header2);
+                ->withConsecutive(
+                    ['Message-ID', 'some@id'],
+                    ['Message-ID', 'other@id'],
+                    ['Message-ID', 'more@id']
+                )
+                ->willReturnOnConsecutiveCalls(
+                    $header0,
+                    $header1,
+                    $header2
+                );
 
         $set = $this->createSet($factory);
         $set->addIdHeader('Message-ID', 'some@id');
@@ -300,18 +302,18 @@ class Swift_Mime_SimpleHeaderSetTest extends \PHPUnit\Framework\TestCase
         $header1 = $this->createHeader('Subject');
         $header2 = $this->createHeader('To');
         $factory = $this->createFactory();
-        $factory->expects($this->at(0))
+        $factory->expects($this->exactly(3))
                 ->method('createIdHeader')
-                ->with('Message-ID', 'some@id')
-                ->willReturn($header0);
-        $factory->expects($this->at(1))
-                ->method('createIdHeader')
-                ->with('Subject', 'thing')
-                ->willReturn($header1);
-        $factory->expects($this->at(2))
-                ->method('createIdHeader')
-                ->with('To', 'person@example.org')
-                ->willReturn($header2);
+                ->withConsecutive(
+                    ['Message-ID', 'some@id'],
+                    ['Subject', 'thing'],
+                    ['To', 'person@example.org']
+                )
+                ->willReturnOnConsecutiveCalls(
+                    $header0,
+                    $header1,
+                    $header2
+                );
 
         $set = $this->createSet($factory);
         $set->addIdHeader('Message-ID', 'some@id');
@@ -333,7 +335,7 @@ class Swift_Mime_SimpleHeaderSetTest extends \PHPUnit\Framework\TestCase
     {
         $header = $this->createHeader('Message-ID');
         $factory = $this->createFactory();
-        $factory->expects($this->at(0))
+        $factory->expects($this->once())
                 ->method('createIdHeader')
                 ->with('Message-ID', 'some@id')
                 ->willReturn($header);
@@ -349,14 +351,16 @@ class Swift_Mime_SimpleHeaderSetTest extends \PHPUnit\Framework\TestCase
         $header0 = $this->createHeader('Message-ID');
         $header1 = $this->createHeader('Message-ID');
         $factory = $this->createFactory();
-        $factory->expects($this->at(0))
+        $factory->expects($this->exactly(2))
                 ->method('createIdHeader')
-                ->with('Message-ID', 'some@id')
-                ->willReturn($header0);
-        $factory->expects($this->at(1))
-                ->method('createIdHeader')
-                ->with('Message-ID', 'other@id')
-                ->willReturn($header1);
+                ->withConsecutive(
+                    ['Message-ID', 'some@id'],
+                    ['Message-ID', 'other@id']
+                )
+                ->willReturnOnConsecutiveCalls(
+                    $header0,
+                    $header1
+                );
 
         $set = $this->createSet($factory);
         $set->addIdHeader('Message-ID', 'some@id');
@@ -375,14 +379,16 @@ class Swift_Mime_SimpleHeaderSetTest extends \PHPUnit\Framework\TestCase
         $header0 = $this->createHeader('Message-ID');
         $header1 = $this->createHeader('Message-ID');
         $factory = $this->createFactory();
-        $factory->expects($this->at(0))
+        $factory->expects($this->exactly(2))
                 ->method('createIdHeader')
-                ->with('Message-ID', 'some@id')
-                ->willReturn($header0);
-        $factory->expects($this->at(1))
-                ->method('createIdHeader')
-                ->with('Message-ID', 'other@id')
-                ->willReturn($header1);
+                ->withConsecutive(
+                    ['Message-ID', 'some@id'],
+                    ['Message-ID', 'other@id']
+                )
+                ->willReturnOnConsecutiveCalls(
+                    $header0,
+                    $header1
+                );
 
         $set = $this->createSet($factory);
         $set->addIdHeader('Message-ID', 'some@id');
@@ -395,7 +401,7 @@ class Swift_Mime_SimpleHeaderSetTest extends \PHPUnit\Framework\TestCase
     {
         $header = $this->createHeader('Message-ID');
         $factory = $this->createFactory();
-        $factory->expects($this->at(0))
+        $factory->expects($this->once())
                 ->method('createIdHeader')
                 ->with('Message-ID', 'some@id')
                 ->willReturn($header);
@@ -411,14 +417,16 @@ class Swift_Mime_SimpleHeaderSetTest extends \PHPUnit\Framework\TestCase
         $header0 = $this->createHeader('Message-ID');
         $header1 = $this->createHeader('Message-ID');
         $factory = $this->createFactory();
-        $factory->expects($this->at(0))
+        $factory->expects($this->exactly(2))
                 ->method('createIdHeader')
-                ->with('Message-ID', 'some@id')
-                ->willReturn($header0);
-        $factory->expects($this->at(1))
-                ->method('createIdHeader')
-                ->with('Message-ID', 'other@id')
-                ->willReturn($header1);
+                ->withConsecutive(
+                    ['Message-ID', 'some@id'],
+                    ['Message-ID', 'other@id']
+                )
+                ->willReturnOnConsecutiveCalls(
+                    $header0,
+                    $header1
+                );
 
         $set = $this->createSet($factory);
         $set->addIdHeader('Message-ID', 'some@id');
@@ -432,7 +440,7 @@ class Swift_Mime_SimpleHeaderSetTest extends \PHPUnit\Framework\TestCase
     {
         $header = $this->createHeader('Message-ID');
         $factory = $this->createFactory();
-        $factory->expects($this->at(0))
+        $factory->expects($this->once())
                 ->method('createIdHeader')
                 ->with('Message-ID', 'some@id')
                 ->willReturn($header);
@@ -446,7 +454,7 @@ class Swift_Mime_SimpleHeaderSetTest extends \PHPUnit\Framework\TestCase
     {
         $header = $this->createHeader('Message-ID');
         $factory = $this->createFactory();
-        $factory->expects($this->at(0))
+        $factory->expects($this->once())
                 ->method('createIdHeader')
                 ->with('Message-ID', 'some@id')
                 ->willReturn($header);
@@ -460,7 +468,7 @@ class Swift_Mime_SimpleHeaderSetTest extends \PHPUnit\Framework\TestCase
     {
         $header = $this->createHeader('Message-ID');
         $factory = $this->createFactory();
-        $factory->expects($this->at(0))
+        $factory->expects($this->once())
                 ->method('createIdHeader')
                 ->with('Message-ID', 'some@id')
                 ->willReturn($header);
@@ -474,7 +482,7 @@ class Swift_Mime_SimpleHeaderSetTest extends \PHPUnit\Framework\TestCase
     {
         $header = $this->createHeader('Message-ID');
         $factory = $this->createFactory();
-        $factory->expects($this->at(0))
+        $factory->expects($this->once())
                 ->method('createIdHeader')
                 ->with('Message-ID', 'some@id')
                 ->willReturn($header);
@@ -489,7 +497,7 @@ class Swift_Mime_SimpleHeaderSetTest extends \PHPUnit\Framework\TestCase
     {
         $header = $this->createHeader('Message-ID');
         $factory = $this->createFactory();
-        $factory->expects($this->at(0))
+        $factory->expects($this->once())
                 ->method('createIdHeader')
                 ->with('Message-ID', 'some@id')
                 ->willReturn($header);
@@ -503,14 +511,16 @@ class Swift_Mime_SimpleHeaderSetTest extends \PHPUnit\Framework\TestCase
     public function testToStringJoinsHeadersTogether()
     {
         $factory = $this->createFactory();
-        $factory->expects($this->at(0))
+        $factory->expects($this->exactly(2))
                 ->method('createTextHeader')
-                ->with('Foo', 'bar')
-                ->willReturn($this->createHeader('Foo', 'bar'));
-        $factory->expects($this->at(1))
-                ->method('createTextHeader')
-                ->with('Zip', 'buttons')
-                ->willReturn($this->createHeader('Zip', 'buttons'));
+                ->withConsecutive(
+                    ['Foo', 'bar'],
+                    ['Zip', 'buttons']
+                )
+                ->willReturnOnConsecutiveCalls(
+                    $this->createHeader('Foo', 'bar'),
+                    $this->createHeader('Zip', 'buttons')
+                );
 
         $set = $this->createSet($factory);
         $set->addTextHeader('Foo', 'bar');
@@ -525,14 +535,16 @@ class Swift_Mime_SimpleHeaderSetTest extends \PHPUnit\Framework\TestCase
     public function testHeadersWithoutBodiesAreNotDisplayed()
     {
         $factory = $this->createFactory();
-        $factory->expects($this->at(0))
+        $factory->expects($this->exactly(2))
                 ->method('createTextHeader')
-                ->with('Foo', 'bar')
-                ->willReturn($this->createHeader('Foo', 'bar'));
-        $factory->expects($this->at(1))
-                ->method('createTextHeader')
-                ->with('Zip', '')
-                ->willReturn($this->createHeader('Zip', ''));
+                ->withConsecutive(
+                    ['Foo', 'bar'],
+                    ['Zip', '']
+                )
+                ->willReturnOnConsecutiveCalls(
+                    $this->createHeader('Foo', 'bar'),
+                    $this->createHeader('Zip', '')
+                );
 
         $set = $this->createSet($factory);
         $set->addTextHeader('Foo', 'bar');
@@ -546,14 +558,16 @@ class Swift_Mime_SimpleHeaderSetTest extends \PHPUnit\Framework\TestCase
     public function testHeadersWithoutBodiesCanBeForcedToDisplay()
     {
         $factory = $this->createFactory();
-        $factory->expects($this->at(0))
+        $factory->expects($this->exactly(2))
                 ->method('createTextHeader')
-                ->with('Foo', '')
-                ->willReturn($this->createHeader('Foo', ''));
-        $factory->expects($this->at(1))
-                ->method('createTextHeader')
-                ->with('Zip', '')
-                ->willReturn($this->createHeader('Zip', ''));
+                ->withConsecutive(
+                    ['Foo', ''],
+                    ['Zip', '']
+                )
+                ->willReturnOnConsecutiveCalls(
+                    $this->createHeader('Foo', ''),
+                    $this->createHeader('Zip', '')
+                );
 
         $set = $this->createSet($factory);
         $set->addTextHeader('Foo', '');
@@ -569,18 +583,18 @@ class Swift_Mime_SimpleHeaderSetTest extends \PHPUnit\Framework\TestCase
     public function testHeaderSequencesCanBeSpecified()
     {
         $factory = $this->createFactory();
-        $factory->expects($this->at(0))
+        $factory->expects($this->exactly(3))
                 ->method('createTextHeader')
-                ->with('Third', 'three')
-                ->willReturn($this->createHeader('Third', 'three'));
-        $factory->expects($this->at(1))
-                ->method('createTextHeader')
-                ->with('First', 'one')
-                ->willReturn($this->createHeader('First', 'one'));
-        $factory->expects($this->at(2))
-                ->method('createTextHeader')
-                ->with('Second', 'two')
-                ->willReturn($this->createHeader('Second', 'two'));
+                ->withConsecutive(
+                    ['Third', 'three'],
+                    ['First', 'one'],
+                    ['Second', 'two']
+                )
+                ->willReturnOnConsecutiveCalls(
+                    $this->createHeader('Third', 'three'),
+                    $this->createHeader('First', 'one'),
+                    $this->createHeader('Second', 'two')
+                );
 
         $set = $this->createSet($factory);
         $set->addTextHeader('Third', 'three');
@@ -600,26 +614,22 @@ class Swift_Mime_SimpleHeaderSetTest extends \PHPUnit\Framework\TestCase
     public function testUnsortedHeadersAppearAtEnd()
     {
         $factory = $this->createFactory();
-        $factory->expects($this->at(0))
+        $factory->expects($this->exactly(5))
                 ->method('createTextHeader')
-                ->with('Fourth', 'four')
-                ->willReturn($this->createHeader('Fourth', 'four'));
-        $factory->expects($this->at(1))
-                ->method('createTextHeader')
-                ->with('Fifth', 'five')
-                ->willReturn($this->createHeader('Fifth', 'five'));
-        $factory->expects($this->at(2))
-                ->method('createTextHeader')
-                ->with('Third', 'three')
-                ->willReturn($this->createHeader('Third', 'three'));
-        $factory->expects($this->at(3))
-                ->method('createTextHeader')
-                ->with('First', 'one')
-                ->willReturn($this->createHeader('First', 'one'));
-        $factory->expects($this->at(4))
-                ->method('createTextHeader')
-                ->with('Second', 'two')
-                ->willReturn($this->createHeader('Second', 'two'));
+                ->withConsecutive(
+                    ['Fourth', 'four'],
+                    ['Fifth', 'five'],
+                    ['Third', 'three'],
+                    ['First', 'one'],
+                    ['Second', 'two']
+                )
+                ->willReturnOnConsecutiveCalls(
+                    $this->createHeader('Fourth', 'four'),
+                    $this->createHeader('Fifth', 'five'),
+                    $this->createHeader('Third', 'three'),
+                    $this->createHeader('First', 'one'),
+                    $this->createHeader('Second', 'two')
+                );
 
         $set = $this->createSet($factory);
         $set->addTextHeader('Fourth', 'four');
@@ -645,14 +655,16 @@ class Swift_Mime_SimpleHeaderSetTest extends \PHPUnit\Framework\TestCase
         $subject = $this->createHeader('Subject', 'some text');
         $xHeader = $this->createHeader('X-Header', 'some text');
         $factory = $this->createFactory();
-        $factory->expects($this->at(0))
+        $factory->expects($this->exactly(2))
                 ->method('createTextHeader')
-                ->with('Subject', 'some text')
-                ->willReturn($subject);
-        $factory->expects($this->at(1))
-                ->method('createTextHeader')
-                ->with('X-Header', 'some text')
-                ->willReturn($xHeader);
+                ->withConsecutive(
+                    ['Subject', 'some text'],
+                    ['X-Header', 'some text']
+                )
+                ->willReturnOnConsecutiveCalls(
+                    $subject,
+                    $xHeader
+                );
         $subject->expects($this->once())
                 ->method('setCharset')
                 ->with('utf-8');
@@ -672,14 +684,16 @@ class Swift_Mime_SimpleHeaderSetTest extends \PHPUnit\Framework\TestCase
         $subject = $this->createHeader('Subject', 'some text');
         $xHeader = $this->createHeader('X-Header', 'some text');
         $factory = $this->createFactory();
-        $factory->expects($this->at(0))
+        $factory->expects($this->exactly(2))
                 ->method('createTextHeader')
-                ->with('Subject', 'some text')
-                ->willReturn($subject);
-        $factory->expects($this->at(1))
-                ->method('createTextHeader')
-                ->with('X-Header', 'some text')
-                ->willReturn($xHeader);
+                ->withConsecutive(
+                    ['Subject', 'some text'],
+                    ['X-Header', 'some text']
+                )
+                ->willReturnOnConsecutiveCalls(
+                    $subject,
+                    $xHeader
+                );
         $subject->expects($this->once())
                 ->method('setCharset')
                 ->with('utf-8');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Doc update?   | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | none
| License       | MIT

Hi,

to prepare for PHP 8, I added it to the travis config and updated bunch of tests to not use the depreacted `at()` method anymore.
Please let me know if you'd prefer any of this to be solved differently.