### PR TITLE
Removes PHP version from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Swift Mailer
 ------------
 
-Swift Mailer is a component based mailing solution for PHP 7.
+Swift Mailer is a component based mailing solution for PHP.
 It is released under the MIT license.
 
 Swift Mailer is highly object-oriented by design and lends itself


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Doc update?   | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | N/A
| License       | MIT

Swiftmailer supports PHP 8 now, so I felt the description in the README was not accurate anymore.