### PR TITLE
Remove invalid PHPDocs param in EventDispatcher interface

### DIFF
--- a/lib/classes/Swift/Events/EventDispatcher.php
+++ b/lib/classes/Swift/Events/EventDispatcher.php
@@ -18,8 +18,6 @@ interface Swift_Events_EventDispatcher
     /**
      * Create a new SendEvent for $source and $message.
      *
-     * @param Swift_Mime_SimpleMessage
-     *
      * @return Swift_Events_SendEvent
      */
     public function createSendEvent(Swift_Transport $source, Swift_Mime_SimpleMessage $message);


### PR DESCRIPTION

<!-- Please fill in this template according to the PR you're about to submit. -->

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc update?   | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT


<!-- Replace this comment by the description of your issue. -->


As Psalm is complaining with the following error:

```
ERROR: InvalidDocblock - vendor/swiftmailer/swiftmailer/lib/classes/Swift/Events/EventDispatcher.php:25:5 - Badly-formatted @param in docblock for Swift_Events_EventDispatcher::createSendEvent (see https://psalm.dev/008)
    /**
     * Create a new SendEvent for $source and $message.
     *
     * @param Swift_Mime_SimpleMessage
     *
     * @return Swift_Events_SendEvent
     */
    public function createSendEvent(Swift_Transport $source, Swift_Mime_SimpleMessage $message);
```