### PR TITLE
Remove -DEV from version

### DIFF
--- a/lib/classes/Swift.php
+++ b/lib/classes/Swift.php
@@ -15,7 +15,7 @@
  */
 abstract class Swift
 {
-    const VERSION = '6.2.5-DEV';
+    const VERSION = '6.2.5';
 
     public static $initialized = false;
     public static $inits = [];


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Doc update?   | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 
| License       | MIT

6.2.5 was released today. `VERSION` still says 6.2.5-DEV

Remove the `-DEV`  from the version.

But it is too late for this to actually be in 6.2.5 release tag. So maybe a bump to 6.2.6 is needed and a new release tag?