### PR TITLE
Add missing changelog for 6.2.5

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,10 +1,13 @@
 Changelog
 =========
 
-6.2.5 (2021-XX-XX)
+6.2.5 (2021-01-12)
 ------------------
 
- * n/a
+ * Don't trust properties at destruct time
+ * Remove invalid PHPDocs param in EventDispatcher interface
+ * Bump license year
+ * Removes PHP version from README
 
 6.2.4 (2020-12-08)
 ------------------


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Doc update?   | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | ---
| License       | MIT

This is based on the commits:
```
698a6a9 bug #1317 Don't trust properties at destruct time (nicolas-grekas)
59935da minor #1315 Remove invalid PHPDocs param in EventDispatcher interface (michal...
0ce398a Bump license year
99d6207 Remove invalid PHPDocs param in EventDispatcher interface
a5261eb minor #1314 Fix CS for variable names (fabpot)
79efd15 Fix CS for variable names
636117b minor #1313 fix typos in tests files (abdounikarim)
1047591 fix typos in tests files
7de4089 minor #1311 Removes PHP version from README (derrabus)
a07dabf Removes PHP version from README.
```