### PR TITLE
Update return type hint in SimpleHeaderSet

### DIFF
--- a/lib/classes/Swift/Mime/SimpleHeaderSet.php
+++ b/lib/classes/Swift/Mime/SimpleHeaderSet.php
@@ -177,7 +177,7 @@ class Swift_Mime_SimpleHeaderSet implements Swift_Mime_CharsetObserver
      * @param string $name
      * @param int    $index
      *
-     * @return Swift_Mime_Header
+     * @return Swift_Mime_Header|null
      */
     public function get($name, $index = 0)
     {


### PR DESCRIPTION
Fixes return type int according to line 175

Found while running https://github.com/phpstan/phpstan on my code

<!-- Please fill in this template according to the PR you're about to submit. -->

| Q             | A
| ------------- | ---
| Bug fix?      | no (really just an inline comment fix)
| New feature?  | no
| Doc update?   | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT


<!-- Replace this comment by the description of your issue. -->
