### PR TITLE
[doc] Clarify encryption options 'ssl' vs. 'tls'

### DIFF
--- a/doc/sending.rst
+++ b/doc/sending.rst
@@ -95,7 +95,8 @@ within your application and adjust the settings accordingly if the code is
 moved or if the SMTP server is changed.
 
 Some SMTP servers -- Google for example -- use encryption for security reasons.
-Swift Mailer supports using both SSL and TLS encryption settings.
+Swift Mailer supports using both ``ssl`` (SMTPS = SMTP over TLS) and ``tls``
+(SMTP with STARTTLS) encryption settings.
 
 Using the SMTP Transport
 ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -129,11 +130,14 @@ A connection to the SMTP server will be established upon the first call to
 Encrypted SMTP
 ^^^^^^^^^^^^^^
 
-You can use SSL or TLS encryption with the SMTP Transport by specifying it as a
-parameter or with a method call::
+You can use ``ssl`` (SMTPS) or ``tls`` (STARTTLS) encryption with the SMTP Transport
+by specifying it as a parameter or with a method call::
 
     // Create the Transport
+    // Option #1: SMTPS = SMTP over TLS (always encrypted):
     $transport = new Swift_SmtpTransport('smtp.example.org', 587, 'ssl');
+    // Option #2: SMTP with STARTTLS (best effort encryption):
+    $transport = new Swift_SmtpTransport('smtp.example.org', 587, 'tls');
 
     // Create the Mailer using your created Transport
     $mailer = new Swift_Mailer($transport);
@@ -143,8 +147,7 @@ A connection to the SMTP server will be established upon the first call to
 settings.
 
 .. note::
-
-    For SSL or TLS encryption to work your PHP installation must have
+    For SMTPS or STARTTLS encryption to work your PHP installation must have
     appropriate OpenSSL transports wrappers. You can check if "tls" and/or
     "ssl" are present in your PHP installation by using the PHP function
     ``stream_get_transports()``.
@@ -152,6 +155,14 @@ settings.
 .. note::
     If you are using Mailcatcher_, make sure you do not set the encryption
     for the ``Swift_SmtpTransport``, since Mailcatcher does not support encryption.
+
+.. note::
+    When in doubt, try ``ssl`` first for higher security, since the communication
+    is always encrypted.
+
+.. note::
+    Usually, port 587 or 465 is used for encrypted SMTP. Check the documentation
+    of your mail provider.
 
 SMTP with a Username and Password
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/lib/classes/Swift/SmtpTransport.php
+++ b/lib/classes/Swift/SmtpTransport.php
@@ -25,7 +25,10 @@ class Swift_SmtpTransport extends Swift_Transport_EsmtpTransport
     /**
      * @param string $host
      * @param int    $port
-     * @param string $encryption
+     * @param string|null $encryption SMTP encryption mode:
+     *        - null for plain SMTP (no encryption),
+     *        - 'tls' for SMTP with STARTTLS (best effort encryption),
+     *        - 'ssl' for SMTPS = SMTP over TLS (always encrypted).
      */
     public function __construct($host = 'localhost', $port = 25, $encryption = null)
     {


### PR DESCRIPTION
<!-- Please fill in this template according to the PR you're about to submit. -->

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Doc update?   | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #1329 
| License       | MIT

Fixes #1329 
Got help from #545

Both the PHPDoc comments and the documentation are unclear about the difference between `ssl` and `tls`.
Especially considering that `ssl` nowadays sounds "old & deprecated", this needed clarification, since in this case
`ssl` is surprisingly the more secure option.