### PR TITLE
Egulias EmailValidator v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "php": ">=7.0.0",
-        "egulias/email-validator": "^2.0",
+        "egulias/email-validator": "^2.0|^3.1",
         "symfony/polyfill-iconv": "^1.0",
         "symfony/polyfill-mbstring": "^1.0",
         "symfony/polyfill-intl-idn": "^1.10"

--- a/lib/classes/Swift/Mime/Headers/IdentificationHeader.php
+++ b/lib/classes/Swift/Mime/Headers/IdentificationHeader.php
@@ -9,6 +9,7 @@
  */
 
 use Egulias\EmailValidator\EmailValidator;
+use Egulias\EmailValidator\Validation\MessageIDValidation;
 use Egulias\EmailValidator\Validation\RFCValidation;
 
 /**
@@ -179,7 +180,9 @@ class Swift_Mime_Headers_IdentificationHeader extends Swift_Mime_Headers_Abstrac
      */
     private function assertValidId($id)
     {
-        if (!$this->emailValidator->isValid($id, new RFCValidation())) {
+        $emailValidation = class_exists(MessageIDValidation::class) ? new MessageIDValidation() : new RFCValidation();
+
+        if (!$this->emailValidator->isValid($id, $emailValidation)) {
             throw new Swift_RfcComplianceException('Invalid ID given <'.$id.'>');
         }
     }


### PR DESCRIPTION
<!-- Please fill in this template according to the PR you're about to submit. -->

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Doc update?   | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT


This PR implements egulias/email-validator v3. After some back an forth in https://github.com/egulias/EmailValidator/issues/282 @egulias was so kind to provide a new EmailValidation that properly handles the test case of SwiftMailer's IdentificationHeader validation. `^3.1` is needed to make use of the new email validation. I've added a class check to use the old one when it isn't present for `^2.0`. 

After merging and tagging this PR we can add support for EmailValidator v3 in Laravel. Let me know if you need anything else 👍 