### PR TITLE
Attachment raw body

### DIFF
--- a/lib/classes/Swift/Mime/SimpleMimeEntity.php
+++ b/lib/classes/Swift/Mime/SimpleMimeEntity.php
@@ -365,6 +365,16 @@ class Swift_Mime_SimpleMimeEntity implements Swift_Mime_CharsetObserver, Swift_M
     }
 
     /**
+     * Get the body of this entity.
+     *
+     * @return Swift_ByteStream_FileByteStream
+     */
+    public function getRawBody()
+    {
+        return $this->body;
+    }
+
+    /**
      * Set the body of this entity, either as a string, or as an instance of
      * {@link Swift_OutputByteStream}.
      *

--- a/tests/unit/Swift/Mime/AttachmentTest.php
+++ b/tests/unit/Swift/Mime/AttachmentTest.php
@@ -260,6 +260,16 @@ class Swift_Mime_AttachmentTest extends Swift_Mime_AbstractMimeEntityTest
         $this->assertEquals('<some data>', $attachment->getBody());
     }
 
+    public function testFilePathCanBeReadFromRawBody()
+    {
+        $file = $this->createFileStream('/foo/file.ext', '<some data>');
+        $attachment = $this->createAttachment($this->createHeaderSet(),
+            $this->createEncoder(), $this->createCache()
+            );
+        $attachment->setFile($file);
+        $this->assertEquals('/foo/file.ext', $attachment->getRawBody()->getPath());
+    }
+
     public function testFluidInterface()
     {
         $attachment = $this->createAttachment($this->createHeaderSet(),


### PR DESCRIPTION
<!-- Please fill in this template according to the PR you're about to submit. -->

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Doc update?   | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #1004
| License       | MIT


<!-- Replace this comment by the description of your issue. -->
To access the to raw attachment body

`$message->getChildren()[0]->getRawBody();`
