### PR TITLE
Disable warning for rename function on Swift_FileSpool class

### DIFF
--- a/lib/classes/Swift/FileSpool.php
+++ b/lib/classes/Swift/FileSpool.php
@@ -163,7 +163,7 @@ class Swift_FileSpool extends Swift_ConfigurableSpool
             }
 
             /* We try a rename, it's an atomic operation, and avoid locking the file */
-            if (rename($file, $file.'.sending')) {
+            if (@rename($file, $file.'.sending')) {
                 $message = unserialize(file_get_contents($file.'.sending'));
 
                 $count += $transport->send($message, $failedRecipients);


### PR DESCRIPTION
<!-- Please fill in this template according to the PR you're about to submit. -->

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc update?   | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT

I disabled the warning of the native rename function (FileSpool.php line 166) because in a scenario where several workers are allocated to process spool messages, the function in question returns a warning because the file could be processed by another process (another worker)

PHP Warning:  rename(/srv/app/var/spool/foo/uyhkfPBqqP.messagetototo,/srv/app/var/spool/foo/uyhkfPBqqP.message.sending): No such file or directory in /srv/app/vendor/swiftmailer/swiftmailer/lib/classes/Swift/FileSpool.php on line 166
