### PR TITLE
Add AMP email support

### DIFF
--- a/lib/classes/Swift/Mime/SimpleMimeEntity.php
+++ b/lib/classes/Swift/Mime/SimpleMimeEntity.php
@@ -70,8 +70,9 @@ class Swift_Mime_SimpleMimeEntity implements Swift_Mime_CharsetObserver, Swift_M
     /** The order in which alternative mime types should appear */
     private $alternativePartOrder = [
         'text/plain' => 1,
-        'text/html' => 2,
-        'multipart/related' => 3,
+        'text/x-amp-html' => 2,
+        'text/html' => 3,
+        'multipart/related' => 4,
     ];
 
     /** The CID of this entity */

--- a/lib/mime_types.php
+++ b/lib/mime_types.php
@@ -45,6 +45,7 @@ $swift_mime_types = [
     'air' => 'application/vnd.adobe.air-application-installer-package+zip',
     'ait' => 'application/vnd.dvb.ait',
     'ami' => 'application/vnd.amiga.ami',
+    'amp' => 'text/x-amp-html',
     'apk' => 'application/vnd.android.package-archive',
     'appcache' => 'text/cache-manifest',
     'apr' => 'application/vnd.lotus-approach',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Doc update?   | no
| BC breaks?    | ?
| Deprecations? | no
| Fixed tickets | #1229
| License       | MIT


We use SwiftMailer to send AMP emails.
Due to the requirements in the issue, we needed to modify `$alternativePartOrder`.
So, we modified it and made a pull request.

If you can't reveive this PR due to policy, please reply to that and reject the request.
Also, if there are any workarounds in part order, please let me know about it.